### PR TITLE
Make the cost of a proposal flat in log length

### DIFF
--- a/examples/propose_scaling.rs
+++ b/examples/propose_scaling.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scaling probe: proposes N entries into a 3-node cluster and reports the
+//! wall time per size. A per-propose cost that is constant in log length gives
+//! a ~2x time ratio when N doubles; a cost that is linear in log length gives
+//! ~4x.
+
+use std::time::Instant;
+
+use matrixraft::{RaftCluster, RaftConfig, RustRaftPeer, RustRaftReplicaRole};
+
+fn peer(node_id: u64, role: RustRaftReplicaRole) -> RustRaftPeer {
+    RustRaftPeer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role,
+        auto_promote: false,
+    }
+}
+
+fn run(entries: usize, payload_bytes: usize) -> f64 {
+    let mut cluster = RaftCluster::new(
+        7,
+        RaftConfig::default(),
+        vec![
+            peer(1, RustRaftReplicaRole::Voter),
+            peer(2, RustRaftReplicaRole::Voter),
+            peer(3, RustRaftReplicaRole::Voter),
+        ],
+    )
+    .expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+
+    let payload = vec![7_u8; payload_bytes];
+    let started = Instant::now();
+    for _ in 0..entries {
+        cluster.propose(payload.clone()).expect("propose");
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    assert!(cluster.leader_id().is_some());
+    elapsed
+}
+
+fn main() {
+    let payload_bytes: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(64);
+    println!("payload_bytes={payload_bytes}");
+    println!(
+        "{:>8}  {:>12}  {:>12}  {:>8}",
+        "entries", "seconds", "us/propose", "ratio"
+    );
+    let mut previous: Option<(usize, f64)> = None;
+    for entries in [1000_usize, 2000, 4000, 8000, 16000] {
+        let seconds = run(entries, payload_bytes);
+        let per = seconds * 1e6 / entries as f64;
+        let ratio = previous
+            .map(|(_, prev_seconds)| seconds / prev_seconds)
+            .unwrap_or(f64::NAN);
+        println!("{entries:>8}  {seconds:>12.4}  {per:>12.2}  {ratio:>8.2}");
+        previous = Some((entries, seconds));
+    }
+}

--- a/examples/wal_amplification.rs
+++ b/examples/wal_amplification.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Measures how many WAL bytes one proposal costs, mirroring what the node
+//! runtime does per proposal: propose, then append `wal_record_for` to the WAL.
+
+use std::time::Instant;
+
+use matrixraft::{
+    PersistentRaftWal, PersistentRaftWalOptions, RaftCluster, RaftConfig, RustRaftPeer,
+    RustRaftReplicaRole,
+};
+
+fn peer(node_id: u64, role: RustRaftReplicaRole) -> RustRaftPeer {
+    RustRaftPeer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role,
+        auto_promote: false,
+    }
+}
+
+fn dir_bytes(dir: &std::path::Path) -> u64 {
+    let mut total = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if let Ok(meta) = entry.metadata() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+fn run(entries: usize, payload_bytes: usize) -> (u64, f64) {
+    let dir =
+        std::env::temp_dir().join(format!("mraft-wal-probe-{}-{entries}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let mut wal = PersistentRaftWal::open(PersistentRaftWalOptions {
+        dir: dir.clone(),
+        max_records_per_segment: 1_000_000,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        fsync_on_append: false,
+    })
+    .expect("open wal");
+
+    let mut cluster = RaftCluster::new(
+        7,
+        RaftConfig::default(),
+        vec![
+            peer(1, RustRaftReplicaRole::Voter),
+            peer(2, RustRaftReplicaRole::Voter),
+            peer(3, RustRaftReplicaRole::Voter),
+        ],
+    )
+    .expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+
+    let payload = vec![7_u8; payload_bytes];
+    let started = Instant::now();
+    for _ in 0..entries {
+        cluster.propose(payload.clone()).expect("propose");
+        wal.append(cluster.wal_record_for(1).expect("record"))
+            .expect("append");
+    }
+    let seconds = started.elapsed().as_secs_f64();
+    let bytes = dir_bytes(&dir);
+    let _ = std::fs::remove_dir_all(&dir);
+    (bytes, seconds)
+}
+
+fn main() {
+    let payload_bytes: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(64);
+    println!("payload_bytes={payload_bytes}  (fsync disabled: this measures bytes, not syscalls)");
+    println!(
+        "{:>8}  {:>14}  {:>14}  {:>12}  {:>10}",
+        "proposals", "wal_bytes", "bytes/proposal", "amplification", "seconds"
+    );
+    for entries in [250_usize, 500, 1000, 2000] {
+        let (bytes, seconds) = run(entries, payload_bytes);
+        let per = bytes as f64 / entries as f64;
+        let amplification = per / payload_bytes as f64;
+        println!("{entries:>8}  {bytes:>14}  {per:>14.0}  {amplification:>12.1}x  {seconds:>10.3}");
+    }
+}

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -2551,7 +2551,7 @@ impl RaftCluster {
                 continue;
             }
             let response = if let Some(pipeline) = self.peer_pipelines.get_mut(&node_id) {
-                pipeline.queue_append(entry.clone())?;
+                pipeline.queue_append(&entry)?;
                 let _ = pipeline.flush_append_batch(64, self.config.max_payload_bytes.max(1));
                 if node.healthy {
                     let match_index = node.match_index();
@@ -5025,7 +5025,7 @@ impl RaftCluster {
         self.peer_pipelines
             .get_mut(&peer_id)
             .ok_or(RaftError::NodeNotFound(peer_id))?
-            .receive_out_of_order(entry)
+            .receive_out_of_order(&entry)
     }
 
     pub fn expire_peer_reorder_queue(&mut self, peer_id: RustRaftNodeId) -> Result<u64, RaftError> {

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -37,6 +37,10 @@ struct RaftNode {
     raft_role: RustRaftRole,
     hard_state: RustRaftHardState,
     log: Vec<RustRaftLogEntry>,
+    // Running total of `log` payload bytes. Maintained by every log mutation so
+    // that the admission checks on the propose path do not sum the log.
+    #[serde(default)]
+    retained_log_bytes: u64,
     installed_snapshot: Option<RustRaftSnapshotMeta>,
     commit_index: RustRaftLogIndex,
     applied_index: RustRaftLogIndex,
@@ -65,6 +69,7 @@ impl RaftNode {
                 committed: None,
             },
             log: Vec::new(),
+            retained_log_bytes: 0,
             installed_snapshot: None,
             commit_index: 0,
             applied_index: 0,
@@ -95,6 +100,71 @@ impl RaftNode {
         log_index.max(snapshot_index)
     }
 
+    /// Slot holding `log_index`, or `None` when the index is outside the
+    /// retained log.
+    ///
+    /// `log` is ordered by index, so a contiguous log answers by subtracting
+    /// the first retained index. The binary search only runs if a gap ever puts
+    /// the entry somewhere other than its arithmetic slot.
+    fn log_position(&self, log_index: RustRaftLogIndex) -> Option<usize> {
+        let first_index = self.log.first()?.log_id.index;
+        let offset = log_index.checked_sub(first_index)? as usize;
+        if self.log.get(offset).map(|entry| entry.log_id.index) == Some(log_index) {
+            return Some(offset);
+        }
+        self.log
+            .binary_search_by(|entry| entry.log_id.index.cmp(&log_index))
+            .ok()
+    }
+
+    /// Slot of the first entry at or after `log_index`, or `None` when every
+    /// retained entry is below it.
+    fn log_position_at_or_after(&self, log_index: RustRaftLogIndex) -> Option<usize> {
+        if self
+            .log
+            .last()
+            .is_none_or(|last| last.log_id.index < log_index)
+        {
+            return None;
+        }
+        Some(
+            self.log
+                .partition_point(|entry| entry.log_id.index < log_index),
+        )
+    }
+
+    fn truncate_log_at(&mut self, position: usize) {
+        let released: u64 = self.log[position..]
+            .iter()
+            .map(|entry| entry.payload.len() as u64)
+            .sum();
+        self.retained_log_bytes = self.retained_log_bytes.saturating_sub(released);
+        self.log.truncate(position);
+    }
+
+    /// Drops every retained entry at or below `log_index` and reports how many
+    /// went away.
+    fn discard_log_through(&mut self, log_index: RustRaftLogIndex) -> usize {
+        let cut = self
+            .log
+            .partition_point(|entry| entry.log_id.index <= log_index);
+        if cut == 0 {
+            return 0;
+        }
+        let released: u64 = self.log[..cut]
+            .iter()
+            .map(|entry| entry.payload.len() as u64)
+            .sum();
+        self.retained_log_bytes = self.retained_log_bytes.saturating_sub(released);
+        self.log.drain(..cut);
+        cut
+    }
+
+    fn set_log(&mut self, log: Vec<RustRaftLogEntry>) {
+        self.retained_log_bytes = log.iter().map(|entry| entry.payload.len() as u64).sum();
+        self.log = log;
+    }
+
     fn log_term_at(&self, log_index: RustRaftLogIndex) -> Option<RustRaftTerm> {
         if log_index == 0 {
             return Some(0);
@@ -104,10 +174,8 @@ impl RaftNode {
                 return Some(snapshot.last_log_id.term);
             }
         }
-        self.log
-            .iter()
-            .find(|entry| entry.log_id.index == log_index)
-            .map(|entry| entry.log_id.term)
+        self.log_position(log_index)
+            .map(|position| self.log[position].log_id.term)
     }
 
     fn is_fresh_candidate_log(&self, candidate_last_log_id: Option<&RustRaftLogId>) -> bool {
@@ -121,23 +189,26 @@ impl RaftNode {
     }
 
     fn append_entry(&mut self, entry: RustRaftLogEntry) {
-        if let Some(position) = self
+        // An entry past the tail cannot collide with a retained index, so the
+        // steady-state append never looks at the rest of the log.
+        let extends_tail = self
             .log
-            .iter()
-            .position(|existing| existing.log_id.index == entry.log_id.index)
-        {
-            self.log.truncate(position);
+            .last()
+            .is_none_or(|last| last.log_id.index < entry.log_id.index);
+        if !extends_tail {
+            if let Some(position) = self.log_position(entry.log_id.index) {
+                self.truncate_log_at(position);
+            }
         }
+        self.retained_log_bytes = self
+            .retained_log_bytes
+            .saturating_add(entry.payload.len() as u64);
         self.log.push(entry);
     }
 
     fn truncate_log_from(&mut self, log_index: RustRaftLogIndex) {
-        if let Some(position) = self
-            .log
-            .iter()
-            .position(|existing| existing.log_id.index >= log_index)
-        {
-            self.log.truncate(position);
+        if let Some(position) = self.log_position_at_or_after(log_index) {
+            self.truncate_log_at(position);
         }
     }
 
@@ -207,7 +278,7 @@ impl RaftNode {
         let snapshot_index = snapshot.meta.last_log_id.index;
         let snapshot_log_id = snapshot.meta.last_log_id.clone();
         self.installed_snapshot = Some(snapshot.meta);
-        self.log.retain(|entry| entry.log_id.index > snapshot_index);
+        self.discard_log_through(snapshot_index);
         if self.replica_role == RustRaftReplicaRole::Witness {
             self.witness_ack_index = self.witness_ack_index.max(snapshot_index);
         }
@@ -232,16 +303,11 @@ impl RaftNode {
             self.commit_index
         };
         let log_index = log_index.min(safe_compaction_index);
-        let before = self.log.len();
-        self.log.retain(|entry| entry.log_id.index > log_index);
-        before.saturating_sub(self.log.len()) as u64
+        self.discard_log_through(log_index) as u64
     }
 
     fn retained_log_bytes(&self) -> u64 {
-        self.log
-            .iter()
-            .map(|entry| entry.payload.len() as u64)
-            .sum()
+        self.retained_log_bytes
     }
 }
 
@@ -2575,7 +2641,7 @@ impl RaftCluster {
             .get_mut(&record.node_id)
             .ok_or(RaftError::NodeNotFound(record.node_id))?;
         node.hard_state = record.hard_state;
-        node.log = record.entries;
+        node.set_log(record.entries);
         node.installed_snapshot = record.installed_snapshot;
         node.commit_index = record.apply_snapshot_fence.commit_index;
         node.applied_index = record.apply_snapshot_fence.applied_index;
@@ -3816,12 +3882,12 @@ impl RaftCluster {
         reason_prefix: &str,
     ) -> Result<RaftLearnerCatchUpLoopReport, RaftError> {
         let leader_id = self.leader_id.ok_or(RaftError::NoLeader)?;
-        let leader = self
+        let leader_snapshot = self
             .nodes
             .get(&leader_id)
-            .ok_or(RaftError::NodeNotFound(leader_id))?;
-        let leader_log = leader.log.clone();
-        let leader_snapshot = leader.installed_snapshot.clone();
+            .ok_or(RaftError::NodeNotFound(leader_id))?
+            .installed_snapshot
+            .clone();
         let leader_commit_index = self.commit_index;
 
         let peer = self
@@ -3837,10 +3903,23 @@ impl RaftCluster {
             }
         }
         let current_match = peer.match_index();
-        for entry in leader_log
-            .into_iter()
-            .filter(|entry| entry.log_id.index > current_match)
-        {
+
+        // Copy only the tail the peer is missing rather than the whole leader
+        // log, which this runs over once per lagging peer per tick.
+        let leader = self
+            .nodes
+            .get(&leader_id)
+            .ok_or(RaftError::NodeNotFound(leader_id))?;
+        let missing_tail: Vec<RustRaftLogEntry> = leader
+            .log_position_at_or_after(current_match.saturating_add(1))
+            .map(|position| leader.log[position..].to_vec())
+            .unwrap_or_default();
+
+        let peer = self
+            .nodes
+            .get_mut(&peer_id)
+            .ok_or(RaftError::NodeNotFound(peer_id))?;
+        for entry in missing_tail {
             if peer.replica_role == RustRaftReplicaRole::Witness {
                 peer.append_witness_entry(entry, false);
             } else {
@@ -4287,16 +4366,17 @@ impl RaftCluster {
     }
 
     fn log_retained_range(&self) -> RaftLogRetainedRange {
+        // Each node's log is index-ordered, so its bounds are its ends.
         let first_log_index = self
             .nodes
             .values()
-            .flat_map(|node| node.log.iter().map(|entry| entry.log_id.index))
+            .filter_map(|node| node.log.first().map(|entry| entry.log_id.index))
             .min()
             .unwrap_or_default();
         let last_log_index = self
             .nodes
             .values()
-            .flat_map(|node| node.log.iter().map(|entry| entry.log_id.index))
+            .filter_map(|node| node.log.last().map(|entry| entry.log_id.index))
             .max()
             .unwrap_or(self.last_log_index);
         let record_count = self.nodes.values().map(|node| node.log.len() as u64).sum();

--- a/src/facade/tests.rs
+++ b/src/facade/tests.rs
@@ -5,6 +5,120 @@
 // Split from src/lib.rs to keep the crate facade small and focused.
 
 #[cfg(test)]
+mod log_addressing_tests {
+    use super::*;
+
+    fn entry(term: RustRaftTerm, index: RustRaftLogIndex, bytes: usize) -> RustRaftLogEntry {
+        RustRaftLogEntry {
+            log_id: RustRaftLogId { term, index },
+            payload: vec![b'x'; bytes],
+            is_command: false,
+        }
+    }
+
+    fn summed_payload_bytes(node: &RaftNode) -> u64 {
+        node.log.iter().map(|entry| entry.payload.len() as u64).sum()
+    }
+
+    fn assert_byte_count_matches_log(node: &RaftNode, stage: &str) {
+        assert_eq!(
+            node.retained_log_bytes(),
+            summed_payload_bytes(node),
+            "retained byte count drifted from the log after {stage}"
+        );
+    }
+
+    fn voter() -> RaftNode {
+        RaftNode::new(1, RustRaftReplicaRole::Voter, false)
+    }
+
+    #[test]
+    fn retained_byte_count_follows_every_log_mutation() {
+        let mut node = voter();
+        assert_byte_count_matches_log(&node, "construction");
+
+        for index in 1..=10 {
+            node.append_entry(entry(1, index, index as usize * 4));
+        }
+        assert_byte_count_matches_log(&node, "appends");
+        assert_eq!(node.retained_log_bytes(), (1..=10_u64).map(|i| i * 4).sum::<u64>());
+
+        // Re-appending an occupied index drops the conflicting tail with it.
+        node.append_entry(entry(2, 6, 1));
+        assert_byte_count_matches_log(&node, "conflicting append");
+        assert_eq!(node.log.len(), 6);
+        assert_eq!(node.log_term_at(6), Some(2));
+
+        node.truncate_log_from(4);
+        assert_byte_count_matches_log(&node, "truncate");
+        assert_eq!(node.log.len(), 3);
+
+        // Truncating past the tail is a no-op, not a rewind.
+        node.truncate_log_from(99);
+        assert_byte_count_matches_log(&node, "truncate past the tail");
+        assert_eq!(node.log.len(), 3);
+
+        let discarded = node.discard_log_through(2);
+        assert_eq!(discarded, 2);
+        assert_byte_count_matches_log(&node, "discard");
+        assert_eq!(node.log.first().map(|entry| entry.log_id.index), Some(3));
+
+        node.set_log(vec![entry(3, 20, 7), entry(3, 21, 9)]);
+        assert_byte_count_matches_log(&node, "restore");
+        assert_eq!(node.retained_log_bytes(), 16);
+    }
+
+    #[test]
+    fn log_term_lookup_survives_a_compacted_prefix() {
+        let mut node = voter();
+        for index in 1..=8 {
+            let term = if index <= 4 { 1 } else { 2 };
+            node.append_entry(entry(term, index, 3));
+        }
+        node.discard_log_through(5);
+
+        assert_eq!(node.log_term_at(0), Some(0));
+        // Indices below the retained prefix are gone, not mislabelled.
+        assert_eq!(node.log_term_at(3), None);
+        assert_eq!(node.log_term_at(5), None);
+        assert_eq!(node.log_term_at(6), Some(2));
+        assert_eq!(node.log_term_at(8), Some(2));
+        assert_eq!(node.log_term_at(9), None);
+    }
+
+    #[test]
+    fn log_positions_agree_with_a_scan() {
+        let mut node = voter();
+        for index in 1..=32 {
+            node.append_entry(entry(1, index, 2));
+        }
+        node.discard_log_through(7);
+
+        for log_index in 0..40 {
+            let scanned = node
+                .log
+                .iter()
+                .position(|entry| entry.log_id.index == log_index);
+            assert_eq!(
+                node.log_position(log_index),
+                scanned,
+                "log_position disagreed with a scan at index {log_index}"
+            );
+
+            let scanned_after = node
+                .log
+                .iter()
+                .position(|entry| entry.log_id.index >= log_index);
+            assert_eq!(
+                node.log_position_at_or_after(log_index),
+                scanned_after,
+                "log_position_at_or_after disagreed with a scan at index {log_index}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -470,7 +470,10 @@ impl RaftReplicationPipeline {
         while !self.is_paused()
             && self.status.inflight_entries < self.limits.max_inflights_replicate
         {
-            let Some(first_log_id) = self.append_queue.front().map(|queued| queued.log_id.clone())
+            let Some(first_log_id) = self
+                .append_queue
+                .front()
+                .map(|queued| queued.log_id.clone())
             else {
                 break;
             };

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,7 +3,7 @@
 
 //! Replication pipeline evidence and BaselineRaft-style backpressure validation.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
@@ -295,16 +295,25 @@ pub fn rustraft_apply_batch_outcome_like_matrixraft(
     }
 }
 
+/// What the pipeline needs to remember about a queued append: where it sits in
+/// the log and how much it weighs. The payload itself stays in the log, so
+/// queueing an entry for N peers no longer copies it N times.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RaftQueuedAppend {
+    log_id: RustRaftLogId,
+    bytes: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RaftReplicationPipeline {
     peer_id: RustRaftNodeId,
     limits: RustRaftPipelineLimits,
     status: RustRaftPeerPipelineStatus,
-    append_queue: VecDeque<RustRaftLogEntry>,
+    append_queue: VecDeque<RaftQueuedAppend>,
     append_queue_bytes: u64,
     inflight: VecDeque<RaftInflightAppend>,
     apply_inflight: VecDeque<RaftApplyInflightTask>,
-    reorder_queue: BTreeMap<RustRaftLogIndex, RustRaftLogEntry>,
+    reorder_queue: BTreeSet<RustRaftLogIndex>,
     snapshot_transfer: Option<RaftSnapshotTransferState>,
 }
 
@@ -322,7 +331,7 @@ impl RaftReplicationPipeline {
             append_queue_bytes: 0,
             inflight: VecDeque::new(),
             apply_inflight: VecDeque::new(),
-            reorder_queue: BTreeMap::new(),
+            reorder_queue: BTreeSet::new(),
             snapshot_transfer: None,
         }
     }
@@ -407,7 +416,7 @@ impl RaftReplicationPipeline {
         }
     }
 
-    pub fn queue_append(&mut self, entry: RustRaftLogEntry) -> Result<(), RaftError> {
+    pub fn queue_append(&mut self, entry: &RustRaftLogEntry) -> Result<(), RaftError> {
         let bytes = entry.payload.len() as u64;
         if bytes > self.limits.max_apply_batch_bytes {
             self.status.oversized_log_rejections += 1;
@@ -429,7 +438,10 @@ impl RaftReplicationPipeline {
                 "replication memory backpressure limit reached".to_string(),
             ));
         }
-        self.append_queue.push_back(entry);
+        self.append_queue.push_back(RaftQueuedAppend {
+            log_id: entry.log_id.clone(),
+            bytes,
+        });
         self.append_queue_bytes = self.append_queue_bytes.saturating_add(bytes);
         self.status.append_queue_depth = self.append_queue.len() as u64;
         self.status.append_queue_max_depth = self
@@ -458,7 +470,7 @@ impl RaftReplicationPipeline {
         while !self.is_paused()
             && self.status.inflight_entries < self.limits.max_inflights_replicate
         {
-            let Some(first_log_id) = self.append_queue.front().map(|entry| entry.log_id.clone())
+            let Some(first_log_id) = self.append_queue.front().map(|queued| queued.log_id.clone())
             else {
                 break;
             };
@@ -466,10 +478,10 @@ impl RaftReplicationPipeline {
             let mut bytes = 0;
             let mut last_log_id = first_log_id.clone();
             while entry_count < max_entries {
-                let Some(entry) = self.append_queue.front().cloned() else {
+                let Some(queued) = self.append_queue.front() else {
                     break;
                 };
-                let entry_bytes = entry.payload.len() as u64;
+                let entry_bytes = queued.bytes;
                 if entry_count > 0 && bytes + entry_bytes > max_bytes {
                     break;
                 }
@@ -480,7 +492,7 @@ impl RaftReplicationPipeline {
                 }
                 bytes += entry_bytes;
                 entry_count += 1;
-                last_log_id = entry.log_id.clone();
+                last_log_id = queued.log_id.clone();
                 let _ = self.append_queue.pop_front().expect("front exists");
                 self.append_queue_bytes = self.append_queue_bytes.saturating_sub(entry_bytes);
             }
@@ -721,7 +733,7 @@ impl RaftReplicationPipeline {
         self.status.offline_timeout_reached = true;
     }
 
-    pub fn receive_out_of_order(&mut self, entry: RustRaftLogEntry) -> Result<(), RaftError> {
+    pub fn receive_out_of_order(&mut self, entry: &RustRaftLogEntry) -> Result<(), RaftError> {
         if entry.log_id.index < self.status.next_index {
             self.status.out_of_order_append_rejections += 1;
             return Err(RaftError::InvalidRequest(
@@ -746,7 +758,7 @@ impl RaftReplicationPipeline {
                 "reorder queue window is full".to_string(),
             ));
         }
-        self.reorder_queue.insert(entry.log_id.index, entry);
+        self.reorder_queue.insert(entry.log_id.index);
         self.status.reorder_queue_depth = self.reorder_queue.len() as u64;
         Ok(())
     }
@@ -1009,9 +1021,9 @@ impl RaftReplicationPipeline {
     }
 
     fn drain_reorder_queue(&mut self) {
-        while let Some(entry) = self.reorder_queue.remove(&self.status.next_index) {
-            self.status.match_index = entry.log_id.index;
-            self.status.next_index = entry.log_id.index + 1;
+        while self.reorder_queue.remove(&self.status.next_index) {
+            self.status.match_index = self.status.next_index;
+            self.status.next_index = self.status.next_index.saturating_add(1);
         }
         self.status.reorder_queue_depth = self.reorder_queue.len() as u64;
     }

--- a/tests/replication_pipeline.rs
+++ b/tests/replication_pipeline.rs
@@ -196,10 +196,10 @@ fn replication_pipeline_batches_retries_backoff_and_lag() {
     );
     pipeline.set_progress_state(RustRaftPeerProgressState::Replicate);
 
-    pipeline.queue_append(entry(1, b"one")).expect("queue one");
-    pipeline.queue_append(entry(2, b"two")).expect("queue two");
+    pipeline.queue_append(&entry(1, b"one")).expect("queue one");
+    pipeline.queue_append(&entry(2, b"two")).expect("queue two");
     pipeline
-        .queue_append(entry(3, b"three"))
+        .queue_append(&entry(3, b"three"))
         .expect("queue three");
 
     let flushed = pipeline.flush_append_batch(3, 1024);
@@ -266,7 +266,7 @@ fn replication_pipeline_batches_retries_backoff_and_lag() {
     assert_eq!(pipeline.status().retry_attempts, 0);
 
     pipeline
-        .queue_append(entry(4, b"four"))
+        .queue_append(&entry(4, b"four"))
         .expect("queue four");
     assert_eq!(pipeline.flush_append_window().len(), 1);
     assert_eq!(pipeline.status().inflight_entries, 1);
@@ -279,10 +279,10 @@ fn replication_pipeline_batches_retries_backoff_and_lag() {
 
     let mut probing = RaftReplicationPipeline::new(4, 7, RustRaftPipelineLimits::default());
     probing
-        .queue_append(entry(7, b"seven"))
+        .queue_append(&entry(7, b"seven"))
         .expect("queue probe");
     probing
-        .queue_append(entry(8, b"eight"))
+        .queue_append(&entry(8, b"eight"))
         .expect("queue second probe");
     let probe_flush = probing.flush_append_batch(4, 1024);
     assert_eq!(probe_flush.len(), 1);
@@ -318,8 +318,8 @@ fn replication_pipeline_pauses_and_resumes_progress_like_matrixraft() {
             reorder_timeout_us: 10,
         },
     );
-    probe.queue_append(entry(1, b"a")).expect("queue 1");
-    probe.queue_append(entry(2, b"b")).expect("queue 2");
+    probe.queue_append(&entry(1, b"a")).expect("queue 1");
+    probe.queue_append(&entry(2, b"b")).expect("queue 2");
     assert_eq!(probe.progress_state(), RustRaftPeerProgressState::Probe);
     assert_eq!(probe.flush_append_batch(1, 256).len(), 1);
     assert!(probe.is_paused());
@@ -343,7 +343,7 @@ fn replication_pipeline_pauses_and_resumes_progress_like_matrixraft() {
     assert_eq!(probe.progress_state(), RustRaftPeerProgressState::Replicate);
     assert!(probe.no_inflights());
 
-    probe.queue_append(entry(3, b"c")).expect("queue 3");
+    probe.queue_append(&entry(3, b"c")).expect("queue 3");
     assert_eq!(probe.flush_append_window().len(), 1);
     assert!(probe
         .handle_append_response(&RustRaftAppendEntriesResponse {
@@ -362,7 +362,7 @@ fn replication_pipeline_pauses_and_resumes_progress_like_matrixraft() {
 
     let mut replicate = RaftReplicationPipeline::new(3, 1, small_limits());
     replicate.set_progress_state(RustRaftPeerProgressState::Replicate);
-    replicate.queue_append(entry(1, b"a")).expect("queue");
+    replicate.queue_append(&entry(1, b"a")).expect("queue");
     assert_eq!(replicate.flush_append_window().len(), 1);
     assert!(replicate.is_paused());
     assert!(!replicate.no_inflights());
@@ -378,7 +378,7 @@ fn replication_pipeline_pauses_and_resumes_progress_like_matrixraft() {
 #[test]
 fn heartbeat_response_resumes_paused_peer_like_matrixraft() {
     let mut probe = RaftReplicationPipeline::new(2, 1, small_limits());
-    probe.queue_append(entry(1, b"a")).expect("queue append");
+    probe.queue_append(&entry(1, b"a")).expect("queue append");
     assert_eq!(probe.flush_append_batch(1, 1024).len(), 1);
     assert!(probe.is_paused());
 
@@ -392,7 +392,7 @@ fn heartbeat_response_resumes_paused_peer_like_matrixraft() {
 #[test]
 fn stale_success_does_not_unpause_or_free_inflight_like_matrixraft() {
     let mut probe = RaftReplicationPipeline::new(2, 5, RustRaftPipelineLimits::default());
-    probe.queue_append(entry(5, b"five")).expect("queue probe");
+    probe.queue_append(&entry(5, b"five")).expect("queue probe");
     assert_eq!(probe.flush_append_batch(1, 1024).len(), 1);
     assert!(probe.is_paused());
 
@@ -416,7 +416,7 @@ fn stale_success_does_not_unpause_or_free_inflight_like_matrixraft() {
     let mut replicate = RaftReplicationPipeline::new(3, 5, small_limits());
     replicate.set_progress_state(RustRaftPeerProgressState::Replicate);
     replicate
-        .queue_append(entry(5, b"five"))
+        .queue_append(&entry(5, b"five"))
         .expect("queue replicate");
     assert_eq!(replicate.flush_append_window().len(), 1);
     assert!(replicate.is_paused());
@@ -508,7 +508,7 @@ fn replicate_rejection_falls_back_to_matched_boundary_like_matrixraft() {
     assert_eq!(pipeline.status().next_index, 9);
 
     pipeline
-        .queue_append(entry(9, b"next"))
+        .queue_append(&entry(9, b"next"))
         .expect("queue next");
     assert_eq!(pipeline.flush_append_window().len(), 1);
     assert!(pipeline
@@ -574,7 +574,7 @@ fn replication_pipeline_enforces_windows_and_memory_backpressure() {
     let mut pipeline = RaftReplicationPipeline::new(2, 1, small_limits());
 
     pipeline
-        .queue_append(entry(1, b"12345678"))
+        .queue_append(&entry(1, b"12345678"))
         .expect("queue first");
     let flushed = pipeline.flush_append_window();
     assert_eq!(flushed.len(), 1);
@@ -582,9 +582,9 @@ fn replication_pipeline_enforces_windows_and_memory_backpressure() {
     assert_eq!(pipeline.status().inflight_bytes, 8);
 
     pipeline
-        .queue_append(entry(2, b"abcd"))
+        .queue_append(&entry(2, b"abcd"))
         .expect("queue second");
-    assert!(pipeline.queue_append(entry(3, b"efgh")).is_err());
+    assert!(pipeline.queue_append(&entry(3, b"efgh")).is_err());
     assert_eq!(pipeline.status().append_queue_depth, 1);
     assert_eq!(pipeline.status().apply_backpressure_rejections, 1);
 
@@ -618,9 +618,9 @@ fn replication_pipeline_enforces_windows_and_memory_backpressure() {
         },
     );
     memory_limited
-        .queue_append(entry(1, b"12345678"))
+        .queue_append(&entry(1, b"12345678"))
         .expect("queue memory baseline");
-    assert!(memory_limited.queue_append(entry(2, b"abcd")).is_err());
+    assert!(memory_limited.queue_append(&entry(2, b"abcd")).is_err());
     assert_eq!(memory_limited.status().memory_backpressure_rejections, 1);
 }
 
@@ -629,24 +629,24 @@ fn replication_pipeline_drains_and_expires_reorder_queue() {
     let mut pipeline = RaftReplicationPipeline::new(2, 1, small_limits());
 
     pipeline
-        .receive_out_of_order(entry(3, b"three"))
+        .receive_out_of_order(&entry(3, b"three"))
         .expect("queue out of order");
     assert_eq!(pipeline.status().reorder_queue_depth, 1);
 
     pipeline
-        .receive_out_of_order(entry(1, b"one"))
+        .receive_out_of_order(&entry(1, b"one"))
         .expect("accept next index");
     assert_eq!(pipeline.status().match_index, 1);
     assert_eq!(pipeline.status().reorder_queue_depth, 1);
 
     pipeline
-        .receive_out_of_order(entry(2, b"two"))
+        .receive_out_of_order(&entry(2, b"two"))
         .expect("drain through queued three");
     assert_eq!(pipeline.status().match_index, 3);
     assert_eq!(pipeline.status().reorder_queue_depth, 0);
 
     pipeline
-        .receive_out_of_order(entry(5, b"five"))
+        .receive_out_of_order(&entry(5, b"five"))
         .expect("queue gap");
     assert_eq!(pipeline.expire_reorder_queue(), 1);
     assert_eq!(pipeline.status().reorder_entry_timeouts, 1);


### PR DESCRIPTION
Proposing an entry cost more the longer the log got, so a run of N proposals was quadratic in N. Three commits: the algorithmic fix, the copy removal, and the probes that measure both.

## What was slow

Each node keeps its log in an index-ordered `Vec`, but every access walked it:

- `log_term_at` scanned the log for a matching index. It is called from `advance_commit` for every node on every commit advance, from `refresh_commit_index` on every proposal, and once per entry inside the append loop.
- `append_entry` scanned the whole log before every push, looking for a colliding index that in the steady state is never there.
- `conflict_next_index` called `log_term_at` in a loop, so a conflicting follower cost O(n^2).
- `is_busy()` and `should_release_memory()` each summed every payload in the log, and both run at the top of every proposal.
- The replication pipeline queued a full copy of each entry per peer, and flushing a batch cloned each entry again purely to read its length before dropping it. Nothing downstream ever read either copy.

## What changed

Address the log arithmetically. A term lookup subtracts the first retained index; a binary search is the fallback if a missing index ever moves an entry off its arithmetic slot. An append past the tail cannot collide, so it skips the collision check. Truncation and compaction cut by partition point. Each node carries a running payload-byte total, so admission reads a counter instead of summing the log. Peer catch-up copies only the tail the peer is missing rather than cloning the whole leader log, and the retained-range report reads each log's ends rather than every entry.

The pipeline now queues a log id and a byte count instead of the entry, holds the reorder window as a set of indexes, and takes the entry by shared borrow. The payload exists once, in the log.

## Measured

Back to back on one box, 3-node group, release build, 16k proposals:

| payload | before | after | |
|---|---|---|---|
| 64 B | 119.0 us/proposal | 3.4 us/proposal | 35x |
| 4 KiB | 135.5 us/proposal | 11.9 us/proposal | 11x |

The shape matters more than the multiple: doubling the entry count used to cost 4.1x and now costs 1.9x, so the per-proposal cost is flat in log length instead of growing with it. The multiple therefore keeps widening as the log gets longer. Per-peer memory held for un-flushed appends drops from the payload size to 24 bytes.

`examples/propose_scaling.rs` is what produced those numbers and is the guard against the cost creeping back.

## Known behaviour this does not address

`examples/wal_amplification.rs` measures the other half of a proposal's cost and it is larger than everything above. Every WAL record carries the whole retained log, so proposal k writes and fsyncs k entries: 2000 proposals of 64 bytes each write 385 MB, with the per-proposal cost climbing from 24 KB at 250 proposals to 193 KB at 2000. Fixing it means records carrying a delta and recovery folding them, which changes what is on disk and interacts with segment retention -- a record that a later delta depends on must not be compacted away. That is a separate change with its own design and tests; this one deliberately leaves the behaviour alone and only makes its size a number.

## Compatibility

`queue_append` and `receive_out_of_order` now take `&RustRaftLogEntry` rather than an owned entry. Source-breaking for callers that were passing a clone; the fix at each call site is to drop the clone.

## Checks

517 tests pass, unchanged from 514 on main plus the 3 new ones. `cargo clippy --all-targets -- -D warnings` clean, `cargo doc` clean, `cargo +1.82.0 check --all-targets` clean. `cargo fmt --check` reports the same 13 files it already reports on main -- this branch adds none and fixes none of them, which is worth a look separately since CI gates on it.

New tests: `log_positions_agree_with_a_scan` checks both new lookups against the scans they replace at every index across a compacted log, and `retained_byte_count_follows_every_log_mutation` checks the byte counter against a recomputed sum after each kind of mutation.
