### PR TITLE
Name the crate's functions after the crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,52 +32,52 @@ License: Apache-2.0.
 - `RustRaftStatusSnapshot`
 - `RustRaftMetricNames`
 - `RustRaftFaultScenario`
-- `rustraft_fault_harness_readiness_report`
-- `rustraft_read_safety_decision`
-- `rustraft_applied_index_fence_report`
-- `rustraft_lease_read_eligibility_report`
-- `rustraft_bounded_stale_read_report`
-- `rustraft_learner_promotion_decision`
-- `rustraft_append_safety_decision`
+- `matrixraft_fault_harness_readiness_report`
+- `matrixraft_read_safety_decision`
+- `matrixraft_applied_index_fence_report`
+- `matrixraft_lease_read_eligibility_report`
+- `matrixraft_bounded_stale_read_report`
+- `matrixraft_learner_promotion_decision`
+- `matrixraft_append_safety_decision`
 - `RustRaftReadinessEvidence`
 - `RustRaftReadinessSnapshot`
-- `rustraft_parity_contract`
-- `rustraft_parity_report`
-- `rustraft_production_readiness_report`
-- `rustraft_data_node_process_rollout_readiness_report`
-- `rustraft_meta_process_rollout_readiness_report`
-- `rustraft_baseline_raft_runtime_capability_report`
-- `rustraft_baseline_raft_runtime_capability_prometheus`
-- `rustraft_public_api_contract`
-- `rustraft_open_source_surface`
-- `rustraft_temporalstore_adapter_shape`
-- `rustraft_temporalstore_extraction_plan`
-- `rustraft_metric_names`
-- `rustraft_grafana_dashboard`
-- `rustraft_grafana_dashboard_json`
-- `rustraft_alert_rules`
-- `rustraft_alert_rules_json`
-- `rustraft_diagnostic_log_prometheus`
-- `rustraft_observability_provisioning`
-- `rustraft_observability_provisioning_json`
-- `rustraft_observability_provisioning_runbook_steps`
-- `rustraft_observability_provisioning_validation_prometheus`
-- `rustraft_validate_observability_provisioning`
-- `rustraft_validate_observability_provisioning_json`
-- `rustraft_operator_triage_summary`
-- `rustraft_operator_triage_prometheus`
-- `rustraft_operator_runbook_steps`
-- `rustraft_operator_runbook_prometheus`
-- `rustraft_debug_bundle_contract`
-- `rustraft_validate_debug_snapshot`
-- `rustraft_validate_debug_snapshot_json`
-- `rustraft_debug_bundle_validation_prometheus`
-- `rustraft_admin_diagnostic_log_entries`
-- `rustraft_admin_diagnostic_json_lines`
-- `rustraft_optimization_report`
-- `rustraft_optimization_report_prometheus`
-- `rustraft_debug_snapshot_json`
-- `rustraft_debug_snapshot_metadata_prometheus`
+- `matrixraft_parity_contract`
+- `matrixraft_parity_report`
+- `matrixraft_production_readiness_report`
+- `matrixraft_data_node_process_rollout_readiness_report`
+- `matrixraft_meta_process_rollout_readiness_report`
+- `matrixraft_baseline_raft_runtime_capability_report`
+- `matrixraft_baseline_raft_runtime_capability_prometheus`
+- `matrixraft_public_api_contract`
+- `matrixraft_open_source_surface`
+- `matrixraft_temporalstore_adapter_shape`
+- `matrixraft_temporalstore_extraction_plan`
+- `matrixraft_metric_names`
+- `matrixraft_grafana_dashboard`
+- `matrixraft_grafana_dashboard_json`
+- `matrixraft_alert_rules`
+- `matrixraft_alert_rules_json`
+- `matrixraft_diagnostic_log_prometheus`
+- `matrixraft_observability_provisioning`
+- `matrixraft_observability_provisioning_json`
+- `matrixraft_observability_provisioning_runbook_steps`
+- `matrixraft_observability_provisioning_validation_prometheus`
+- `matrixraft_validate_observability_provisioning`
+- `matrixraft_validate_observability_provisioning_json`
+- `matrixraft_operator_triage_summary`
+- `matrixraft_operator_triage_prometheus`
+- `matrixraft_operator_runbook_steps`
+- `matrixraft_operator_runbook_prometheus`
+- `matrixraft_debug_bundle_contract`
+- `matrixraft_validate_debug_snapshot`
+- `matrixraft_validate_debug_snapshot_json`
+- `matrixraft_debug_bundle_validation_prometheus`
+- `matrixraft_admin_diagnostic_log_entries`
+- `matrixraft_admin_diagnostic_json_lines`
+- `matrixraft_optimization_report`
+- `matrixraft_optimization_report_prometheus`
+- `matrixraft_debug_snapshot_json`
+- `matrixraft_debug_snapshot_metadata_prometheus`
 
 Run `cargo run --example debug_artifacts` to print a complete sample support
 artifact with the debug snapshot, JSON log lines, diagnostic and optimization
@@ -91,7 +91,7 @@ conservative parity report.
 
 ## Production Readiness Status
 
-`rustraft_parity_report` returns both a compatibility boolean and an explicit
+`matrixraft_parity_report` returns both a compatibility boolean and an explicit
 production status:
 
 - `blocked`: at least one required safety, durability, transport, snapshot,
@@ -105,7 +105,7 @@ Reports include `production_blockers` such as
 `durability:storage_apply_fence`, making missing production evidence easy to
 surface in TemporalStore readiness gates and CI.
 
-`rustraft_production_readiness_report` is the fail-closed deployment gate. It
+`matrixraft_production_readiness_report` is the fail-closed deployment gate. It
 wraps the semantic parity report with runtime evidence for peer pipeline,
 snapshot lifecycle, WAL lifecycle, data-node rollout, metaserver rollout,
 admin/status observability, fault harness results, and real BaselineRaft benchmark
@@ -113,7 +113,7 @@ parity.
 The data-node and metaserver rollout report helpers expose the same fail-closed
 process-path checks independently, so TemporalStore and downstream adopters can
 validate spawned-process evidence before composing the full production report.
-`rustraft_baseline_raft_runtime_capability_report` groups the same evidence into
+`matrixraft_baseline_raft_runtime_capability_report` groups the same evidence into
 BaselineRaft-derived runtime capability families: process-path rollout proof,
 per-peer replication pipeline state, reorder queues, snapshot sender/downloader
 lifecycle, WAL segment lifecycle, read-index/lease safety, membership role
@@ -130,57 +130,57 @@ Membership evidence must prove joint-consensus commits with both old and new
 quorum acknowledgements for voter-changing scale-up and scale-down transitions.
 WAL lifecycle evidence must prove segment compaction after slow-fsync pressure,
 not only slow-fsync and released-segment counters observed independently.
-`rustraft_baseline_raft_runtime_capability_prometheus` renders that report as generic
+`matrixraft_baseline_raft_runtime_capability_prometheus` renders that report as generic
 `rustraft_baseline_raft_*` Prometheus text metrics. Product runtimes such as
 TemporalStore can attach their own service labels without duplicating the
 capability-matrix logic.
-`rustraft_grafana_dashboard_json` renders a deterministic Grafana dashboard
+`matrixraft_grafana_dashboard_json` renders a deterministic Grafana dashboard
 contract for the canonical `rustraft_*` readiness, latency, queue, WAL, snapshot,
 blocker, and fatal-event metrics.
-`rustraft_admin_diagnostic_json_lines` renders the admin report as structured
+`matrixraft_admin_diagnostic_json_lines` renders the admin report as structured
 JSON log lines for embedders that want RustRaft-owned debugging context without
 adopting a specific logging crate.
-`rustraft_diagnostic_log_prometheus` exports those structured diagnostics as
+`matrixraft_diagnostic_log_prometheus` exports those structured diagnostics as
 severity and per-entry Prometheus counters for dashboards and alert triage.
-`rustraft_optimization_report` converts admin status evidence into deterministic
+`matrixraft_optimization_report` converts admin status evidence into deterministic
 pipeline, WAL, quorum, and reorder-queue tuning hints for operators and CI.
-`rustraft_optimization_report_prometheus` renders those hints as Prometheus text
+`matrixraft_optimization_report_prometheus` renders those hints as Prometheus text
 metrics, including readiness, per-hint, and component-level optimization series,
 for Grafana dashboards and alerting rules.
-`rustraft_alert_rules_json` emits deterministic alert-rule metadata for
+`matrixraft_alert_rules_json` emits deterministic alert-rule metadata for
 optimization readiness, critical optimization hints, fatal events, diagnostic
 errors, and blocker presence, operator triage watch/attention states, critical
 runbook steps, stale debug snapshots, debug-bundle validation failures, and
 provisioning validation failures, so operators can wire the same metric contract
 into monitoring.
-`rustraft_observability_provisioning_json` emits the required metrics, Grafana
+`matrixraft_observability_provisioning_json` emits the required metrics, Grafana
 dashboard, alert rules, debug-bundle contract, and default operator runbook
 steps needed to install the same monitoring contract in downstream runtimes.
-`rustraft_debug_snapshot_json` emits a single timestamped support bundle
+`matrixraft_debug_snapshot_json` emits a single timestamped support bundle
 containing the admin report, diagnostic log entries, optimization hints,
 optimization Prometheus text, runbook Prometheus text, Grafana dashboard
 metadata, alert-rule metadata, and an operator triage summary with first action,
 top diagnostic, top alert, top optimization hint, and runbook steps. The bundle includes a
-versioned `rustraft_debug_bundle_contract` marker and
-`rustraft_validate_debug_snapshot` or `rustraft_validate_debug_snapshot_json`
+versioned `matrixraft_debug_bundle_contract` marker and
+`matrixraft_validate_debug_snapshot` or `matrixraft_validate_debug_snapshot_json`
 for downstream tooling, including timestamp, diagnostic-log, optimization,
 pointer, triage, Prometheus, Grafana, alert-rule, derived-field, and runbook consistency checks.
-`rustraft_debug_snapshot_metadata_prometheus` exports the debug snapshot
+`matrixraft_debug_snapshot_metadata_prometheus` exports the debug snapshot
 generation timestamp and age as Prometheus gauges for Grafana freshness triage.
-`rustraft_debug_bundle_validation_prometheus` turns that validation report into
+`matrixraft_debug_bundle_validation_prometheus` turns that validation report into
 Prometheus readiness, issue-count, first-issue, and per-issue series for
 dashboards and alerting.
-`rustraft_operator_runbook_prometheus` exports grouped remediation counts,
+`matrixraft_operator_runbook_prometheus` exports grouped remediation counts,
 per-step presence, and the first active runbook step for Grafana triage.
-`rustraft_observability_provisioning_validation_prometheus` exposes the same
+`matrixraft_observability_provisioning_validation_prometheus` exposes the same
 readiness, issue-count, first-issue, and per-issue shape for provisioning drift.
 
 Production readiness also requires real BaselineRaft benchmark evidence. Model
 benchmark runners remain available for unit tests, but
-`rustraft_production_readiness_report()` blocks production claims unless
+`matrixraft_production_readiness_report()` blocks production claims unless
 benchmark evidence proves the Rust RustRaft runtime ran the same release-scale workload dimensions and passed
 correctness plus the configured latency and throughput threshold. It also
-requires `rustraft_fault_harness_readiness_report`
+requires `matrixraft_fault_harness_readiness_report`
 evidence for the BaselineRaft-derived packet-loss/partition-heal, slow WAL fsync,
 snapshot-during-membership-change, leader-transfer-under-load,
 follower-rejoin-after-compaction, and rolling-restart joint-consensus scenarios.
@@ -219,7 +219,7 @@ in-memory transport router. The router is meant for library tests and harness
 adapters; production TemporalStore still owns real process transports and
 durable FSM adapters.
 
-The `rustraft_temporalstore_extraction_plan()` API is the typed migration
+The `matrixraft_temporalstore_extraction_plan()` API is the typed migration
 ledger. It records which Raft responsibilities are already owned by this
 standalone crate, which remain pending migration, and which must stay as
 TemporalStore-specific adapters.
@@ -229,7 +229,7 @@ TemporalStore-specific adapters.
 RustRaft exposes its standalone boundary through public modules for `node`,
 `cluster`, `membership`, `wal`, `snapshot`, `transport`, `status`, `metrics`,
 `readiness`, `storage`, `benchmark`, and `fault`. The
-`rustraft_open_source_surface()` report names those modules, embedding examples,
+`matrixraft_open_source_surface()` report names those modules, embedding examples,
 BaselineRaft parity matrix entries, benchmark harness APIs, and compatibility
 reports so consumers can check the published surface without scraping docs.
 
@@ -239,7 +239,7 @@ TemporalStore keeps adapter docs and implementation details for command codecs,
 TemporalEngine apply logic, metaserver scheduling, HTTP/process endpoints, and
 storage-object wiring.
 
-`rustraft_standalone_readiness_report()` is the fail-closed status check for a
+`matrixraft_standalone_readiness_report()` is the fail-closed status check for a
 non-TemporalStore embedding. It only reports `ProductionReady` when the public
 crate surface covers node lifecycle, replication, election/pre-vote, membership,
 WAL recovery, snapshots, read-index/lease-read, and status/metrics/readiness
@@ -261,7 +261,7 @@ struct TemporalRaftConsensusBackend {
 }
 ```
 
-`rustraft_temporalstore_adapter_shape()` exposes this as a typed compatibility
+`matrixraft_temporalstore_adapter_shape()` exposes this as a typed compatibility
 report. RustRaft owns consensus behavior inside the node runtime; TemporalStore
 owns command encoding, apply semantics, storage engine integration, and
 process/admin surfaces.
@@ -321,7 +321,7 @@ This example validates and prints a
 `rustraft.baseline_raft_operational_evidence_bundle.v1` JSON document. Real
 embedders should replace the example counters with observations from spawned
 data-node and metaserver processes, then call
-`rustraft_validate_baseline_raft_operational_evidence_bundle` before forwarding the
+`matrixraft_validate_baseline_raft_operational_evidence_bundle` before forwarding the
 bundle into service readiness or CI gates. The bundle deliberately keeps the
 five BaselineRaft-derived evidence families separate:
 

--- a/examples/baseline_raft_operational_evidence.rs
+++ b/examples/baseline_raft_operational_evidence.rs
@@ -2,14 +2,14 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_baseline_raft_operational_evidence_bundle,
-    rustraft_validate_baseline_raft_operational_evidence_bundle, RustRaftPeerPipelineStatus,
+    matrixraft_baseline_raft_operational_evidence_bundle,
+    matrixraft_validate_baseline_raft_operational_evidence_bundle, RustRaftPeerPipelineStatus,
     RustRaftPipelineLimits, RustRaftWalLifecycleStatus,
 };
 
 fn main() {
     let pipeline_limits = RustRaftPipelineLimits::production_default();
-    let bundle = rustraft_baseline_raft_operational_evidence_bundle(
+    let bundle = matrixraft_baseline_raft_operational_evidence_bundle(
         replication_pipeline_peers(pipeline_limits),
         pipeline_limits,
         snapshot_lifecycle_peers(pipeline_limits),
@@ -17,7 +17,7 @@ fn main() {
         1,
         wal_lifecycle_status(),
     );
-    let validation = rustraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
+    let validation = matrixraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
     assert!(
         validation.valid,
         "BaselineRaft operational evidence bundle failed validation: {validation:#?}"

--- a/examples/baseline_raft_parity_benchmark.rs
+++ b/examples/baseline_raft_parity_benchmark.rs
@@ -2,11 +2,12 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::benchmark::{
-    rustraft_assert_production_baseline_raft_parity,
-    rustraft_baseline_raft_benchmark_failure_summary, rustraft_find_baseline_raft_harness,
-    rustraft_run_baseline_raft_parity_benchmark,
-    rustraft_validate_production_baseline_raft_benchmark_options, RustRaftBenchmarkFailureSummary,
-    RustRaftBenchmarkOptions, RustRaftExternalBaselineRaftRunner, RustRaftRuntimeBenchmarkRunner,
+    matrixraft_assert_production_baseline_raft_parity,
+    matrixraft_baseline_raft_benchmark_failure_summary, matrixraft_find_baseline_raft_harness,
+    matrixraft_run_baseline_raft_parity_benchmark,
+    matrixraft_validate_production_baseline_raft_benchmark_options,
+    RustRaftBenchmarkFailureSummary, RustRaftBenchmarkOptions, RustRaftExternalBaselineRaftRunner,
+    RustRaftRuntimeBenchmarkRunner,
 };
 use std::fs::{self, File};
 use std::io::Write;
@@ -48,7 +49,8 @@ fn main() {
             std::process::exit(2);
         });
     }
-    if let Err(blockers) = rustraft_validate_production_baseline_raft_benchmark_options(&options) {
+    if let Err(blockers) = matrixraft_validate_production_baseline_raft_benchmark_options(&options)
+    {
         eprintln!("BaselineRaft parity benchmark invalid production options: {blockers}");
         std::process::exit(2);
     }
@@ -61,7 +63,7 @@ fn main() {
         .or_else(|| {
             baseline_raft_root
                 .as_ref()
-                .and_then(|root| rustraft_find_baseline_raft_harness(root).ok())
+                .and_then(|root| matrixraft_find_baseline_raft_harness(root).ok())
         });
     let Some(baseline_raft_bin) = baseline_raft_bin else {
         eprintln!(
@@ -82,8 +84,8 @@ fn main() {
     };
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new(build_profile);
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
 
     println!("{}", serde_json::to_string_pretty(&report).unwrap());
     if let Ok(summary_out) = std::env::var("RUSTRAFT_BENCHMARK_SUMMARY_OUT") {
@@ -94,7 +96,7 @@ fn main() {
             std::process::exit(2);
         }
     }
-    if let Err(blockers) = rustraft_assert_production_baseline_raft_parity(&report) {
+    if let Err(blockers) = matrixraft_assert_production_baseline_raft_parity(&report) {
         eprintln!("BaselineRaft parity benchmark failed: {blockers}");
         eprintln!(
             "BaselineRaft parity benchmark summary: {}",

--- a/examples/baseline_raft_parity_verify.rs
+++ b/examples/baseline_raft_parity_verify.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::benchmark::{
-    rustraft_assert_production_baseline_raft_artifacts, RustRaftBenchmarkFailureSummary,
+    matrixraft_assert_production_baseline_raft_artifacts, RustRaftBenchmarkFailureSummary,
     RustRaftBenchmarkReport,
 };
 use std::{
@@ -67,7 +67,7 @@ fn main() {
     assert_fresh_artifact(&summary_path, "summary", max_age_seconds);
     let report = read_json::<RustRaftBenchmarkReport>(&report_path, "report");
     let summary = read_json::<RustRaftBenchmarkFailureSummary>(&summary_path, "summary");
-    match rustraft_assert_production_baseline_raft_artifacts(&report, &summary) {
+    match matrixraft_assert_production_baseline_raft_artifacts(&report, &summary) {
         Ok(()) => {
             println!("BaselineRaft-vs-RustRaft benchmark artifacts verified");
         }

--- a/examples/debug_artifacts.rs
+++ b/examples/debug_artifacts.rs
@@ -7,12 +7,13 @@
 #![recursion_limit = "4096"]
 
 use matrixraft::{
-    rustraft_capability_evidence, rustraft_debug_bundle_validation_prometheus,
-    rustraft_debug_snapshot, rustraft_debug_snapshot_metadata_prometheus,
-    rustraft_observability_provisioning, rustraft_observability_provisioning_validation_prometheus,
-    rustraft_operator_runbook_prometheus, rustraft_operator_triage_prometheus,
-    rustraft_runtime_admin_report, rustraft_validate_debug_snapshot,
-    rustraft_validate_observability_provisioning, RaftCluster, RaftPeerPipelineState,
+    matrixraft_capability_evidence, matrixraft_debug_bundle_validation_prometheus,
+    matrixraft_debug_snapshot, matrixraft_debug_snapshot_metadata_prometheus,
+    matrixraft_observability_provisioning,
+    matrixraft_observability_provisioning_validation_prometheus,
+    matrixraft_operator_runbook_prometheus, matrixraft_operator_triage_prometheus,
+    matrixraft_runtime_admin_report, matrixraft_validate_debug_snapshot,
+    matrixraft_validate_observability_provisioning, RaftCluster, RaftPeerPipelineState,
     RustRaftDebugBundleValidationReport, RustRaftPeer, RustRaftPeerProgressState,
     RustRaftReadinessSnapshot, RustRaftReplicaRole,
 };
@@ -41,16 +42,16 @@ fn peer(node_id: u64) -> RustRaftPeer {
 
 fn readiness() -> RustRaftReadinessSnapshot {
     RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     }
@@ -134,8 +135,8 @@ fn main() {
         .expect("write commits");
 
     let readiness = readiness();
-    let capability_evidence = rustraft_capability_evidence(&readiness);
-    let report = rustraft_runtime_admin_report(
+    let capability_evidence = matrixraft_capability_evidence(&readiness);
+    let report = matrixraft_runtime_admin_report(
         cluster.cluster_status_report().expect("cluster status"),
         readiness,
         capability_evidence,
@@ -154,7 +155,7 @@ fn main() {
         wal_segment_lifecycle_present: true,
     };
     let labels = [("service", "rustraft-example")];
-    let snapshot = rustraft_debug_snapshot(&report, &status_surface, &labels);
+    let snapshot = matrixraft_debug_snapshot(&report, &status_surface, &labels);
     let snapshot_json = serde_json::to_string_pretty(&snapshot).expect("debug snapshot serializes");
     let diagnostic_json_lines = snapshot
         .diagnostics
@@ -163,25 +164,25 @@ fn main() {
         .collect::<Vec<_>>()
         .join("\n");
     let snapshot_metadata_prometheus =
-        rustraft_debug_snapshot_metadata_prometheus(&snapshot, &labels);
-    let validation = rustraft_validate_debug_snapshot(&snapshot);
-    let validation_prometheus = rustraft_debug_bundle_validation_prometheus(&validation, &labels);
-    let triage_prometheus = rustraft_operator_triage_prometheus(&snapshot.triage, &labels);
-    let provisioning = rustraft_observability_provisioning();
+        matrixraft_debug_snapshot_metadata_prometheus(&snapshot, &labels);
+    let validation = matrixraft_validate_debug_snapshot(&snapshot);
+    let validation_prometheus = matrixraft_debug_bundle_validation_prometheus(&validation, &labels);
+    let triage_prometheus = matrixraft_operator_triage_prometheus(&snapshot.triage, &labels);
+    let provisioning = matrixraft_observability_provisioning();
     let dashboard_json = serde_json::to_string_pretty(&provisioning.dashboard)
         .expect("grafana dashboard serializes");
     let alert_rules_json =
         serde_json::to_string_pretty(&provisioning.alert_rules).expect("alert rules serialize");
     let provisioning_json =
         serde_json::to_string_pretty(&provisioning).expect("observability provisioning serializes");
-    let provisioning_validation = rustraft_validate_observability_provisioning(&provisioning);
+    let provisioning_validation = matrixraft_validate_observability_provisioning(&provisioning);
     let provisioning_validation_prometheus =
-        rustraft_observability_provisioning_validation_prometheus(
+        matrixraft_observability_provisioning_validation_prometheus(
             &provisioning_validation,
             &labels,
         );
     let provisioning_runbook_prometheus =
-        rustraft_operator_runbook_prometheus(&provisioning.runbook_steps, &labels);
+        matrixraft_operator_runbook_prometheus(&provisioning.runbook_steps, &labels);
     let envelope_artifact_names = vec![
         "debug_snapshot",
         "debug_snapshot_json",
@@ -2806,7 +2807,7 @@ fn main() {
         ("support_envelope_status", support_envelope_status),
         ("support_envelope_severity", support_envelope_severity),
     ];
-    let support_envelope_validation_prometheus = rustraft_debug_bundle_validation_prometheus(
+    let support_envelope_validation_prometheus = matrixraft_debug_bundle_validation_prometheus(
         &support_envelope_report,
         &support_envelope_labels,
     );

--- a/examples/open_source_surface.rs
+++ b/examples/open_source_surface.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-use matrixraft::readiness::rustraft_open_source_surface;
+use matrixraft::readiness::matrixraft_open_source_surface;
 
 fn main() {
-    let surface = rustraft_open_source_surface();
+    let surface = matrixraft_open_source_surface();
     println!("{}", serde_json::to_string_pretty(&surface).unwrap());
 }

--- a/examples/read_safety.rs
+++ b/examples/read_safety.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_read_safety_decision, RustRaftReadIndexRequest, RustRaftRole, RustRaftStatusSnapshot,
+    matrixraft_read_safety_decision, RustRaftReadIndexRequest, RustRaftRole, RustRaftStatusSnapshot,
 };
 
 fn main() {
@@ -19,7 +19,7 @@ fn main() {
         peers: Vec::new(),
     };
 
-    let decision = rustraft_read_safety_decision(
+    let decision = matrixraft_read_safety_decision(
         &status,
         &RustRaftReadIndexRequest {
             group_id: 7,

--- a/examples/readiness_report.rs
+++ b/examples/readiness_report.rs
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-use matrixraft::{rustraft_parity_report, RustRaftProductionStatus, RustRaftReadinessSnapshot};
+use matrixraft::{matrixraft_parity_report, RustRaftProductionStatus, RustRaftReadinessSnapshot};
 
 fn main() {
     let readiness = RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     };
 
-    let report = rustraft_parity_report(&readiness);
+    let report = matrixraft_parity_report(&readiness);
     assert_eq!(
         report.production_status,
         RustRaftProductionStatus::ProductionReady

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -9,33 +9,33 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::{
-    rustraft_production_readiness_report, PersistentRaftWal, PersistentRaftWalOptions, RaftCluster,
-    RaftConfig, RaftError, RustRaftApplySnapshotFence, RustRaftHardState, RustRaftLogEntry,
-    RustRaftLogId, RustRaftMembership, RustRaftPeer, RustRaftProductionReadinessInput,
-    RustRaftProductionReadinessReport, RustRaftReplicaRole, RustRaftSnapshotMeta,
-    RustRaftWalRecord,
+    matrixraft_production_readiness_report, PersistentRaftWal, PersistentRaftWalOptions,
+    RaftCluster, RaftConfig, RaftError, RustRaftApplySnapshotFence, RustRaftHardState,
+    RustRaftLogEntry, RustRaftLogId, RustRaftMembership, RustRaftPeer,
+    RustRaftProductionReadinessInput, RustRaftProductionReadinessReport, RustRaftReplicaRole,
+    RustRaftSnapshotMeta, RustRaftWalRecord,
 };
 
-const RUSTRAFT_BENCHMARK_MAX_ARTIFACT_AGE_MS: u64 = 24 * 60 * 60 * 1000;
-const RUSTRAFT_BENCHMARK_MAX_FUTURE_SKEW_MS: u64 = 60 * 1000;
-pub const RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT: usize = 5;
-pub const RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD: usize = 128;
-pub const RUSTRAFT_BENCHMARK_MIN_PRODUCTION_BATCH_SIZE: usize = 2;
-pub const RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES: usize = 4096;
-pub const RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT: f64 = 10.0;
-pub const RUSTRAFT_BENCHMARK_REPORT_SCHEMA: &str = "rustraft.baseline_raft_benchmark_report.v1";
-pub const RUSTRAFT_BENCHMARK_SUMMARY_SCHEMA: &str = "rustraft.baseline_raft_benchmark_summary.v1";
+const MATRIXRAFT_BENCHMARK_MAX_ARTIFACT_AGE_MS: u64 = 24 * 60 * 60 * 1000;
+const MATRIXRAFT_BENCHMARK_MAX_FUTURE_SKEW_MS: u64 = 60 * 1000;
+pub const MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT: usize = 5;
+pub const MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD: usize = 128;
+pub const MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_BATCH_SIZE: usize = 2;
+pub const MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES: usize = 4096;
+pub const MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT: f64 = 10.0;
+pub const MATRIXRAFT_BENCHMARK_REPORT_SCHEMA: &str = "rustraft.baseline_raft_benchmark_report.v1";
+pub const MATRIXRAFT_BENCHMARK_SUMMARY_SCHEMA: &str = "rustraft.baseline_raft_benchmark_summary.v1";
 
-static RUSTRAFT_BENCHMARK_RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static MATRIXRAFT_BENCHMARK_RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RustRaftBaselineRaftBenchmarkEvidence {
     pub real_baseline_raft: bool,
-    pub rustraft_runtime: bool,
+    pub matrixraft_runtime: bool,
     #[serde(default)]
     pub baseline_raft_reference: bool,
     #[serde(default)]
-    pub rustraft_rust_candidate: bool,
+    pub matrixraft_rust_candidate: bool,
     pub correctness_passed: bool,
     pub performance_within_threshold: bool,
     pub workloads: Vec<String>,
@@ -145,7 +145,7 @@ impl RustRaftBenchmarkWorkload {
     }
 }
 
-pub fn rustraft_baseline_raft_benchmark_workloads() -> Vec<RustRaftBenchmarkWorkload> {
+pub fn matrixraft_baseline_raft_benchmark_workloads() -> Vec<RustRaftBenchmarkWorkload> {
     vec![
         RustRaftBenchmarkWorkload::SingleKeyWrites,
         RustRaftBenchmarkWorkload::BatchedWrites,
@@ -159,45 +159,45 @@ pub fn rustraft_baseline_raft_benchmark_workloads() -> Vec<RustRaftBenchmarkWork
     ]
 }
 
-pub fn rustraft_baseline_raft_benchmark_required_workloads() -> Vec<String> {
-    rustraft_baseline_raft_benchmark_workloads()
+pub fn matrixraft_baseline_raft_benchmark_required_workloads() -> Vec<String> {
+    matrixraft_baseline_raft_benchmark_workloads()
         .into_iter()
         .map(|workload| workload.id().to_string())
         .collect()
 }
 
-pub fn rustraft_production_readiness_input_with_benchmark_artifacts(
+pub fn matrixraft_production_readiness_input_with_benchmark_artifacts(
     mut input: RustRaftProductionReadinessInput,
     report: &RustRaftBenchmarkReport,
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> Result<RustRaftProductionReadinessInput, String> {
-    input.baseline_raft_benchmark = Some(rustraft_baseline_raft_benchmark_evidence_from_artifacts(
-        report, summary,
-    )?);
+    input.baseline_raft_benchmark = Some(
+        matrixraft_baseline_raft_benchmark_evidence_from_artifacts(report, summary)?,
+    );
     Ok(input)
 }
 
-pub fn rustraft_production_readiness_input_with_benchmark_summary(
+pub fn matrixraft_production_readiness_input_with_benchmark_summary(
     mut input: RustRaftProductionReadinessInput,
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> RustRaftProductionReadinessInput {
-    input.baseline_raft_benchmark = Some(rustraft_baseline_raft_benchmark_evidence_from_summary(
+    input.baseline_raft_benchmark = Some(matrixraft_baseline_raft_benchmark_evidence_from_summary(
         summary,
     ));
     input
 }
 
-pub fn rustraft_production_readiness_report_with_benchmark_artifacts(
+pub fn matrixraft_production_readiness_report_with_benchmark_artifacts(
     input: &RustRaftProductionReadinessInput,
     report: &RustRaftBenchmarkReport,
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> Result<RustRaftProductionReadinessReport, String> {
-    let input = rustraft_production_readiness_input_with_benchmark_artifacts(
+    let input = matrixraft_production_readiness_input_with_benchmark_artifacts(
         input.clone(),
         report,
         summary,
     )?;
-    Ok(rustraft_production_readiness_report(&input))
+    Ok(matrixraft_production_readiness_report(&input))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -212,11 +212,11 @@ pub struct RustRaftBenchmarkOptions {
 impl Default for RustRaftBenchmarkOptions {
     fn default() -> Self {
         Self {
-            node_count: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT,
+            node_count: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT,
             iterations_per_workload: 128,
             batch_size: 16,
-            payload_size_bytes: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES,
-            pass_tolerance_percent: RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT,
+            payload_size_bytes: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES,
+            pass_tolerance_percent: MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT,
         }
     }
 }
@@ -326,70 +326,70 @@ pub struct RustRaftBenchmarkWorkloadSummary {
     pub workload: RustRaftBenchmarkWorkload,
     pub passed: bool,
     pub baseline_raft_correctness_passed: bool,
-    pub rustraft_correctness_passed: bool,
+    pub matrixraft_correctness_passed: bool,
     pub baseline_raft_engine_source: RustRaftBenchmarkEngineSource,
-    pub rustraft_engine_source: RustRaftBenchmarkEngineSource,
+    pub matrixraft_engine_source: RustRaftBenchmarkEngineSource,
     #[serde(default)]
     pub baseline_raft_benchmark_run_id: String,
     #[serde(default)]
-    pub rustraft_benchmark_run_id: String,
+    pub matrixraft_benchmark_run_id: String,
     #[serde(default)]
     pub baseline_raft_implementation: RustRaftBenchmarkImplementation,
     #[serde(default)]
-    pub rustraft_implementation: RustRaftBenchmarkImplementation,
+    pub matrixraft_implementation: RustRaftBenchmarkImplementation,
     #[serde(default)]
     pub baseline_raft_binary_path: Option<String>,
     #[serde(default)]
-    pub rustraft_binary_path: Option<String>,
+    pub matrixraft_binary_path: Option<String>,
     #[serde(default)]
     pub baseline_raft_git_revision: Option<String>,
     #[serde(default)]
-    pub rustraft_git_revision: Option<String>,
+    pub matrixraft_git_revision: Option<String>,
     #[serde(default)]
     pub baseline_raft_build_profile: String,
     #[serde(default)]
-    pub rustraft_build_profile: String,
+    pub matrixraft_build_profile: String,
     #[serde(default)]
     pub baseline_raft_harness_kind: RustRaftBenchmarkHarnessKind,
     #[serde(default)]
-    pub rustraft_harness_kind: RustRaftBenchmarkHarnessKind,
+    pub matrixraft_harness_kind: RustRaftBenchmarkHarnessKind,
     pub node_count: usize,
     #[serde(default)]
     pub baseline_raft_node_count: usize,
     #[serde(default)]
-    pub rustraft_node_count: usize,
+    pub matrixraft_node_count: usize,
     pub baseline_raft_iterations_per_workload: usize,
-    pub rustraft_iterations_per_workload: usize,
+    pub matrixraft_iterations_per_workload: usize,
     pub baseline_raft_batch_size: usize,
-    pub rustraft_batch_size: usize,
+    pub matrixraft_batch_size: usize,
     pub baseline_raft_payload_size_bytes: usize,
-    pub rustraft_payload_size_bytes: usize,
+    pub matrixraft_payload_size_bytes: usize,
     #[serde(default)]
     pub baseline_raft_timed_iteration_count: usize,
     #[serde(default)]
-    pub rustraft_timed_iteration_count: usize,
+    pub matrixraft_timed_iteration_count: usize,
     #[serde(default)]
     pub baseline_raft_operations_per_timed_iteration: usize,
     #[serde(default)]
-    pub rustraft_operations_per_timed_iteration: usize,
+    pub matrixraft_operations_per_timed_iteration: usize,
     #[serde(default)]
     pub baseline_raft_total_duration_micros: u64,
     #[serde(default)]
-    pub rustraft_total_duration_micros: u64,
+    pub matrixraft_total_duration_micros: u64,
     pub baseline_raft_operation_count: usize,
-    pub rustraft_operation_count: usize,
+    pub matrixraft_operation_count: usize,
     #[serde(default)]
     pub baseline_raft_p50_latency_micros: u64,
     #[serde(default)]
-    pub rustraft_p50_latency_micros: u64,
+    pub matrixraft_p50_latency_micros: u64,
     #[serde(default)]
     pub baseline_raft_p99_latency_micros: u64,
     #[serde(default)]
-    pub rustraft_p99_latency_micros: u64,
+    pub matrixraft_p99_latency_micros: u64,
     #[serde(default)]
     pub baseline_raft_throughput_ops_per_sec: f64,
     #[serde(default)]
-    pub rustraft_throughput_ops_per_sec: f64,
+    pub matrixraft_throughput_ops_per_sec: f64,
     pub p50_ratio: f64,
     pub p99_ratio: f64,
     pub throughput_ratio: f64,
@@ -448,7 +448,7 @@ impl RustRaftSameMachineModelRunner {
         }
     }
 
-    pub fn rustraft_candidate() -> Self {
+    pub fn matrixraft_candidate() -> Self {
         Self {
             engine: RustRaftBenchmarkEngine::RustRaft,
         }
@@ -546,7 +546,7 @@ impl RustRaftExternalBaselineRaftRunner {
                 binary_path.display()
             ));
         }
-        if let Some(blocker) = rustraft_baseline_raft_harness_executable_blocker(&binary_path) {
+        if let Some(blocker) = matrixraft_baseline_raft_harness_executable_blocker(&binary_path) {
             return Err(blocker);
         }
         let baseline_raft_root = baseline_raft_root.map(Into::into);
@@ -567,7 +567,7 @@ impl RustRaftExternalBaselineRaftRunner {
     ) -> Result<Self, String> {
         let root = baseline_raft_root.as_ref();
         let build_profile = build_profile.into();
-        let binary = rustraft_find_or_build_baseline_raft_harness(root, &build_profile)?;
+        let binary = matrixraft_find_or_build_baseline_raft_harness(root, &build_profile)?;
         Self::new(binary, Some(root.to_path_buf()), build_profile)
     }
 }
@@ -957,7 +957,7 @@ fn failed_real_baseline_raft_sample(
     }
 }
 
-pub fn rustraft_find_baseline_raft_harness(
+pub fn matrixraft_find_baseline_raft_harness(
     baseline_raft_root: impl AsRef<Path>,
 ) -> Result<PathBuf, String> {
     let root = baseline_raft_root.as_ref();
@@ -979,7 +979,7 @@ pub fn rustraft_find_baseline_raft_harness(
         if !path.is_file() {
             continue;
         }
-        if let Some(blocker) = rustraft_baseline_raft_harness_executable_blocker(&path) {
+        if let Some(blocker) = matrixraft_baseline_raft_harness_executable_blocker(&path) {
             non_executable.push(blocker);
             continue;
         }
@@ -996,7 +996,7 @@ pub fn rustraft_find_baseline_raft_harness(
 }
 
 #[cfg(unix)]
-fn rustraft_baseline_raft_harness_executable_blocker(path: &Path) -> Option<String> {
+fn matrixraft_baseline_raft_harness_executable_blocker(path: &Path) -> Option<String> {
     use std::os::unix::fs::PermissionsExt;
 
     match fs::metadata(path) {
@@ -1013,16 +1013,16 @@ fn rustraft_baseline_raft_harness_executable_blocker(path: &Path) -> Option<Stri
 }
 
 #[cfg(not(unix))]
-fn rustraft_baseline_raft_harness_executable_blocker(_path: &Path) -> Option<String> {
+fn matrixraft_baseline_raft_harness_executable_blocker(_path: &Path) -> Option<String> {
     None
 }
 
-pub fn rustraft_probe_baseline_raft_native_benchmark(
+pub fn matrixraft_probe_baseline_raft_native_benchmark(
     baseline_raft_root: impl AsRef<Path>,
 ) -> RustRaftBaselineRaftNativeBenchmarkCapability {
     let root = baseline_raft_root.as_ref();
-    let kvserver_binary = rustraft_find_baseline_raft_kvserver(root).ok();
-    let kvbench_binary = rustraft_find_baseline_raft_kvbench(root).ok();
+    let kvserver_binary = matrixraft_find_baseline_raft_kvserver(root).ok();
+    let kvbench_binary = matrixraft_find_baseline_raft_kvbench(root).ok();
     let kvserver_source = root.join("example/kv/kv_server.cc");
     let kvbench_source = root.join("example/kv/kv_benchmark.cc");
     let bench_script = root.join("script/bench.sh");
@@ -1047,7 +1047,7 @@ pub fn rustraft_probe_baseline_raft_native_benchmark(
         supported_workloads.push(RustRaftBenchmarkWorkload::LeaseReads.id().to_string());
     }
 
-    let required = rustraft_baseline_raft_benchmark_workloads()
+    let required = matrixraft_baseline_raft_benchmark_workloads()
         .into_iter()
         .map(|workload| workload.id().to_string())
         .collect::<Vec<_>>();
@@ -1096,7 +1096,7 @@ pub fn rustraft_probe_baseline_raft_native_benchmark(
     }
 }
 
-fn rustraft_find_baseline_raft_kvserver(baseline_raft_root: &Path) -> Result<PathBuf, String> {
+fn matrixraft_find_baseline_raft_kvserver(baseline_raft_root: &Path) -> Result<PathBuf, String> {
     let root = baseline_raft_root;
     let candidates = [
         root.join("build/example/kv/kvserver"),
@@ -1115,7 +1115,7 @@ fn rustraft_find_baseline_raft_kvserver(baseline_raft_root: &Path) -> Result<Pat
         })
 }
 
-fn rustraft_find_baseline_raft_kvbench(baseline_raft_root: &Path) -> Result<PathBuf, String> {
+fn matrixraft_find_baseline_raft_kvbench(baseline_raft_root: &Path) -> Result<PathBuf, String> {
     let root = baseline_raft_root;
     let candidates = [
         root.join("build/example/kv/kvbench"),
@@ -1134,12 +1134,12 @@ fn rustraft_find_baseline_raft_kvbench(baseline_raft_root: &Path) -> Result<Path
         })
 }
 
-pub fn rustraft_find_or_build_baseline_raft_harness(
+pub fn matrixraft_find_or_build_baseline_raft_harness(
     baseline_raft_root: impl AsRef<Path>,
     build_profile: &str,
 ) -> Result<PathBuf, String> {
     let root = baseline_raft_root.as_ref();
-    let initial_harness_error = match rustraft_find_baseline_raft_harness(root) {
+    let initial_harness_error = match matrixraft_find_baseline_raft_harness(root) {
         Ok(binary) => return Ok(binary),
         Err(err) => err,
     };
@@ -1165,7 +1165,7 @@ pub fn rustraft_find_or_build_baseline_raft_harness(
         try_baseline_raft_bazel_target(root, build_profile),
     ];
 
-    let final_harness_error = match rustraft_find_baseline_raft_harness(root) {
+    let final_harness_error = match matrixraft_find_baseline_raft_harness(root) {
         Ok(binary) => return Ok(binary),
         Err(err) => err,
     };
@@ -1280,7 +1280,7 @@ fn try_baseline_raft_bazel_target(root: &Path, _build_profile: &str) -> Result<(
     }
 }
 
-pub fn rustraft_run_baseline_raft_parity_benchmark(
+pub fn matrixraft_run_baseline_raft_parity_benchmark(
     baseline_raft: &mut impl RustRaftBenchmarkRunner,
     rustraft: &mut impl RustRaftBenchmarkRunner,
     options: &RustRaftBenchmarkOptions,
@@ -1291,7 +1291,7 @@ pub fn rustraft_run_baseline_raft_parity_benchmark(
     );
     assert_eq!(rustraft.engine(), RustRaftBenchmarkEngine::RustRaft);
     let benchmark_run_id = benchmark_run_id();
-    let comparisons = rustraft_baseline_raft_benchmark_workloads()
+    let comparisons = matrixraft_baseline_raft_benchmark_workloads()
         .into_iter()
         .map(|workload| {
             let mut baseline = baseline_raft.run_workload(workload, options);
@@ -1301,10 +1301,10 @@ pub fn rustraft_run_baseline_raft_parity_benchmark(
             compare_samples(baseline, candidate, options.pass_tolerance_percent)
         })
         .collect::<Vec<_>>();
-    let passed = comparisons.len() == rustraft_baseline_raft_benchmark_workloads().len()
+    let passed = comparisons.len() == matrixraft_baseline_raft_benchmark_workloads().len()
         && comparisons.iter().all(|comparison| comparison.passed);
     RustRaftBenchmarkReport {
-        schema: RUSTRAFT_BENCHMARK_REPORT_SCHEMA.to_string(),
+        schema: MATRIXRAFT_BENCHMARK_REPORT_SCHEMA.to_string(),
         generated_at_unix_ms: benchmark_now_unix_ms(),
         benchmark_run_id,
         environment_fingerprint: benchmark_environment_fingerprint(),
@@ -1312,13 +1312,13 @@ pub fn rustraft_run_baseline_raft_parity_benchmark(
         options: options.clone(),
         pass_tolerance_percent: options.pass_tolerance_percent,
         correctness_required: true,
-        required_workloads: rustraft_baseline_raft_benchmark_required_workloads(),
+        required_workloads: matrixraft_baseline_raft_benchmark_required_workloads(),
         passed,
         comparisons,
     }
 }
 
-pub fn rustraft_assert_baseline_raft_parity(
+pub fn matrixraft_assert_baseline_raft_parity(
     report: &RustRaftBenchmarkReport,
 ) -> Result<(), String> {
     if report.passed {
@@ -1338,13 +1338,13 @@ pub fn rustraft_assert_baseline_raft_parity(
     Err(blockers.join("; "))
 }
 
-pub fn rustraft_assert_production_baseline_raft_parity(
+pub fn matrixraft_assert_production_baseline_raft_parity(
     report: &RustRaftBenchmarkReport,
 ) -> Result<(), String> {
-    let parity_error = rustraft_assert_baseline_raft_parity(report).err();
-    let evidence = rustraft_baseline_raft_benchmark_evidence(report);
+    let parity_error = matrixraft_assert_baseline_raft_parity(report).err();
+    let evidence = matrixraft_baseline_raft_benchmark_evidence(report);
     if evidence.real_baseline_raft
-        && evidence.rustraft_runtime
+        && evidence.matrixraft_runtime
         && evidence.correctness_passed
         && evidence.performance_within_threshold
         && evidence.blockers.is_empty()
@@ -1365,19 +1365,19 @@ pub fn rustraft_assert_production_baseline_raft_parity(
     Err(blockers.join("; "))
 }
 
-pub fn rustraft_assert_production_baseline_raft_artifacts(
+pub fn matrixraft_assert_production_baseline_raft_artifacts(
     report: &RustRaftBenchmarkReport,
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> Result<(), String> {
-    let expected = rustraft_baseline_raft_benchmark_failure_summary(report);
+    let expected = matrixraft_baseline_raft_benchmark_failure_summary(report);
     if summary != &expected {
         return Err("benchmark:summary_artifact_mismatch".to_string());
     }
     let mut blockers = Vec::new();
-    if let Err(error) = rustraft_assert_production_baseline_raft_summary(summary) {
+    if let Err(error) = matrixraft_assert_production_baseline_raft_summary(summary) {
         blockers.extend(error.split("; ").map(str::to_string));
     }
-    if let Err(error) = rustraft_assert_production_baseline_raft_parity(report) {
+    if let Err(error) = matrixraft_assert_production_baseline_raft_parity(report) {
         blockers.extend(error.split("; ").map(str::to_string));
     }
     blockers.sort();
@@ -1389,14 +1389,14 @@ pub fn rustraft_assert_production_baseline_raft_artifacts(
     }
 }
 
-pub fn rustraft_assert_production_baseline_raft_summary(
+pub fn matrixraft_assert_production_baseline_raft_summary(
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> Result<(), String> {
     let mut blockers = Vec::new();
-    if summary.schema != RUSTRAFT_BENCHMARK_SUMMARY_SCHEMA {
+    if summary.schema != MATRIXRAFT_BENCHMARK_SUMMARY_SCHEMA {
         blockers.push(format!(
             "benchmark:summary_schema_mismatch:{}:{}",
-            summary.schema, RUSTRAFT_BENCHMARK_SUMMARY_SCHEMA
+            summary.schema, MATRIXRAFT_BENCHMARK_SUMMARY_SCHEMA
         ));
     }
     blockers.extend(benchmark_artifact_timestamp_blockers(
@@ -1442,7 +1442,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             summary.failed_workload_count, actual_failed_workload_count
         ));
     }
-    let required_workload_manifest = rustraft_baseline_raft_benchmark_required_workloads();
+    let required_workload_manifest = matrixraft_baseline_raft_benchmark_required_workloads();
     if summary.required_workloads != required_workload_manifest {
         blockers.push(format!(
             "benchmark:summary_required_workloads_mismatch:declared_{}_required_{}",
@@ -1597,7 +1597,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             && workload.p99_ratio <= max_latency_ratio
             && workload.throughput_ratio >= min_throughput_ratio;
         let workload_correctness_passed =
-            workload.baseline_raft_correctness_passed && workload.rustraft_correctness_passed;
+            workload.baseline_raft_correctness_passed && workload.matrixraft_correctness_passed;
         if workload.passed && !workload.blockers.is_empty() {
             blockers.push(format!(
                 "benchmark:summary_workload_passed_with_blockers:{}",
@@ -1632,7 +1632,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.workload.id()
             ));
         }
-        if !workload.rustraft_correctness_passed {
+        if !workload.matrixraft_correctness_passed {
             blockers.push(format!(
                 "benchmark:summary_rustraft_correctness_failed:{}",
                 workload.workload.id()
@@ -1644,7 +1644,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.workload.id()
             ));
         }
-        if workload.rustraft_engine_source != RustRaftBenchmarkEngineSource::RustRaftRuntime {
+        if workload.matrixraft_engine_source != RustRaftBenchmarkEngineSource::RustRaftRuntime {
             blockers.push(format!(
                 "benchmark:summary_rustraft_runtime_missing:{}",
                 workload.workload.id()
@@ -1663,28 +1663,28 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 summary.benchmark_run_id
             ));
         }
-        if workload.rustraft_benchmark_run_id.is_empty() {
+        if workload.matrixraft_benchmark_run_id.is_empty() {
             blockers.push(format!(
                 "benchmark:summary_rustraft_run_id_missing:{}",
                 workload.workload.id()
             ));
-        } else if workload.rustraft_benchmark_run_id != summary.benchmark_run_id {
+        } else if workload.matrixraft_benchmark_run_id != summary.benchmark_run_id {
             blockers.push(format!(
                 "benchmark:summary_rustraft_run_id_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_benchmark_run_id,
+                workload.matrixraft_benchmark_run_id,
                 summary.benchmark_run_id
             ));
         }
         if !workload.baseline_raft_benchmark_run_id.is_empty()
-            && !workload.rustraft_benchmark_run_id.is_empty()
-            && workload.baseline_raft_benchmark_run_id != workload.rustraft_benchmark_run_id
+            && !workload.matrixraft_benchmark_run_id.is_empty()
+            && workload.baseline_raft_benchmark_run_id != workload.matrixraft_benchmark_run_id
         {
             blockers.push(format!(
                 "benchmark:summary_sample_run_id_pair_mismatch:{}:{}:{}",
                 workload.workload.id(),
                 workload.baseline_raft_benchmark_run_id,
-                workload.rustraft_benchmark_run_id
+                workload.matrixraft_benchmark_run_id
             ));
         }
         if workload.baseline_raft_implementation != RustRaftBenchmarkImplementation::BaselineRaft {
@@ -1694,11 +1694,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.baseline_raft_implementation.id()
             ));
         }
-        if workload.rustraft_implementation != RustRaftBenchmarkImplementation::RustRaftRust {
+        if workload.matrixraft_implementation != RustRaftBenchmarkImplementation::RustRaftRust {
             blockers.push(format!(
                 "benchmark:summary_rustraft_implementation_mismatch:{}:{}:rustraft_rust",
                 workload.workload.id(),
-                workload.rustraft_implementation.id()
+                workload.matrixraft_implementation.id()
             ));
         }
         blockers.extend(summary_binary_path_blockers(
@@ -1709,7 +1709,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
         blockers.extend(summary_binary_path_blockers(
             "rustraft",
             workload.workload,
-            workload.rustraft_binary_path.as_deref(),
+            workload.matrixraft_binary_path.as_deref(),
         ));
         blockers.extend(summary_git_revision_blockers(
             "baseline_raft",
@@ -1719,7 +1719,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
         blockers.extend(summary_git_revision_blockers(
             "rustraft",
             workload.workload,
-            workload.rustraft_git_revision.as_deref(),
+            workload.matrixraft_git_revision.as_deref(),
         ));
         if workload.baseline_raft_build_profile.is_empty() {
             blockers.push(format!(
@@ -1727,29 +1727,29 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.workload.id()
             ));
         }
-        if workload.rustraft_build_profile.is_empty() {
+        if workload.matrixraft_build_profile.is_empty() {
             blockers.push(format!(
                 "benchmark:summary_rustraft_provenance_build_profile_missing:{}",
                 workload.workload.id()
             ));
         }
         if !workload.baseline_raft_build_profile.is_empty()
-            && !workload.rustraft_build_profile.is_empty()
-            && workload.baseline_raft_build_profile != workload.rustraft_build_profile
+            && !workload.matrixraft_build_profile.is_empty()
+            && workload.baseline_raft_build_profile != workload.matrixraft_build_profile
         {
             blockers.push(format!(
                 "benchmark:summary_build_profile_mismatch:{}:{}:{}",
                 workload.workload.id(),
                 workload.baseline_raft_build_profile,
-                workload.rustraft_build_profile
+                workload.matrixraft_build_profile
             ));
         }
-        if let (Some(baseline_raft_binary_path), Some(rustraft_binary_path)) = (
+        if let (Some(baseline_raft_binary_path), Some(matrixraft_binary_path)) = (
             workload.baseline_raft_binary_path.as_deref(),
-            workload.rustraft_binary_path.as_deref(),
+            workload.matrixraft_binary_path.as_deref(),
         ) {
             if !baseline_raft_binary_path.is_empty()
-                && baseline_raft_binary_path == rustraft_binary_path
+                && baseline_raft_binary_path == matrixraft_binary_path
             {
                 blockers.push(format!(
                     "benchmark:summary_binary_path_collision:{}:{}",
@@ -1767,13 +1767,13 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.baseline_raft_build_profile
             ));
         }
-        if !workload.rustraft_build_profile.is_empty()
-            && workload.rustraft_build_profile != "release"
+        if !workload.matrixraft_build_profile.is_empty()
+            && workload.matrixraft_build_profile != "release"
         {
             blockers.push(format!(
                 "benchmark:summary_rustraft_build_profile_not_release:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_build_profile
+                workload.matrixraft_build_profile
             ));
         }
         if workload.baseline_raft_harness_kind
@@ -1785,11 +1785,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.baseline_raft_harness_kind.id()
             ));
         }
-        if workload.rustraft_harness_kind != RustRaftBenchmarkHarnessKind::RustRaftRuntime {
+        if workload.matrixraft_harness_kind != RustRaftBenchmarkHarnessKind::RustRaftRuntime {
             blockers.push(format!(
                 "benchmark:summary_rustraft_runtime_harness_missing:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_harness_kind.id()
+                workload.matrixraft_harness_kind.id()
             ));
         }
         if workload.node_count != summary.options.node_count {
@@ -1808,11 +1808,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 summary.options.node_count
             ));
         }
-        if workload.rustraft_node_count != summary.options.node_count {
+        if workload.matrixraft_node_count != summary.options.node_count {
             blockers.push(format!(
                 "benchmark:summary_rustraft_node_count_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_node_count,
+                workload.matrixraft_node_count,
                 summary.options.node_count
             ));
         }
@@ -1825,11 +1825,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 summary.options.iterations_per_workload
             ));
         }
-        if workload.rustraft_iterations_per_workload != summary.options.iterations_per_workload {
+        if workload.matrixraft_iterations_per_workload != summary.options.iterations_per_workload {
             blockers.push(format!(
                 "benchmark:summary_rustraft_iterations_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_iterations_per_workload,
+                workload.matrixraft_iterations_per_workload,
                 summary.options.iterations_per_workload
             ));
         }
@@ -1841,11 +1841,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 summary.options.batch_size
             ));
         }
-        if workload.rustraft_batch_size != summary.options.batch_size {
+        if workload.matrixraft_batch_size != summary.options.batch_size {
             blockers.push(format!(
                 "benchmark:summary_rustraft_batch_size_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_batch_size,
+                workload.matrixraft_batch_size,
                 summary.options.batch_size
             ));
         }
@@ -1857,11 +1857,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 summary.options.payload_size_bytes
             ));
         }
-        if workload.rustraft_payload_size_bytes != summary.options.payload_size_bytes {
+        if workload.matrixraft_payload_size_bytes != summary.options.payload_size_bytes {
             blockers.push(format!(
                 "benchmark:summary_rustraft_payload_size_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_payload_size_bytes,
+                workload.matrixraft_payload_size_bytes,
                 summary.options.payload_size_bytes
             ));
         }
@@ -1873,11 +1873,11 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 summary.options.iterations_per_workload
             ));
         }
-        if workload.rustraft_timed_iteration_count != summary.options.iterations_per_workload {
+        if workload.matrixraft_timed_iteration_count != summary.options.iterations_per_workload {
             blockers.push(format!(
                 "benchmark:summary_rustraft_timed_iteration_count_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_timed_iteration_count,
+                workload.matrixraft_timed_iteration_count,
                 summary.options.iterations_per_workload
             ));
         }
@@ -1893,13 +1893,13 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 expected_operations_per_timed_iteration
             ));
         }
-        if workload.rustraft_operations_per_timed_iteration
+        if workload.matrixraft_operations_per_timed_iteration
             != expected_operations_per_timed_iteration
         {
             blockers.push(format!(
                 "benchmark:summary_rustraft_operations_per_timed_iteration_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_operations_per_timed_iteration,
+                workload.matrixraft_operations_per_timed_iteration,
                 expected_operations_per_timed_iteration
             ));
         }
@@ -1909,7 +1909,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 workload.workload.id()
             ));
         }
-        if workload.rustraft_total_duration_micros == 0 {
+        if workload.matrixraft_total_duration_micros == 0 {
             blockers.push(format!(
                 "benchmark:summary_rustraft_total_duration_zero:{}",
                 workload.workload.id()
@@ -1924,15 +1924,15 @@ pub fn rustraft_assert_production_baseline_raft_summary(
                 expected_operation_count
             ));
         }
-        if workload.rustraft_operation_count != expected_operation_count {
+        if workload.matrixraft_operation_count != expected_operation_count {
             blockers.push(format!(
                 "benchmark:summary_rustraft_operation_count_mismatch:{}:{}:{}",
                 workload.workload.id(),
-                workload.rustraft_operation_count,
+                workload.matrixraft_operation_count,
                 expected_operation_count
             ));
         }
-        if workload.baseline_raft_operation_count == 0 || workload.rustraft_operation_count == 0 {
+        if workload.baseline_raft_operation_count == 0 || workload.matrixraft_operation_count == 0 {
             blockers.push(format!(
                 "benchmark:summary_zero_operations:{}",
                 workload.workload.id()
@@ -1951,12 +1951,12 @@ pub fn rustraft_assert_production_baseline_raft_summary(
         blockers.extend(summary_sample_metric_blockers(
             "rustraft",
             workload.workload,
-            workload.rustraft_p50_latency_micros,
-            workload.rustraft_p99_latency_micros,
-            workload.rustraft_throughput_ops_per_sec,
-            workload.rustraft_operation_count,
-            workload.rustraft_timed_iteration_count,
-            workload.rustraft_total_duration_micros,
+            workload.matrixraft_p50_latency_micros,
+            workload.matrixraft_p99_latency_micros,
+            workload.matrixraft_throughput_ops_per_sec,
+            workload.matrixraft_operation_count,
+            workload.matrixraft_timed_iteration_count,
+            workload.matrixraft_total_duration_micros,
         ));
         push_workload_summary_ratio_finite_blocker(
             &mut blockers,
@@ -1964,7 +1964,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             "p50",
             workload.p50_ratio,
             ratio(
-                workload.rustraft_p50_latency_micros as f64,
+                workload.matrixraft_p50_latency_micros as f64,
                 workload.baseline_raft_p50_latency_micros as f64,
             ),
         );
@@ -1974,7 +1974,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             "p99",
             workload.p99_ratio,
             ratio(
-                workload.rustraft_p99_latency_micros as f64,
+                workload.matrixraft_p99_latency_micros as f64,
                 workload.baseline_raft_p99_latency_micros as f64,
             ),
         );
@@ -1984,7 +1984,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             "throughput",
             workload.throughput_ratio,
             ratio(
-                workload.rustraft_throughput_ops_per_sec,
+                workload.matrixraft_throughput_ops_per_sec,
                 workload.baseline_raft_throughput_ops_per_sec,
             ),
         );
@@ -1994,7 +1994,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             "p50",
             workload.p50_ratio,
             ratio(
-                workload.rustraft_p50_latency_micros as f64,
+                workload.matrixraft_p50_latency_micros as f64,
                 workload.baseline_raft_p50_latency_micros as f64,
             ),
         );
@@ -2004,7 +2004,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             "p99",
             workload.p99_ratio,
             ratio(
-                workload.rustraft_p99_latency_micros as f64,
+                workload.matrixraft_p99_latency_micros as f64,
                 workload.baseline_raft_p99_latency_micros as f64,
             ),
         );
@@ -2014,7 +2014,7 @@ pub fn rustraft_assert_production_baseline_raft_summary(
             "throughput",
             workload.throughput_ratio,
             ratio(
-                workload.rustraft_throughput_ops_per_sec,
+                workload.matrixraft_throughput_ops_per_sec,
                 workload.baseline_raft_throughput_ops_per_sec,
             ),
         );
@@ -2061,18 +2061,18 @@ pub fn rustraft_assert_production_baseline_raft_summary(
     }
 }
 
-pub fn rustraft_baseline_raft_benchmark_evidence_from_artifacts(
+pub fn matrixraft_baseline_raft_benchmark_evidence_from_artifacts(
     report: &RustRaftBenchmarkReport,
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> Result<RustRaftBaselineRaftBenchmarkEvidence, String> {
-    let expected = rustraft_baseline_raft_benchmark_failure_summary(report);
+    let expected = matrixraft_baseline_raft_benchmark_failure_summary(report);
     if summary != &expected {
         return Err("benchmark:summary_artifact_mismatch".to_string());
     }
-    Ok(rustraft_baseline_raft_benchmark_evidence(report))
+    Ok(matrixraft_baseline_raft_benchmark_evidence(report))
 }
 
-pub fn rustraft_baseline_raft_benchmark_evidence_from_summary(
+pub fn matrixraft_baseline_raft_benchmark_evidence_from_summary(
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> RustRaftBaselineRaftBenchmarkEvidence {
     let has_required_workloads = benchmark_summary_has_required_workload_set(summary);
@@ -2082,23 +2082,23 @@ pub fn rustraft_baseline_raft_benchmark_evidence_from_summary(
                 workload.baseline_raft_engine_source
                     == RustRaftBenchmarkEngineSource::RealBaselineRaft
             }),
-        rustraft_runtime: has_required_workloads
+        matrixraft_runtime: has_required_workloads
             && summary.workloads.iter().all(|workload| {
-                workload.rustraft_engine_source == RustRaftBenchmarkEngineSource::RustRaftRuntime
+                workload.matrixraft_engine_source == RustRaftBenchmarkEngineSource::RustRaftRuntime
             }),
         baseline_raft_reference: has_required_workloads
             && summary.workloads.iter().all(|workload| {
                 workload.baseline_raft_implementation
                     == RustRaftBenchmarkImplementation::BaselineRaft
             }),
-        rustraft_rust_candidate: has_required_workloads
+        matrixraft_rust_candidate: has_required_workloads
             && summary.workloads.iter().all(|workload| {
-                workload.rustraft_implementation == RustRaftBenchmarkImplementation::RustRaftRust
+                workload.matrixraft_implementation == RustRaftBenchmarkImplementation::RustRaftRust
             }),
         correctness_passed: has_required_workloads
             && summary.correctness_blocker_count == 0
             && summary.workloads.iter().all(|workload| {
-                workload.baseline_raft_correctness_passed && workload.rustraft_correctness_passed
+                workload.baseline_raft_correctness_passed && workload.matrixraft_correctness_passed
             }),
         performance_within_threshold: has_required_workloads
             && summary.performance_blocker_count == 0
@@ -2108,7 +2108,7 @@ pub fn rustraft_baseline_raft_benchmark_evidence_from_summary(
             .iter()
             .map(|workload| workload.workload.id().to_string())
             .collect(),
-        blockers: rustraft_baseline_raft_summary_blockers(summary),
+        blockers: matrixraft_baseline_raft_summary_blockers(summary),
         missing_baseline_raft_binaries: summary_blockers_with_prefix(
             summary,
             "benchmark:summary_missing_baseline_raft",
@@ -2128,10 +2128,10 @@ pub fn rustraft_baseline_raft_benchmark_evidence_from_summary(
     }
 }
 
-fn rustraft_baseline_raft_summary_blockers(
+fn matrixraft_baseline_raft_summary_blockers(
     summary: &RustRaftBenchmarkFailureSummary,
 ) -> Vec<String> {
-    match rustraft_assert_production_baseline_raft_summary(summary) {
+    match matrixraft_assert_production_baseline_raft_summary(summary) {
         Ok(()) => Vec::new(),
         Err(error) => error
             .split("; ")
@@ -2145,16 +2145,16 @@ fn summary_blockers_with_prefix(
     summary: &RustRaftBenchmarkFailureSummary,
     prefix: &str,
 ) -> Vec<String> {
-    rustraft_baseline_raft_summary_blockers(summary)
+    matrixraft_baseline_raft_summary_blockers(summary)
         .into_iter()
         .filter(|blocker| blocker.starts_with(prefix))
         .collect()
 }
 
-pub fn rustraft_baseline_raft_benchmark_failure_summary(
+pub fn matrixraft_baseline_raft_benchmark_failure_summary(
     report: &RustRaftBenchmarkReport,
 ) -> RustRaftBenchmarkFailureSummary {
-    let evidence = rustraft_baseline_raft_benchmark_evidence(report);
+    let evidence = matrixraft_baseline_raft_benchmark_evidence(report);
     let classified = evidence
         .missing_baseline_raft_binaries
         .iter()
@@ -2188,15 +2188,15 @@ pub fn rustraft_baseline_raft_benchmark_failure_summary(
         0.0
     };
     RustRaftBenchmarkFailureSummary {
-        schema: RUSTRAFT_BENCHMARK_SUMMARY_SCHEMA.to_string(),
+        schema: MATRIXRAFT_BENCHMARK_SUMMARY_SCHEMA.to_string(),
         generated_at_unix_ms: report.generated_at_unix_ms,
         benchmark_run_id: report.benchmark_run_id.clone(),
         environment_fingerprint: report.environment_fingerprint.clone(),
         passed: report.passed,
         production_evidence_ready: evidence.real_baseline_raft
-            && evidence.rustraft_runtime
+            && evidence.matrixraft_runtime
             && evidence.baseline_raft_reference
-            && evidence.rustraft_rust_candidate
+            && evidence.matrixraft_rust_candidate
             && evidence.correctness_passed
             && evidence.performance_within_threshold
             && evidence.blockers.is_empty(),
@@ -2211,7 +2211,7 @@ pub fn rustraft_baseline_raft_benchmark_failure_summary(
         workloads: report
             .comparisons
             .iter()
-            .map(rustraft_baseline_raft_workload_summary)
+            .map(matrixraft_baseline_raft_workload_summary)
             .collect(),
         missing_baseline_raft_binary_count: evidence.missing_baseline_raft_binaries.len(),
         unsupported_workload_count: evidence.unsupported_workloads.len(),
@@ -2225,53 +2225,55 @@ pub fn rustraft_baseline_raft_benchmark_failure_summary(
     }
 }
 
-fn rustraft_baseline_raft_workload_summary(
+fn matrixraft_baseline_raft_workload_summary(
     comparison: &RustRaftBenchmarkComparison,
 ) -> RustRaftBenchmarkWorkloadSummary {
     RustRaftBenchmarkWorkloadSummary {
         workload: comparison.workload,
         passed: comparison.passed,
         baseline_raft_correctness_passed: comparison.baseline_raft.correctness_passed,
-        rustraft_correctness_passed: comparison.rustraft.correctness_passed,
+        matrixraft_correctness_passed: comparison.rustraft.correctness_passed,
         baseline_raft_engine_source: comparison.baseline_raft.engine_source,
-        rustraft_engine_source: comparison.rustraft.engine_source,
+        matrixraft_engine_source: comparison.rustraft.engine_source,
         baseline_raft_benchmark_run_id: comparison.baseline_raft.benchmark_run_id.clone(),
-        rustraft_benchmark_run_id: comparison.rustraft.benchmark_run_id.clone(),
+        matrixraft_benchmark_run_id: comparison.rustraft.benchmark_run_id.clone(),
         baseline_raft_implementation: comparison.baseline_raft.implementation,
-        rustraft_implementation: comparison.rustraft.implementation,
+        matrixraft_implementation: comparison.rustraft.implementation,
         baseline_raft_binary_path: comparison.baseline_raft.binary_path.clone(),
-        rustraft_binary_path: comparison.rustraft.binary_path.clone(),
+        matrixraft_binary_path: comparison.rustraft.binary_path.clone(),
         baseline_raft_git_revision: comparison.baseline_raft.git_revision.clone(),
-        rustraft_git_revision: comparison.rustraft.git_revision.clone(),
+        matrixraft_git_revision: comparison.rustraft.git_revision.clone(),
         baseline_raft_build_profile: comparison.baseline_raft.build_profile.clone(),
-        rustraft_build_profile: comparison.rustraft.build_profile.clone(),
+        matrixraft_build_profile: comparison.rustraft.build_profile.clone(),
         baseline_raft_harness_kind: comparison.baseline_raft.harness_kind,
-        rustraft_harness_kind: comparison.rustraft.harness_kind,
+        matrixraft_harness_kind: comparison.rustraft.harness_kind,
         node_count: comparison.baseline_raft.node_count,
         baseline_raft_node_count: comparison.baseline_raft.node_count,
-        rustraft_node_count: comparison.rustraft.node_count,
+        matrixraft_node_count: comparison.rustraft.node_count,
         baseline_raft_iterations_per_workload: comparison.baseline_raft.iterations_per_workload,
-        rustraft_iterations_per_workload: comparison.rustraft.iterations_per_workload,
+        matrixraft_iterations_per_workload: comparison.rustraft.iterations_per_workload,
         baseline_raft_batch_size: comparison.baseline_raft.batch_size,
-        rustraft_batch_size: comparison.rustraft.batch_size,
+        matrixraft_batch_size: comparison.rustraft.batch_size,
         baseline_raft_payload_size_bytes: comparison.baseline_raft.payload_size_bytes,
-        rustraft_payload_size_bytes: comparison.rustraft.payload_size_bytes,
+        matrixraft_payload_size_bytes: comparison.rustraft.payload_size_bytes,
         baseline_raft_timed_iteration_count: comparison.baseline_raft.timed_iteration_count,
-        rustraft_timed_iteration_count: comparison.rustraft.timed_iteration_count,
+        matrixraft_timed_iteration_count: comparison.rustraft.timed_iteration_count,
         baseline_raft_operations_per_timed_iteration: comparison
             .baseline_raft
             .operations_per_timed_iteration,
-        rustraft_operations_per_timed_iteration: comparison.rustraft.operations_per_timed_iteration,
+        matrixraft_operations_per_timed_iteration: comparison
+            .rustraft
+            .operations_per_timed_iteration,
         baseline_raft_total_duration_micros: comparison.baseline_raft.total_duration_micros,
-        rustraft_total_duration_micros: comparison.rustraft.total_duration_micros,
+        matrixraft_total_duration_micros: comparison.rustraft.total_duration_micros,
         baseline_raft_operation_count: comparison.baseline_raft.operation_count,
-        rustraft_operation_count: comparison.rustraft.operation_count,
+        matrixraft_operation_count: comparison.rustraft.operation_count,
         baseline_raft_p50_latency_micros: comparison.baseline_raft.p50_latency_micros,
-        rustraft_p50_latency_micros: comparison.rustraft.p50_latency_micros,
+        matrixraft_p50_latency_micros: comparison.rustraft.p50_latency_micros,
         baseline_raft_p99_latency_micros: comparison.baseline_raft.p99_latency_micros,
-        rustraft_p99_latency_micros: comparison.rustraft.p99_latency_micros,
+        matrixraft_p99_latency_micros: comparison.rustraft.p99_latency_micros,
         baseline_raft_throughput_ops_per_sec: comparison.baseline_raft.throughput_ops_per_sec,
-        rustraft_throughput_ops_per_sec: comparison.rustraft.throughput_ops_per_sec,
+        matrixraft_throughput_ops_per_sec: comparison.rustraft.throughput_ops_per_sec,
         p50_ratio: comparison.p50_ratio,
         p99_ratio: comparison.p99_ratio,
         throughput_ratio: comparison.throughput_ratio,
@@ -2283,7 +2285,7 @@ fn rustraft_baseline_raft_workload_summary(
     }
 }
 
-pub fn rustraft_baseline_raft_benchmark_evidence(
+pub fn matrixraft_baseline_raft_benchmark_evidence(
     report: &RustRaftBenchmarkReport,
 ) -> RustRaftBaselineRaftBenchmarkEvidence {
     let mut blockers = Vec::new();
@@ -2298,7 +2300,7 @@ pub fn rustraft_baseline_raft_benchmark_evidence(
             comparison.baseline_raft.engine_source
                 == RustRaftBenchmarkEngineSource::RealBaselineRaft
         });
-    let rustraft_runtime = has_required_workloads
+    let matrixraft_runtime = has_required_workloads
         && report.comparisons.iter().all(|comparison| {
             comparison.rustraft.engine_source == RustRaftBenchmarkEngineSource::RustRaftRuntime
         });
@@ -2306,7 +2308,7 @@ pub fn rustraft_baseline_raft_benchmark_evidence(
         && report.comparisons.iter().all(|comparison| {
             comparison.baseline_raft.implementation == RustRaftBenchmarkImplementation::BaselineRaft
         });
-    let rustraft_rust_candidate = has_required_workloads
+    let matrixraft_rust_candidate = has_required_workloads
         && report.comparisons.iter().all(|comparison| {
             comparison.rustraft.implementation == RustRaftBenchmarkImplementation::RustRaftRust
         });
@@ -2481,14 +2483,14 @@ pub fn rustraft_baseline_raft_benchmark_evidence(
         );
         blockers.push(blocker);
     }
-    if !rustraft_runtime {
+    if !matrixraft_runtime {
         blockers.push("benchmark:rustraft_runtime_missing".to_string());
     }
     RustRaftBaselineRaftBenchmarkEvidence {
         real_baseline_raft,
-        rustraft_runtime,
+        matrixraft_runtime,
         baseline_raft_reference,
-        rustraft_rust_candidate,
+        matrixraft_rust_candidate,
         correctness_passed,
         performance_within_threshold,
         workloads,
@@ -2501,7 +2503,7 @@ pub fn rustraft_baseline_raft_benchmark_evidence(
 }
 
 fn benchmark_report_has_required_workload_set(report: &RustRaftBenchmarkReport) -> bool {
-    let required_workloads = rustraft_baseline_raft_benchmark_required_workloads()
+    let required_workloads = matrixraft_baseline_raft_benchmark_required_workloads()
         .into_iter()
         .collect::<std::collections::BTreeSet<_>>();
     let observed_workloads = report
@@ -2513,7 +2515,7 @@ fn benchmark_report_has_required_workload_set(report: &RustRaftBenchmarkReport) 
 }
 
 fn benchmark_summary_has_required_workload_set(summary: &RustRaftBenchmarkFailureSummary) -> bool {
-    let required_workloads = rustraft_baseline_raft_benchmark_required_workloads()
+    let required_workloads = matrixraft_baseline_raft_benchmark_required_workloads()
         .into_iter()
         .collect::<std::collections::BTreeSet<_>>();
     let observed_workloads = summary
@@ -2688,12 +2690,12 @@ fn benchmark_sample_pair_provenance_blockers(
             baseline_raft.build_profile, rustraft.build_profile
         ));
     }
-    if let (Some(baseline_raft_binary_path), Some(rustraft_binary_path)) = (
+    if let (Some(baseline_raft_binary_path), Some(matrixraft_binary_path)) = (
         baseline_raft.binary_path.as_deref(),
         rustraft.binary_path.as_deref(),
     ) {
         if !baseline_raft_binary_path.is_empty()
-            && baseline_raft_binary_path == rustraft_binary_path
+            && baseline_raft_binary_path == matrixraft_binary_path
         {
             blockers.push(format!(
                 "benchmark:binary_path_collision:{baseline_raft_binary_path}"
@@ -3127,7 +3129,7 @@ fn benchmark_now_unix_ms() -> u64 {
 }
 
 fn benchmark_run_id() -> String {
-    let sequence = RUSTRAFT_BENCHMARK_RUN_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let sequence = MATRIXRAFT_BENCHMARK_RUN_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     format!(
         "rustraft-baseline-raft-parity-{}-pid-{}-seq-{}",
         benchmark_now_unix_ms(),
@@ -3151,10 +3153,10 @@ fn benchmark_artifact_timestamp_blockers(label: &str, generated_at_unix_ms: u64)
         return vec![format!("benchmark:{label}_generated_at_missing")];
     }
     let now = benchmark_now_unix_ms();
-    if generated_at_unix_ms > now.saturating_add(RUSTRAFT_BENCHMARK_MAX_FUTURE_SKEW_MS) {
+    if generated_at_unix_ms > now.saturating_add(MATRIXRAFT_BENCHMARK_MAX_FUTURE_SKEW_MS) {
         return vec![format!("benchmark:{label}_generated_at_in_future")];
     }
-    if now.saturating_sub(generated_at_unix_ms) > RUSTRAFT_BENCHMARK_MAX_ARTIFACT_AGE_MS {
+    if now.saturating_sub(generated_at_unix_ms) > MATRIXRAFT_BENCHMARK_MAX_ARTIFACT_AGE_MS {
         return vec![format!("benchmark:{label}_generated_at_stale")];
     }
     Vec::new()
@@ -3182,10 +3184,10 @@ fn benchmark_environment_release_blockers(
 
 fn benchmark_options_blockers(report: &RustRaftBenchmarkReport) -> Vec<String> {
     let mut blockers = Vec::new();
-    if report.schema != RUSTRAFT_BENCHMARK_REPORT_SCHEMA {
+    if report.schema != MATRIXRAFT_BENCHMARK_REPORT_SCHEMA {
         blockers.push(format!(
             "benchmark:report_schema_mismatch:{}:{}",
-            report.schema, RUSTRAFT_BENCHMARK_REPORT_SCHEMA
+            report.schema, MATRIXRAFT_BENCHMARK_REPORT_SCHEMA
         ));
     }
     blockers.extend(benchmark_artifact_timestamp_blockers(
@@ -3230,7 +3232,7 @@ fn benchmark_options_blockers(report: &RustRaftBenchmarkReport) -> Vec<String> {
         ));
     }
     blockers.extend(benchmark_production_option_blockers(&report.options));
-    let required_workload_manifest = rustraft_baseline_raft_benchmark_required_workloads();
+    let required_workload_manifest = matrixraft_baseline_raft_benchmark_required_workloads();
     if report.required_workloads != required_workload_manifest {
         blockers.push(format!(
             "benchmark:report_required_workloads_mismatch:declared_{}_required_{}",
@@ -3318,42 +3320,43 @@ fn benchmark_options_blockers(report: &RustRaftBenchmarkReport) -> Vec<String> {
 
 fn benchmark_production_option_blockers(options: &RustRaftBenchmarkOptions) -> Vec<String> {
     let mut blockers = Vec::new();
-    if options.node_count < RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT {
+    if options.node_count < MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT {
         blockers.push(format!(
             "benchmark:node_count_below_production_scale:{}:{}",
-            options.node_count, RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT
+            options.node_count, MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT
         ));
     }
     if options.iterations_per_workload == 0 {
         blockers.push("benchmark:invalid_iterations_per_workload:0".to_string());
     } else if options.iterations_per_workload
-        < RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD
+        < MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD
     {
         blockers.push(format!(
             "benchmark:iterations_per_workload_below_production_min:{}:{}",
             options.iterations_per_workload,
-            RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD
+            MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD
         ));
     }
     if options.batch_size == 0 {
         blockers.push("benchmark:invalid_batch_size:0".to_string());
-    } else if options.batch_size < RUSTRAFT_BENCHMARK_MIN_PRODUCTION_BATCH_SIZE {
+    } else if options.batch_size < MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_BATCH_SIZE {
         blockers.push(format!(
             "benchmark:batch_size_below_production_min:{}:{}",
-            options.batch_size, RUSTRAFT_BENCHMARK_MIN_PRODUCTION_BATCH_SIZE
+            options.batch_size, MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_BATCH_SIZE
         ));
     }
     if options.payload_size_bytes == 0 {
         blockers.push("benchmark:invalid_payload_size_bytes:0".to_string());
-    } else if options.payload_size_bytes < RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES {
+    } else if options.payload_size_bytes < MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES {
         blockers.push(format!(
             "benchmark:payload_size_below_production_min:{}:{}",
-            options.payload_size_bytes, RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES
+            options.payload_size_bytes, MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES
         ));
     }
     if !options.pass_tolerance_percent.is_finite()
         || options.pass_tolerance_percent < 0.0
-        || options.pass_tolerance_percent > RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT
+        || options.pass_tolerance_percent
+            > MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT
     {
         blockers.push(format!(
             "benchmark:invalid_pass_tolerance_percent:{:.3}",
@@ -3363,7 +3366,7 @@ fn benchmark_production_option_blockers(options: &RustRaftBenchmarkOptions) -> V
     blockers
 }
 
-pub fn rustraft_validate_production_baseline_raft_benchmark_options(
+pub fn matrixraft_validate_production_baseline_raft_benchmark_options(
     options: &RustRaftBenchmarkOptions,
 ) -> Result<(), String> {
     let mut blockers = benchmark_production_option_blockers(options);
@@ -3586,7 +3589,7 @@ fn compare_samples(
     tolerance_percent: f64,
 ) -> RustRaftBenchmarkComparison {
     let tolerance_valid = tolerance_percent.is_finite()
-        && (0.0..=RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT)
+        && (0.0..=MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT)
             .contains(&tolerance_percent);
     let max_latency_ratio = 1.0 + tolerance_percent / 100.0;
     let min_throughput_ratio = 1.0 - tolerance_percent / 100.0;
@@ -4064,10 +4067,10 @@ fn same_machine_correctness_passes(
     workload: RustRaftBenchmarkWorkload,
     options: &RustRaftBenchmarkOptions,
 ) -> bool {
-    let production_scale = options.node_count >= RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT;
+    let production_scale = options.node_count >= MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT;
     let iterations_present = options.iterations_per_workload > 0;
     let payload_present =
-        options.payload_size_bytes >= RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES;
+        options.payload_size_bytes >= MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES;
     let batch_valid = !matches!(
         workload,
         RustRaftBenchmarkWorkload::BatchedWrites | RustRaftBenchmarkWorkload::ReplicationBatching

--- a/src/channel_selector.rs
+++ b/src/channel_selector.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use crate::{RustRaftMailPriority, RustRaftNodeId};
 
-pub const RUSTRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS: u64 = i64::MAX as u64;
+pub const MATRIXRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS: u64 = i64::MAX as u64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RustRaftChannelSelectorPolicy {
@@ -21,7 +21,7 @@ impl Default for RustRaftChannelSelectorPolicy {
     fn default() -> Self {
         Self {
             limit: 1,
-            timeout_ms: RUSTRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS,
+            timeout_ms: MATRIXRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS,
         }
     }
 }
@@ -231,7 +231,8 @@ impl<Mail> RustRaftChannelSelector<Mail> {
     ) -> RustRaftChannelSelection<Mail> {
         let mut inner = self.inner.lock().expect("channel selector mutex poisoned");
         self.rearrange(&mut inner, input);
-        if !inner.has_ready_work() && policy.timeout_ms == RUSTRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS
+        if !inner.has_ready_work()
+            && policy.timeout_ms == MATRIXRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS
         {
             while !inner.has_ready_work() {
                 inner = self

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -170,7 +170,7 @@ impl RustRaftFileChecksumContext {
     }
 
     pub fn start(&self) -> io::Result<RustRaftFileChecksumResult> {
-        let files = rustraft_checksum_file_list(&self.path)?;
+        let files = matrixraft_checksum_file_list(&self.path)?;
         let mut context = RustRaftChecksumContext::new(self.checksum_type);
         let mut buffer = vec![0; self.block_size];
         for file in &files {
@@ -193,15 +193,15 @@ impl RustRaftFileChecksumContext {
     }
 }
 
-pub fn rustraft_crc32c(data: &[u8]) -> u32 {
+pub fn matrixraft_crc32c(data: &[u8]) -> u32 {
     crc32c_extend(0, data)
 }
 
-pub fn rustraft_murmur32(data: &[u8]) -> u32 {
+pub fn matrixraft_murmur32(data: &[u8]) -> u32 {
     murmur3_x86_32(data, 0)
 }
 
-pub fn rustraft_checksum_file_list(path: &Path) -> io::Result<Vec<PathBuf>> {
+pub fn matrixraft_checksum_file_list(path: &Path) -> io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     if path.is_dir() {
         collect_files(path, &mut files)?;

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -4,10 +4,10 @@
 //! Cluster consensus API used by TemporalStore and other RustRaft consumers.
 
 pub use crate::{
-    rustraft_append_safety_decision, rustraft_applied_index_fence_report,
-    rustraft_bounded_stale_read_report, rustraft_learner_promotion_decision,
-    rustraft_lease_read_eligibility_report, rustraft_read_safety_decision,
-    rustraft_read_safety_runtime_decision, RaftCluster, ReadIndexRequest, ReadIndexResponse,
+    matrixraft_append_safety_decision, matrixraft_applied_index_fence_report,
+    matrixraft_bounded_stale_read_report, matrixraft_learner_promotion_decision,
+    matrixraft_lease_read_eligibility_report, matrixraft_read_safety_decision,
+    matrixraft_read_safety_runtime_decision, RaftCluster, ReadIndexRequest, ReadIndexResponse,
     RustRaftAppendSafetyDecision, RustRaftAppliedIndexFenceReport, RustRaftBoundedStaleReadReport,
     RustRaftConsensus, RustRaftError, RustRaftLearnerPromotionDecision,
     RustRaftLeaseReadEligibilityReport, RustRaftLogEntry, RustRaftLogId, RustRaftProposeOptions,

--- a/src/durability.rs
+++ b/src/durability.rs
@@ -4,39 +4,39 @@
 //! Durable apply, WAL recovery, and snapshot/storage fence parity reports.
 
 use crate::{
-    rustraft_validate_apply_snapshot_fence, rustraft_validate_hard_state_persistence,
-    rustraft_validate_snapshot_floor_log_matching, rustraft_validate_snapshot_install,
-    rustraft_validate_snapshot_tail_catchup, rustraft_validate_storage_apply_fence,
-    rustraft_wal_checksum_valid, RaftSnapshot, RaftWalRecoveryReport,
+    matrixraft_validate_apply_snapshot_fence, matrixraft_validate_hard_state_persistence,
+    matrixraft_validate_snapshot_floor_log_matching, matrixraft_validate_snapshot_install,
+    matrixraft_validate_snapshot_tail_catchup, matrixraft_validate_storage_apply_fence,
+    matrixraft_wal_checksum_valid, RaftSnapshot, RaftWalRecoveryReport,
     RustRaftDurabilityParityReport, RustRaftLogEntry, RustRaftStorageApplyFence, RustRaftWalRecord,
 };
 
-pub fn rustraft_durability_parity_report(
+pub fn matrixraft_durability_parity_report(
     wal_record: &RustRaftWalRecord,
     recovery_report: &RaftWalRecoveryReport,
     snapshot: Option<&RaftSnapshot>,
     tail_entries: &[RustRaftLogEntry],
     storage_fence: &RustRaftStorageApplyFence,
 ) -> RustRaftDurabilityParityReport {
-    let hard_state_persisted = rustraft_validate_hard_state_persistence(wal_record).is_ok();
-    let wal_record_valid = rustraft_wal_checksum_valid(wal_record);
+    let hard_state_persisted = matrixraft_validate_hard_state_persistence(wal_record).is_ok();
+    let wal_record_valid = matrixraft_wal_checksum_valid(wal_record);
     let segmented_wal_recovered = recovery_report.recovered.is_some();
     let corrupt_tail_truncated =
         recovery_report.truncated_corrupt_tail || recovery_report.removed_records > 0;
-    let apply_snapshot_fence_valid = rustraft_validate_apply_snapshot_fence(wal_record).is_ok();
-    let storage_apply_fence_valid = rustraft_validate_storage_apply_fence(storage_fence).is_ok();
+    let apply_snapshot_fence_valid = matrixraft_validate_apply_snapshot_fence(wal_record).is_ok();
+    let storage_apply_fence_valid = matrixraft_validate_storage_apply_fence(storage_fence).is_ok();
     let (snapshot_install_valid, snapshot_floor_preserved, snapshot_tail_catchup_valid) =
         if let Some(snapshot) = snapshot {
             (
-                rustraft_validate_snapshot_install(snapshot, &wal_record.apply_snapshot_fence)
+                matrixraft_validate_snapshot_install(snapshot, &wal_record.apply_snapshot_fence)
                     .is_ok(),
-                rustraft_validate_snapshot_floor_log_matching(
+                matrixraft_validate_snapshot_floor_log_matching(
                     &snapshot.meta,
                     wal_record.apply_snapshot_fence.first_retained_log_index,
                     Some(&snapshot.meta.last_log_id),
                 )
                 .is_ok(),
-                rustraft_validate_snapshot_tail_catchup(&snapshot.meta, tail_entries).is_ok(),
+                matrixraft_validate_snapshot_tail_catchup(&snapshot.meta, tail_entries).is_ok(),
             )
         } else {
             (true, true, tail_entries.is_empty())

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -2626,7 +2626,7 @@ impl RaftCluster {
             },
             checksum: String::new(),
         };
-        record.checksum = rustraft_wal_checksum(&record);
+        record.checksum = matrixraft_wal_checksum(&record);
         Ok(record)
     }
 
@@ -3186,12 +3186,12 @@ impl RaftCluster {
             .get(&request.requester_id)
             .ok_or(RaftError::NodeNotFound(request.requester_id))?;
         let quorum = self.read_quorum_report();
-        let applied_index_fence = rustraft_applied_index_fence_report(
+        let applied_index_fence = matrixraft_applied_index_fence_report(
             request.min_commit_index,
             node.commit_index,
             node.applied_index,
         );
-        let lease_read_eligibility = rustraft_lease_read_eligibility_report(
+        let lease_read_eligibility = matrixraft_lease_read_eligibility_report(
             request.requester_id,
             self.leader_id,
             self.config.enable_lease_read && request.allow_lease_read,
@@ -3199,7 +3199,7 @@ impl RaftCluster {
             applied_index_fence.passed,
         );
         let bounded_stale = self.leader_id.map(|leader_id| {
-            rustraft_bounded_stale_read_report(
+            matrixraft_bounded_stale_read_report(
                 request.requester_id,
                 leader_id,
                 node.commit_index,
@@ -3334,7 +3334,7 @@ impl RaftCluster {
             .as_ref()
             .map(|transfer| transfer.transferee_id);
         let target_role = self.nodes.get(&target).map(|node| node.replica_role);
-        let admission = crate::rustraft_leader_transfer_admission(
+        let admission = crate::matrixraft_leader_transfer_admission(
             leader_id,
             target,
             current_transferee_id,
@@ -4192,7 +4192,7 @@ impl RaftCluster {
                 "snapshot group id mismatch".to_string(),
             ));
         }
-        rustraft_validate_snapshot_install(&snapshot, &fence)?;
+        matrixraft_validate_snapshot_install(&snapshot, &fence)?;
         let node = self
             .nodes
             .get_mut(&target)
@@ -4337,7 +4337,7 @@ impl RaftCluster {
         log_index: RustRaftLogIndex,
         fence: RustRaftStorageApplyFence,
     ) -> Result<RaftWalCompactionReport, RaftError> {
-        if let Err(error) = rustraft_validate_storage_apply_fence(&fence) {
+        if let Err(error) = matrixraft_validate_storage_apply_fence(&fence) {
             return Ok(RaftWalCompactionReport {
                 requested_log_index: log_index,
                 released_segments: 0,
@@ -4841,7 +4841,7 @@ impl RaftCluster {
             .into_iter()
             .map(|node_id| self.status(node_id))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(rustraft_cluster_status_report(
+        Ok(matrixraft_cluster_status_report(
             self.group_id,
             self.leader_id,
             self.leader_transfer.clone(),

--- a/src/facade/node_runtime.rs
+++ b/src/facade/node_runtime.rs
@@ -1386,7 +1386,7 @@ fn raft_node_runtime_loop(
                         heartbeat_ticks > 0,
                         pre_vote_executions > 0,
                     ),
-                    fatal_blocker_report: rustraft_fatal_blocker_report(
+                    fatal_blocker_report: matrixraft_fatal_blocker_report(
                         "raft_node_runtime",
                         blockers.clone(),
                         fatal_blockers.clone(),

--- a/src/facade/status_admin_runtime.rs
+++ b/src/facade/status_admin_runtime.rs
@@ -4,10 +4,10 @@
 // production readiness, status/admin reports, and harness-facing evidence.
 // Split from src/lib.rs to keep the crate facade small and focused.
 
-pub fn rustraft_production_readiness_report(
+pub fn matrixraft_production_readiness_report(
     input: &RustRaftProductionReadinessInput,
 ) -> RustRaftProductionReadinessReport {
-    let parity = rustraft_parity_report(&input.readiness);
+    let parity = matrixraft_parity_report(&input.readiness);
     let mut satisfied = parity
         .satisfied
         .iter()
@@ -317,7 +317,7 @@ pub fn rustraft_production_readiness_report(
     let ready = missing.is_empty() && production_blockers.is_empty();
     RustRaftProductionReadinessReport {
         parity,
-        public_api: rustraft_public_api_contract(),
+        public_api: matrixraft_public_api_contract(),
         ready,
         production_status: if ready {
             RustRaftProductionStatus::ProductionReady
@@ -358,7 +358,7 @@ fn require_baseline_raft_benchmark(
             "run the benchmark against a real BaselineRaft binary",
         ),
         (
-            benchmark.rustraft_runtime,
+            benchmark.matrixraft_runtime,
             "benchmark:rustraft_runtime",
             "run the benchmark against the RustRaft runtime runner",
         ),
@@ -368,7 +368,7 @@ fn require_baseline_raft_benchmark(
             "run the benchmark against the real reference Raft implementation",
         ),
         (
-            benchmark.rustraft_rust_candidate,
+            benchmark.matrixraft_rust_candidate,
             "benchmark:rustraft_rust_candidate",
             "run the benchmark against the Rust RustRaft candidate implementation",
         ),
@@ -385,7 +385,7 @@ fn require_baseline_raft_benchmark(
     ] {
         require_bool(present, id, satisfied, missing, blockers, actions, action);
     }
-    for workload in benchmark::rustraft_baseline_raft_benchmark_workloads() {
+    for workload in benchmark::matrixraft_baseline_raft_benchmark_workloads() {
         let workload_id = workload.id();
         require_bool(
             benchmark
@@ -400,7 +400,7 @@ fn require_baseline_raft_benchmark(
             "run every required BaselineRaft-vs-RustRaft parity workload",
         );
     }
-    let required_workloads = benchmark::rustraft_baseline_raft_benchmark_workloads();
+    let required_workloads = benchmark::matrixraft_baseline_raft_benchmark_workloads();
     let required_workload_ids: std::collections::BTreeSet<&'static str> = required_workloads
         .iter()
         .map(|workload| workload.id())
@@ -686,7 +686,7 @@ fn require_admin_status_surface(
     }
 }
 
-pub fn rustraft_baseline_raft_runtime_capability_report(
+pub fn matrixraft_baseline_raft_runtime_capability_report(
     input: &RustRaftProductionReadinessInput,
 ) -> RustRaftBaselineRaftRuntimeCapabilityReport {
     let data_semantics = input
@@ -697,7 +697,7 @@ pub fn rustraft_baseline_raft_runtime_capability_report(
         .metaserver_rollout
         .as_ref()
         .map(|rollout| &rollout.operational_semantics);
-    let membership_report = rustraft_membership_readiness_report(&input.membership_transitions);
+    let membership_report = matrixraft_membership_readiness_report(&input.membership_transitions);
 
     let mut capability_evidence = Vec::new();
     capability_evidence.push(runtime_capability(
@@ -1064,7 +1064,7 @@ pub fn rustraft_baseline_raft_runtime_capability_report(
         "RustRaftReadinessSnapshot",
         &[
             (
-                input.readiness.rustraft_operator_observability_present,
+                input.readiness.matrixraft_operator_observability_present,
                 "readiness.rustraft_operator_observability_present",
             ),
             (
@@ -1111,7 +1111,7 @@ pub fn rustraft_baseline_raft_runtime_capability_report(
     }
 }
 
-pub fn rustraft_baseline_raft_runtime_capability_prometheus(
+pub fn matrixraft_baseline_raft_runtime_capability_prometheus(
     report: &RustRaftBaselineRaftRuntimeCapabilityReport,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
@@ -1205,7 +1205,7 @@ pub fn rustraft_baseline_raft_runtime_capability_prometheus(
     }
 }
 
-pub fn rustraft_cross_plane_process_evidence_prometheus(
+pub fn matrixraft_cross_plane_process_evidence_prometheus(
     summary: &RustRaftCrossPlaneProcessEvidenceSummary,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
@@ -1348,16 +1348,16 @@ pub fn rustraft_cross_plane_process_evidence_prometheus(
     }
 }
 
-pub fn rustraft_cross_plane_process_evidence_artifact(
+pub fn matrixraft_cross_plane_process_evidence_artifact(
     data_node_report: &RustRaftDataNodeProcessRolloutReport,
     metaserver_report: &RustRaftMetaProcessRolloutReport,
     labels: &[(&str, &str)],
 ) -> RustRaftCrossPlaneProcessEvidenceArtifact {
     let readiness =
-        rustraft_cross_plane_process_readiness_blocker_report(data_node_report, metaserver_report);
+        matrixraft_cross_plane_process_readiness_blocker_report(data_node_report, metaserver_report);
     let summary =
-        rustraft_cross_plane_process_evidence_summary(data_node_report, metaserver_report);
-    let prometheus = rustraft_cross_plane_process_evidence_prometheus(&summary, labels);
+        matrixraft_cross_plane_process_evidence_summary(data_node_report, metaserver_report);
+    let prometheus = matrixraft_cross_plane_process_evidence_prometheus(&summary, labels);
     RustRaftCrossPlaneProcessEvidenceArtifact {
         schema: "rustraft.cross_plane_process_evidence.v1".to_string(),
         readiness,
@@ -1366,7 +1366,7 @@ pub fn rustraft_cross_plane_process_evidence_artifact(
     }
 }
 
-pub fn rustraft_validate_cross_plane_process_evidence_artifact(
+pub fn matrixraft_validate_cross_plane_process_evidence_artifact(
     artifact: &RustRaftCrossPlaneProcessEvidenceArtifact,
 ) -> RustRaftCrossPlaneProcessEvidenceArtifactValidationReport {
     let schema_valid = artifact.schema == "rustraft.cross_plane_process_evidence.v1";
@@ -1473,7 +1473,7 @@ pub fn rustraft_validate_cross_plane_process_evidence_artifact(
     }
 }
 
-pub fn rustraft_data_node_process_rollout_readiness_report(
+pub fn matrixraft_data_node_process_rollout_readiness_report(
     rollout: &RustRaftDataNodeProcessRolloutReport,
 ) -> RustRaftProcessRolloutReadinessReport {
     let mut satisfied = Vec::new();
@@ -1503,7 +1503,7 @@ pub fn rustraft_data_node_process_rollout_readiness_report(
     }
 }
 
-pub fn rustraft_meta_process_rollout_readiness_report(
+pub fn matrixraft_meta_process_rollout_readiness_report(
     rollout: &RustRaftMetaProcessRolloutReport,
 ) -> RustRaftProcessRolloutReadinessReport {
     let mut satisfied = Vec::new();
@@ -1533,7 +1533,7 @@ pub fn rustraft_meta_process_rollout_readiness_report(
     }
 }
 
-pub fn rustraft_cross_plane_process_readiness_report(
+pub fn matrixraft_cross_plane_process_readiness_report(
     data_node_report: &RustRaftDataNodeProcessRolloutReport,
     metaserver_report: &RustRaftMetaProcessRolloutReport,
 ) -> RustRaftCrossPlaneProcessReadinessReport {
@@ -1629,11 +1629,11 @@ pub fn rustraft_cross_plane_process_readiness_report(
     }
 }
 
-pub fn rustraft_cross_plane_process_readiness_blocker_report(
+pub fn matrixraft_cross_plane_process_readiness_blocker_report(
     data_node_report: &RustRaftDataNodeProcessRolloutReport,
     metaserver_report: &RustRaftMetaProcessRolloutReport,
 ) -> RustRaftCrossPlaneProcessReadinessBlockerReport {
-    let report = rustraft_cross_plane_process_readiness_report(data_node_report, metaserver_report);
+    let report = matrixraft_cross_plane_process_readiness_report(data_node_report, metaserver_report);
     RustRaftCrossPlaneProcessReadinessBlockerReport {
         ready: report.ready,
         multi_process_data_node_and_metaserver_raft: report
@@ -1645,12 +1645,12 @@ pub fn rustraft_cross_plane_process_readiness_blocker_report(
         remaining_blockers: report
             .remaining_blockers
             .iter()
-            .map(|field| rustraft_process_readiness_blocker(field))
+            .map(|field| matrixraft_process_readiness_blocker(field))
             .collect(),
     }
 }
 
-pub fn rustraft_cross_plane_process_evidence_summary(
+pub fn matrixraft_cross_plane_process_evidence_summary(
     data_node_report: &RustRaftDataNodeProcessRolloutReport,
     metaserver_report: &RustRaftMetaProcessRolloutReport,
 ) -> RustRaftCrossPlaneProcessEvidenceSummary {
@@ -1695,18 +1695,18 @@ pub fn rustraft_cross_plane_process_evidence_summary(
     }
 }
 
-pub fn rustraft_process_readiness_blocker(evidence_field: &str) -> RustRaftProcessReadinessBlocker {
+pub fn matrixraft_process_readiness_blocker(evidence_field: &str) -> RustRaftProcessReadinessBlocker {
     RustRaftProcessReadinessBlocker {
         blocker: format!(
             "{}_missing",
             evidence_field.replace(['.', '*', '{', '}', '[', ']', ','], "_")
         ),
         evidence_field: evidence_field.to_string(),
-        detail: rustraft_process_readiness_field_detail(evidence_field).to_string(),
+        detail: matrixraft_process_readiness_field_detail(evidence_field).to_string(),
     }
 }
 
-pub fn rustraft_named_readiness_blockers<I, S>(
+pub fn matrixraft_named_readiness_blockers<I, S>(
     blocker: &str,
     evidence_field: &str,
     details: I,
@@ -1725,37 +1725,37 @@ where
         .collect()
 }
 
-pub fn rustraft_data_node_process_rollout_blockers(
+pub fn matrixraft_data_node_process_rollout_blockers(
     prefix: &str,
     report: Option<&RustRaftDataNodeProcessRolloutReport>,
 ) -> Vec<RustRaftProcessReadinessBlocker> {
     let Some(report) = report else {
-        return vec![rustraft_missing_process_rollout_report_blocker(prefix)];
+        return vec![matrixraft_missing_process_rollout_report_blocker(prefix)];
     };
     let mut blockers = Vec::new();
     append_data_node_process_blockers(&mut blockers, prefix, report);
     blockers
         .into_iter()
-        .map(|field| rustraft_process_readiness_blocker(&field))
+        .map(|field| matrixraft_process_readiness_blocker(&field))
         .collect()
 }
 
-pub fn rustraft_meta_process_rollout_blockers(
+pub fn matrixraft_meta_process_rollout_blockers(
     prefix: &str,
     report: Option<&RustRaftMetaProcessRolloutReport>,
 ) -> Vec<RustRaftProcessReadinessBlocker> {
     let Some(report) = report else {
-        return vec![rustraft_missing_process_rollout_report_blocker(prefix)];
+        return vec![matrixraft_missing_process_rollout_report_blocker(prefix)];
     };
     let mut blockers = Vec::new();
     append_meta_process_blockers(&mut blockers, prefix, report);
     blockers
         .into_iter()
-        .map(|field| rustraft_process_readiness_blocker(&field))
+        .map(|field| matrixraft_process_readiness_blocker(&field))
         .collect()
 }
 
-fn rustraft_missing_process_rollout_report_blocker(
+fn matrixraft_missing_process_rollout_report_blocker(
     prefix: &str,
 ) -> RustRaftProcessReadinessBlocker {
     RustRaftProcessReadinessBlocker {
@@ -1765,7 +1765,7 @@ fn rustraft_missing_process_rollout_report_blocker(
     }
 }
 
-pub fn rustraft_process_readiness_field_detail(evidence_field: &str) -> &'static str {
+pub fn matrixraft_process_readiness_field_detail(evidence_field: &str) -> &'static str {
     match evidence_field {
         "final_raft_readiness.multi_process_data_node_and_metaserver_raft" => {
             "both data-node and metaserver Raft evidence must come from spawned process paths with independent WAL/snapshot dirs, observed process requests, read-index responses, restart recovery, and per-node log-store inspection"
@@ -1832,7 +1832,7 @@ pub fn rustraft_process_readiness_field_detail(evidence_field: &str) -> &'static
     }
 }
 
-pub fn rustraft_data_node_strict_process_rollout_validated(
+pub fn matrixraft_data_node_strict_process_rollout_validated(
     report: &RustRaftDataNodeProcessRolloutReport,
 ) -> bool {
     report.ready
@@ -1853,7 +1853,7 @@ pub fn rustraft_data_node_strict_process_rollout_validated(
         && report.operational_semantics.proves_runtime_semantics()
 }
 
-pub fn rustraft_meta_strict_process_rollout_validated(
+pub fn matrixraft_meta_strict_process_rollout_validated(
     report: &RustRaftMetaProcessRolloutReport,
 ) -> bool {
     report.ready
@@ -2184,7 +2184,7 @@ fn runtime_capability(
     source_reference: &str,
     fields: &[(bool, &str)],
 ) -> RaftCapabilityEvidence {
-    rustraft_capability_evidence_from_fields(
+    matrixraft_capability_evidence_from_fields(
         capability,
         source_reference,
         fields.iter().map(|(present, field)| (*present, *field)),
@@ -2524,7 +2524,7 @@ fn require_membership_transitions(
     blockers: &mut Vec<String>,
     actions: &mut Vec<String>,
 ) {
-    let report = rustraft_membership_readiness_report(transitions);
+    let report = matrixraft_membership_readiness_report(transitions);
     if report.ready {
         satisfied.push("membership:all_required_transitions".to_string());
     } else {

--- a/src/facade/tests.rs
+++ b/src/facade/tests.rs
@@ -124,16 +124,16 @@ mod tests {
 
     fn ready_snapshot() -> RustRaftReadinessSnapshot {
         RustRaftReadinessSnapshot {
-            rustraft_leader_write_authority_present: true,
-            rustraft_operator_observability_present: true,
-            rustraft_rpc_transport_contract_present: true,
-            rustraft_log_retention_snapshot_trigger_present: true,
-            rustraft_apply_snapshot_fence_present: true,
+            matrixraft_leader_write_authority_present: true,
+            matrixraft_operator_observability_present: true,
+            matrixraft_rpc_transport_contract_present: true,
+            matrixraft_log_retention_snapshot_trigger_present: true,
+            matrixraft_apply_snapshot_fence_present: true,
             raft_storage_apply_fence_present: true,
-            rustraft_snapshot_floor_log_matching_present: true,
-            rustraft_snapshot_tail_catchup_present: true,
-            rustraft_compacted_entry_rejection_present: true,
-            rustraft_metaserver_snapshot_floor_election_present: true,
+            matrixraft_snapshot_floor_log_matching_present: true,
+            matrixraft_snapshot_tail_catchup_present: true,
+            matrixraft_compacted_entry_rejection_present: true,
+            matrixraft_metaserver_snapshot_floor_election_present: true,
             learner_catchup_promotion_present: true,
             metaserver_membership_workflow_present: true,
         }
@@ -418,7 +418,7 @@ mod tests {
         peer_3.inflight_entries = 1;
         peer_3.inflight_bytes = 128;
 
-        rustraft_admin_status_surface_evidence(&RustRaftAdminStatusSurfaceInput {
+        matrixraft_admin_status_surface_evidence(&RustRaftAdminStatusSurfaceInput {
             commit_index: 104,
             max_observed_node_commit_index: 104,
             quorum_size: 2,
@@ -430,7 +430,7 @@ mod tests {
     }
 
     fn ready_fault_harness() -> fault::RustRaftFaultHarnessReadinessReport {
-        let evidence = fault::rustraft_baseline_raft_fault_scenarios()
+        let evidence = fault::matrixraft_baseline_raft_fault_scenarios()
             .into_iter()
             .map(|requirement| fault::RustRaftFaultScenarioEvidence {
                 scenario: requirement.scenario,
@@ -449,7 +449,7 @@ mod tests {
                 report_path: Some(format!("reports/{}.json", requirement.scenario.id())),
             })
             .collect::<Vec<_>>();
-        fault::rustraft_fault_harness_readiness_report(&evidence)
+        fault::matrixraft_fault_harness_readiness_report(&evidence)
     }
 
     fn ready_production_input() -> RustRaftProductionReadinessInput {
@@ -502,12 +502,12 @@ mod tests {
             membership_transitions: ready_membership_transitions(),
             baseline_raft_benchmark: Some(RustRaftBaselineRaftBenchmarkEvidence {
                 real_baseline_raft: true,
-                rustraft_runtime: true,
+                matrixraft_runtime: true,
                 baseline_raft_reference: true,
-                rustraft_rust_candidate: true,
+                matrixraft_rust_candidate: true,
                 correctness_passed: true,
                 performance_within_threshold: true,
-                workloads: crate::benchmark::rustraft_baseline_raft_benchmark_workloads()
+                workloads: crate::benchmark::matrixraft_baseline_raft_benchmark_workloads()
                     .into_iter()
                     .map(|workload| workload.id().to_string())
                     .collect(),
@@ -574,10 +574,10 @@ mod tests {
                     crate::benchmark::RustRaftBenchmarkHarnessKind::RustRaftRuntime
                 }
             },
-            node_count: crate::benchmark::RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT,
+            node_count: crate::benchmark::MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT,
             iterations_per_workload: 128,
             batch_size: 16,
-            payload_size_bytes: crate::benchmark::RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES,
+            payload_size_bytes: crate::benchmark::MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES,
             timed_iteration_count: 128,
             operations_per_timed_iteration,
             total_duration_micros,
@@ -624,7 +624,7 @@ mod tests {
     }
 
     fn ready_benchmark_report() -> crate::benchmark::RustRaftBenchmarkReport {
-        let comparisons = crate::benchmark::rustraft_baseline_raft_benchmark_workloads()
+        let comparisons = crate::benchmark::matrixraft_baseline_raft_benchmark_workloads()
             .into_iter()
             .map(|workload| {
                 let baseline_raft = ready_benchmark_sample(
@@ -656,7 +656,7 @@ mod tests {
             })
             .collect();
         crate::benchmark::RustRaftBenchmarkReport {
-            schema: crate::benchmark::RUSTRAFT_BENCHMARK_REPORT_SCHEMA.to_string(),
+            schema: crate::benchmark::MATRIXRAFT_BENCHMARK_REPORT_SCHEMA.to_string(),
             generated_at_unix_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("time")
@@ -665,11 +665,11 @@ mod tests {
             environment_fingerprint:
                 "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false"
                     .to_string(),
-            node_count: crate::benchmark::RUSTRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT,
+            node_count: crate::benchmark::MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_NODE_COUNT,
             options: crate::benchmark::RustRaftBenchmarkOptions::default(),
-            pass_tolerance_percent: crate::benchmark::RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT,
+            pass_tolerance_percent: crate::benchmark::MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT,
             correctness_required: true,
-            required_workloads: crate::benchmark::rustraft_baseline_raft_benchmark_required_workloads(),
+            required_workloads: crate::benchmark::matrixraft_baseline_raft_benchmark_required_workloads(),
             passed: true,
             comparisons,
         }
@@ -677,7 +677,7 @@ mod tests {
 
     #[test]
     fn contract_is_openraft_free_and_complete() {
-        let contract = rustraft_parity_contract();
+        let contract = matrixraft_parity_contract();
         assert!(contract.openraft_dependency_removed);
         assert_eq!(contract.requirements.len(), 12);
     }
@@ -686,8 +686,8 @@ mod tests {
     fn crate_readme_documents_open_source_contract_surface() {
         let readme = include_str!("../../README.md");
         assert!(readme.contains("RustRaft"));
-        assert!(readme.contains("rustraft_parity_report"));
-        assert!(readme.contains("rustraft_production_readiness_report"));
+        assert!(readme.contains("matrixraft_parity_report"));
+        assert!(readme.contains("matrixraft_production_readiness_report"));
         assert!(readme.contains("OpenRaft-free"));
         assert!(readme.contains("Apache-2.0"));
     }
@@ -696,7 +696,7 @@ mod tests {
     fn report_fails_closed() {
         let mut snapshot = ready_snapshot();
         snapshot.raft_storage_apply_fence_present = false;
-        let report = rustraft_parity_report(&snapshot);
+        let report = matrixraft_parity_report(&snapshot);
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
         assert_eq!(report.missing, vec!["storage_apply_fence".to_string()]);
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn production_readiness_gate_accepts_complete_evidence() {
-        let report = rustraft_production_readiness_report(&ready_production_input());
+        let report = matrixraft_production_readiness_report(&ready_production_input());
         assert!(report.ready, "{report:#?}");
         assert_eq!(
             report.production_status,
@@ -721,9 +721,9 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -747,9 +747,9 @@ mod tests {
         let mut benchmark = ready_benchmark_report();
         benchmark.environment_fingerprint.clear();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -770,9 +770,9 @@ mod tests {
             "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=true"
                 .to_string();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -792,27 +792,27 @@ mod tests {
         benchmark.comparisons.clear();
         benchmark.passed = true;
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report_evidence = crate::benchmark::rustraft_baseline_raft_benchmark_evidence(&benchmark);
+        let report_evidence = crate::benchmark::matrixraft_baseline_raft_benchmark_evidence(&benchmark);
         assert!(!report_evidence.real_baseline_raft);
-        assert!(!report_evidence.rustraft_runtime);
+        assert!(!report_evidence.matrixraft_runtime);
         assert!(!report_evidence.baseline_raft_reference);
-        assert!(!report_evidence.rustraft_rust_candidate);
+        assert!(!report_evidence.matrixraft_rust_candidate);
         assert!(!report_evidence.correctness_passed);
         assert!(!report_evidence.performance_within_threshold);
 
         let summary_evidence =
-            crate::benchmark::rustraft_baseline_raft_benchmark_evidence_from_summary(&summary);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_evidence_from_summary(&summary);
         assert!(!summary_evidence.real_baseline_raft);
-        assert!(!summary_evidence.rustraft_runtime);
+        assert!(!summary_evidence.matrixraft_runtime);
         assert!(!summary_evidence.baseline_raft_reference);
-        assert!(!summary_evidence.rustraft_rust_candidate);
+        assert!(!summary_evidence.matrixraft_rust_candidate);
         assert!(!summary_evidence.correctness_passed);
         assert!(!summary_evidence.performance_within_threshold);
         assert!(!summary.production_evidence_ready);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -833,8 +833,8 @@ mod tests {
             .contains(&"benchmark:rustraft_runtime".to_string()));
 
         let summary_input =
-            rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
-        let summary_report = rustraft_production_readiness_report(&summary_input);
+            matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let summary_report = matrixraft_production_readiness_report(&summary_input);
         assert!(!summary_report.ready);
         assert!(summary_report.production_blockers.iter().any(|blocker| {
             blocker == "benchmark:summary_passed_mismatch:declared_true_actual_false"
@@ -848,9 +848,9 @@ mod tests {
         let mut benchmark = ready_benchmark_report();
         benchmark.schema = "rustraft.baseline_raft_benchmark_report.v0".to_string();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -870,9 +870,9 @@ mod tests {
         let mut benchmark = ready_benchmark_report();
         benchmark.comparisons[0].rustraft.benchmark_run_id = "different-run".to_string();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -899,9 +899,9 @@ mod tests {
             crate::benchmark::RustRaftBenchmarkImplementation::Unknown;
         benchmark.comparisons[0].rustraft.operation_count = 1;
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -942,9 +942,9 @@ mod tests {
         benchmark.comparisons[0].passed = true;
         benchmark.passed = true;
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -969,9 +969,9 @@ mod tests {
         benchmark.comparisons[0].baseline_raft.p50_latency_micros = 300;
         benchmark.comparisons[0].baseline_raft.p99_latency_micros = 200;
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -991,9 +991,9 @@ mod tests {
         let mut benchmark = ready_benchmark_report();
         benchmark.comparisons[0].rustraft.build_profile = "debug".to_string();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -1011,9 +1011,9 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
-        let report = rustraft_production_readiness_report(&input);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(report.ready, "{report:#?}");
         assert!(report
@@ -1033,11 +1033,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.workloads[0].p99_ratio = 2.0;
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1052,11 +1052,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
-        summary.workloads[0].rustraft_p99_latency_micros = 100;
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
+        summary.workloads[0].matrixraft_p99_latency_micros = 100;
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1076,11 +1076,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.worst_p99_ratio = 1.0;
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1095,11 +1095,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.options.iterations_per_workload = 2;
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1114,11 +1114,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.environment_fingerprint.clear();
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1133,13 +1133,13 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.environment_fingerprint =
             "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=true"
                 .to_string();
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1154,11 +1154,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.schema = "rustraft.baseline_raft_benchmark_summary.v0".to_string();
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1174,11 +1174,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
-        summary.workloads[0].rustraft_benchmark_run_id = "different-run".to_string();
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
+        summary.workloads[0].matrixraft_benchmark_run_id = "different-run".to_string();
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1194,11 +1194,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
-        summary.workloads[0].rustraft_node_count = 3;
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
+        summary.workloads[0].matrixraft_node_count = 3;
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1213,11 +1213,11 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
-        summary.workloads[0].rustraft_build_profile = "debug".to_string();
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
+        summary.workloads[0].matrixraft_build_profile = "debug".to_string();
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1232,12 +1232,12 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.workloads[0].baseline_raft_harness_kind =
             crate::benchmark::RustRaftBenchmarkHarnessKind::NativeKvbenchPartial;
-        let input = rustraft_production_readiness_input_with_benchmark_summary(input, &summary);
+        let input = matrixraft_production_readiness_input_with_benchmark_summary(input, &summary);
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1260,7 +1260,7 @@ mod tests {
                 workload != crate::benchmark::RustRaftBenchmarkWorkload::WalFsync.id()
             });
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1290,7 +1290,7 @@ mod tests {
                     .to_string(),
             );
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1319,7 +1319,7 @@ mod tests {
             .workloads
             .push("ad_hoc_latency_probe".to_string());
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1348,7 +1348,7 @@ mod tests {
             .blockers
             .push("benchmark:full_harness_observation_missing:lease_reads".to_string());
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1371,10 +1371,10 @@ mod tests {
         input.baseline_raft_benchmark = None;
         let benchmark = ready_benchmark_report();
         let mut summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
         summary.workload_count = 0;
 
-        let error = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let error = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap_err();
@@ -1399,9 +1399,9 @@ mod tests {
         );
         comparison.passed = false;
         let summary =
-            crate::benchmark::rustraft_baseline_raft_benchmark_failure_summary(&benchmark);
+            crate::benchmark::matrixraft_baseline_raft_benchmark_failure_summary(&benchmark);
 
-        let report = rustraft_production_readiness_report_with_benchmark_artifacts(
+        let report = matrixraft_production_readiness_report_with_benchmark_artifacts(
             &input, &benchmark, &summary,
         )
         .unwrap();
@@ -1417,7 +1417,7 @@ mod tests {
 
     #[test]
     fn production_readiness_gate_fails_closed_without_runtime_evidence() {
-        let report = rustraft_production_readiness_report(&RustRaftProductionReadinessInput {
+        let report = matrixraft_production_readiness_report(&RustRaftProductionReadinessInput {
             readiness: ready_snapshot(),
             peer_pipeline: None,
             snapshot_lifecycle: None,
@@ -1467,9 +1467,9 @@ mod tests {
         let mut input = ready_production_input();
         input.baseline_raft_benchmark = Some(RustRaftBaselineRaftBenchmarkEvidence {
             real_baseline_raft: false,
-            rustraft_runtime: false,
+            matrixraft_runtime: false,
             baseline_raft_reference: false,
-            rustraft_rust_candidate: false,
+            matrixraft_rust_candidate: false,
             correctness_passed: true,
             performance_within_threshold: true,
             workloads: vec!["single_key_writes".to_string()],
@@ -1482,7 +1482,7 @@ mod tests {
             correctness_blockers: Vec::new(),
             performance_blockers: Vec::new(),
         });
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
         assert!(!report.ready);
         assert!(report
             .production_blockers
@@ -1515,9 +1515,9 @@ mod tests {
         let performance_blocker = "batched_writes:benchmark:p99_regression".to_string();
         input.baseline_raft_benchmark = Some(RustRaftBaselineRaftBenchmarkEvidence {
             real_baseline_raft: true,
-            rustraft_runtime: true,
+            matrixraft_runtime: true,
             baseline_raft_reference: true,
-            rustraft_rust_candidate: true,
+            matrixraft_rust_candidate: true,
             correctness_passed: false,
             performance_within_threshold: false,
             workloads: vec![
@@ -1538,7 +1538,7 @@ mod tests {
             performance_blockers: vec![performance_blocker.clone()],
         });
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         for blocker in [
@@ -1576,7 +1576,7 @@ mod tests {
     #[test]
     fn production_readiness_gate_rejects_incomplete_admin_status_surface() {
         let mut input = ready_production_input();
-        input.admin_status_surface = Some(rustraft_admin_status_surface_evidence(
+        input.admin_status_surface = Some(matrixraft_admin_status_surface_evidence(
             &RustRaftAdminStatusSurfaceInput {
                 commit_index: 104,
                 max_observed_node_commit_index: 106,
@@ -1588,7 +1588,7 @@ mod tests {
             },
         ));
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1609,9 +1609,9 @@ mod tests {
     #[test]
     fn production_readiness_gate_rejects_missing_fault_harness_evidence() {
         let mut input = ready_production_input();
-        input.fault_harness = Some(fault::rustraft_fault_harness_readiness_report(&[]));
+        input.fault_harness = Some(fault::matrixraft_fault_harness_readiness_report(&[]));
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1641,7 +1641,7 @@ mod tests {
             slow_fsync_backpressure_observed: true,
             compaction_after_slow_fsync_observed: true,
         });
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
         assert!(!report.ready);
         assert!(report.missing.contains(&"wal:compaction".to_string()));
         assert!(report
@@ -1658,7 +1658,7 @@ mod tests {
             .unwrap()
             .compaction_after_slow_fsync_observed = false;
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1676,7 +1676,7 @@ mod tests {
             .unwrap()
             .packet_loss_reorder_same_peer_recovered = false;
 
-        let report = rustraft_production_readiness_report(&input);
+        let report = matrixraft_production_readiness_report(&input);
 
         assert!(!report.ready);
         assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
@@ -1707,7 +1707,7 @@ mod tests {
             }],
         };
         assert!(
-            rustraft_read_safety_decision(
+            matrixraft_read_safety_decision(
                 &status,
                 &RustRaftReadIndexRequest {
                     group_id: 1,
@@ -1718,7 +1718,7 @@ mod tests {
             )
             .safe
         );
-        assert!(rustraft_learner_promotion_decision(&status, 2, 0).promotable);
+        assert!(matrixraft_learner_promotion_decision(&status, 2, 0).promotable);
     }
 
     #[test]
@@ -1804,7 +1804,7 @@ mod tests {
 
     #[test]
     fn runtime_read_safety_rejects_stale_leader_lease() {
-        let decision = rustraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
+        let decision = matrixraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
             operation: RustRaftReadSafetyOperation::LeaseRead,
             node_id: 1,
             leader_id: 1,
@@ -1823,7 +1823,7 @@ mod tests {
 
     #[test]
     fn runtime_read_safety_rejects_lagging_follower() {
-        let decision = rustraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
+        let decision = matrixraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
             operation: RustRaftReadSafetyOperation::ReadIndex,
             node_id: 2,
             leader_id: 1,
@@ -1842,7 +1842,7 @@ mod tests {
 
     #[test]
     fn runtime_read_safety_allows_bounded_stale_within_lag_budget() {
-        let decision = rustraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
+        let decision = matrixraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
             operation: RustRaftReadSafetyOperation::BoundedStaleRead,
             node_id: 2,
             leader_id: 1,
@@ -1860,7 +1860,7 @@ mod tests {
 
     #[test]
     fn runtime_read_safety_rejects_minority_writes() {
-        let decision = rustraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
+        let decision = matrixraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
             operation: RustRaftReadSafetyOperation::Write,
             node_id: 1,
             leader_id: 1,
@@ -1879,7 +1879,7 @@ mod tests {
 
     #[test]
     fn membership_readiness_requires_failover_scale_up_and_scale_down_for_meta_and_data_nodes() {
-        let report = rustraft_membership_readiness_report(&ready_membership_transitions());
+        let report = matrixraft_membership_readiness_report(&ready_membership_transitions());
         assert!(report.ready, "{report:#?}");
         assert!(report
             .satisfied
@@ -1902,7 +1902,7 @@ mod tests {
                     && item.transition == RustRaftMembershipTransitionKind::ScaleDown)
             })
             .collect::<Vec<_>>();
-        let report = rustraft_membership_readiness_report(&transitions);
+        let report = matrixraft_membership_readiness_report(&transitions);
         assert!(!report.ready);
         assert!(report
             .missing
@@ -1916,7 +1916,7 @@ mod tests {
             RustRaftMembershipTransitionKind::ScaleUp,
         );
         transition.joint_consensus_used = false;
-        let missing = rustraft_membership_transition_missing(&transition);
+        let missing = matrixraft_membership_transition_missing(&transition);
         assert!(missing.contains(&"joint_consensus_used".to_string()));
     }
 
@@ -1929,7 +1929,7 @@ mod tests {
         transition.joint_acknowledged_voters = vec![1, 2];
         transition.joint_old_majority_acked = false;
 
-        let missing = rustraft_membership_transition_missing(&transition);
+        let missing = matrixraft_membership_transition_missing(&transition);
 
         assert!(missing.contains(&"joint_quorum_commit_proven".to_string()));
     }

--- a/src/facade/transport_runtime.rs
+++ b/src/facade/transport_runtime.rs
@@ -257,11 +257,11 @@ impl RustRaftTransport for InMemoryRaftTransport {
         request: RustRaftAppendEntriesRequest,
     ) -> Result<RustRaftAppendEntriesResponse, RustRaftError> {
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_append_entries_request(&request))?;
+            require_transport_validation(matrixraft_validate_append_entries_request(&request))?;
         }
         let response = self.handler(target)?.append_entries(target, request)?;
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_append_entries_response(&response))?;
+            require_transport_validation(matrixraft_validate_append_entries_response(&response))?;
         }
         Ok(response)
     }
@@ -272,11 +272,11 @@ impl RustRaftTransport for InMemoryRaftTransport {
         request: RustRaftVoteRequest,
     ) -> Result<RustRaftVoteResponse, RustRaftError> {
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_vote_request(&request))?;
+            require_transport_validation(matrixraft_validate_vote_request(&request))?;
         }
         let response = self.handler(target)?.vote(target, request)?;
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_vote_response(&response))?;
+            require_transport_validation(matrixraft_validate_vote_response(&response))?;
         }
         Ok(response)
     }
@@ -287,11 +287,11 @@ impl RustRaftTransport for InMemoryRaftTransport {
         request: RustRaftInstallSnapshotRequest,
     ) -> Result<RustRaftInstallSnapshotResponse, RustRaftError> {
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_install_snapshot_request(&request))?;
+            require_transport_validation(matrixraft_validate_install_snapshot_request(&request))?;
         }
         let response = self.handler(target)?.install_snapshot(target, request)?;
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_install_snapshot_response(&response))?;
+            require_transport_validation(matrixraft_validate_install_snapshot_response(&response))?;
         }
         Ok(response)
     }
@@ -302,11 +302,11 @@ impl RustRaftTransport for InMemoryRaftTransport {
         request: RustRaftReadIndexRequest,
     ) -> Result<RustRaftReadIndexResponse, RustRaftError> {
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_read_index_request(&request))?;
+            require_transport_validation(matrixraft_validate_read_index_request(&request))?;
         }
         let response = self.handler(target)?.read_index(target, request)?;
         if self.validate_messages {
-            require_transport_validation(rustraft_validate_read_index_response(&response))?;
+            require_transport_validation(matrixraft_validate_read_index_response(&response))?;
         }
         Ok(response)
     }
@@ -420,7 +420,7 @@ impl TcpRaftTransport {
             return Ok(Vec::new());
         }
         for request in &requests {
-            require_transport_validation(rustraft_validate_tcp_transport_request(request))?;
+            require_transport_validation(matrixraft_validate_tcp_transport_request(request))?;
         }
         match self.send_rpc(target, TcpRaftTransportRequest::Batch { requests })? {
             TcpRaftTransportResponse::Batch(responses) => Ok(responses),
@@ -437,14 +437,14 @@ impl RustRaftTransport for TcpRaftTransport {
         target: u64,
         request: RustRaftAppendEntriesRequest,
     ) -> Result<RustRaftAppendEntriesResponse, RustRaftError> {
-        require_transport_validation(rustraft_validate_append_entries_request(&request))?;
+        require_transport_validation(matrixraft_validate_append_entries_request(&request))?;
         match self.send_rpc(
             target,
             TcpRaftTransportRequest::AppendEntries { target, request },
         )? {
             TcpRaftTransportResponse::AppendEntries(response) => {
                 let response = response.into_result()?;
-                require_transport_validation(rustraft_validate_append_entries_response(&response))?;
+                require_transport_validation(matrixraft_validate_append_entries_response(&response))?;
                 Ok(response)
             }
             _ => Err(RaftError::Transport(
@@ -458,11 +458,11 @@ impl RustRaftTransport for TcpRaftTransport {
         target: u64,
         request: RustRaftVoteRequest,
     ) -> Result<RustRaftVoteResponse, RustRaftError> {
-        require_transport_validation(rustraft_validate_vote_request(&request))?;
+        require_transport_validation(matrixraft_validate_vote_request(&request))?;
         match self.send_rpc(target, TcpRaftTransportRequest::Vote { target, request })? {
             TcpRaftTransportResponse::Vote(response) => {
                 let response = response.into_result()?;
-                require_transport_validation(rustraft_validate_vote_response(&response))?;
+                require_transport_validation(matrixraft_validate_vote_response(&response))?;
                 Ok(response)
             }
             _ => Err(RaftError::Transport(
@@ -476,14 +476,14 @@ impl RustRaftTransport for TcpRaftTransport {
         target: u64,
         request: RustRaftInstallSnapshotRequest,
     ) -> Result<RustRaftInstallSnapshotResponse, RustRaftError> {
-        require_transport_validation(rustraft_validate_install_snapshot_request(&request))?;
+        require_transport_validation(matrixraft_validate_install_snapshot_request(&request))?;
         match self.send_rpc(
             target,
             TcpRaftTransportRequest::InstallSnapshot { target, request },
         )? {
             TcpRaftTransportResponse::InstallSnapshot(response) => {
                 let response = response.into_result()?;
-                require_transport_validation(rustraft_validate_install_snapshot_response(
+                require_transport_validation(matrixraft_validate_install_snapshot_response(
                     &response,
                 ))?;
                 Ok(response)
@@ -499,14 +499,14 @@ impl RustRaftTransport for TcpRaftTransport {
         target: u64,
         request: RustRaftReadIndexRequest,
     ) -> Result<RustRaftReadIndexResponse, RustRaftError> {
-        require_transport_validation(rustraft_validate_read_index_request(&request))?;
+        require_transport_validation(matrixraft_validate_read_index_request(&request))?;
         match self.send_rpc(
             target,
             TcpRaftTransportRequest::ReadIndex { target, request },
         )? {
             TcpRaftTransportResponse::ReadIndex(response) => {
                 let response = response.into_result()?;
-                require_transport_validation(rustraft_validate_read_index_response(&response))?;
+                require_transport_validation(matrixraft_validate_read_index_response(&response))?;
                 Ok(response)
             }
             _ => Err(RaftError::Transport(
@@ -600,7 +600,7 @@ where
     }
     let request: TcpRaftTransportRequest = serde_json::from_str(&line)
         .map_err(|err| RaftError::Transport(format!("failed to decode raft TCP request: {err}")))?;
-    require_transport_validation(rustraft_validate_tcp_transport_request(&request))?;
+    require_transport_validation(matrixraft_validate_tcp_transport_request(&request))?;
     let response = handle_tcp_raft_request(request, handler);
     let encoded = serde_json::to_vec(&response).map_err(|err| {
         RaftError::Transport(format!("failed to encode raft TCP response: {err}"))

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -69,7 +69,7 @@ impl LocalRaftWal {
     }
 
     pub fn append(&mut self, mut record: RaftWalRecord) -> Result<String, RaftError> {
-        record.checksum = rustraft_wal_checksum(&record);
+        record.checksum = matrixraft_wal_checksum(&record);
         if self
             .segments
             .last()
@@ -141,10 +141,10 @@ impl LocalRaftWal {
     pub fn recover(&mut self) -> Result<RaftWalRecoveryReport, RaftError> {
         let mut records = self.records();
         let original_len = records.len();
-        while matches!(records.last(), Some(record) if !rustraft_wal_checksum_valid(record)) {
+        while matches!(records.last(), Some(record) if !matrixraft_wal_checksum_valid(record)) {
             records.pop();
         }
-        let recovered = rustraft_recover_latest_wal_record(&records).ok();
+        let recovered = matrixraft_recover_latest_wal_record(&records).ok();
         let truncated_corrupt_tail = records.len() != original_len;
         if truncated_corrupt_tail {
             self.rebuild_from_records(records.clone())?;
@@ -155,7 +155,7 @@ impl LocalRaftWal {
             surviving_records: records.len(),
             removed_records: original_len.saturating_sub(records.len()),
             segments_scanned: self.segments.len() as u64,
-            checksum_format: Some(rustraft_wal_checksum_format()),
+            checksum_format: Some(matrixraft_wal_checksum_format()),
             retained_range: Some(wal_retained_range(&self.segments)),
         })
     }
@@ -297,8 +297,8 @@ impl PersistentRaftWal {
         &mut self,
         mut record: RaftWalRecord,
     ) -> Result<RaftWalWriteReport, RaftError> {
-        record.checksum = rustraft_wal_checksum(&record);
-        let hard_state_persisted = rustraft_validate_hard_state_persistence(&record).is_ok();
+        record.checksum = matrixraft_wal_checksum(&record);
+        let hard_state_persisted = matrixraft_validate_hard_state_persistence(&record).is_ok();
         let encoded = serde_json::to_string(&record)
             .map_err(|err| RaftError::Storage(format!("failed to encode WAL record: {err}")))?;
         let record_bytes = encoded.len() as u64 + 1;
@@ -367,7 +367,7 @@ impl PersistentRaftWal {
             segment_id,
             log_index: record_index,
             checksum,
-            checksum_format: rustraft_wal_checksum_format(),
+            checksum_format: matrixraft_wal_checksum_format(),
             bytes_written: record_bytes,
             fsync_on_append: self.options.fsync_on_append,
             fsync_elapsed_ms,
@@ -410,12 +410,12 @@ impl PersistentRaftWal {
         let observed_corrupt_tail = self.truncated_corrupt_tail || truncated_corrupt_tail;
         self.truncated_corrupt_tail = observed_corrupt_tail;
         Ok(RaftWalRecoveryReport {
-            recovered: rustraft_recover_latest_wal_record(&records).ok(),
+            recovered: matrixraft_recover_latest_wal_record(&records).ok(),
             truncated_corrupt_tail: observed_corrupt_tail,
             surviving_records: records.len(),
             removed_records: original_len.saturating_sub(records.len()),
             segments_scanned: self.segments.len() as u64,
-            checksum_format: Some(rustraft_wal_checksum_format()),
+            checksum_format: Some(matrixraft_wal_checksum_format()),
             retained_range: Some(wal_retained_range(&self.segments)),
         })
     }
@@ -464,7 +464,7 @@ impl PersistentRaftWal {
         log_index: RustRaftLogIndex,
         fence: &RustRaftStorageApplyFence,
     ) -> Result<RaftWalCompactionReport, RaftError> {
-        if let Err(error) = rustraft_validate_storage_apply_fence(fence) {
+        if let Err(error) = matrixraft_validate_storage_apply_fence(fence) {
             return Ok(RaftWalCompactionReport {
                 requested_log_index: log_index,
                 released_segments: 0,
@@ -574,7 +574,7 @@ impl PersistentRaftWal {
     }
 
     pub fn checksum_format(&self) -> RaftWalChecksumFormat {
-        rustraft_wal_checksum_format()
+        matrixraft_wal_checksum_format()
     }
 
     pub fn records(&self) -> Vec<RaftWalRecord> {
@@ -756,7 +756,7 @@ fn read_wal_segment_file(path: &Path) -> Result<(Vec<RaftWalRecord>, bool), Raft
             truncated = true;
             break;
         };
-        if !rustraft_wal_checksum_valid(&record) {
+        if !matrixraft_wal_checksum_valid(&record) {
             truncated = true;
             break;
         }

--- a/src/fault.rs
+++ b/src/fault.rs
@@ -3,9 +3,9 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const RUSTRAFT_FAULT_MIN_SCENARIO_RUNTIME_MS: u64 = 1_000;
-pub const RUSTRAFT_FAULT_MIN_CLIENT_OPERATION_COUNT: u64 = 1;
-pub const RUSTRAFT_FAULT_MIN_INJECTED_FAULT_COUNT: u64 = 1;
+pub const MATRIXRAFT_FAULT_MIN_SCENARIO_RUNTIME_MS: u64 = 1_000;
+pub const MATRIXRAFT_FAULT_MIN_CLIENT_OPERATION_COUNT: u64 = 1;
+pub const MATRIXRAFT_FAULT_MIN_INJECTED_FAULT_COUNT: u64 = 1;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -81,7 +81,7 @@ pub struct RustRaftFaultHarnessReadinessReport {
     pub missing: Vec<String>,
 }
 
-pub fn rustraft_baseline_raft_fault_scenarios() -> Vec<RustRaftFaultScenarioRequirement> {
+pub fn matrixraft_baseline_raft_fault_scenarios() -> Vec<RustRaftFaultScenarioRequirement> {
     vec![
         RustRaftFaultScenarioRequirement {
             scenario: RustRaftFaultScenario::PacketLossMajority,
@@ -157,17 +157,17 @@ pub fn rustraft_baseline_raft_fault_scenarios() -> Vec<RustRaftFaultScenarioRequ
     ]
 }
 
-pub fn rustraft_fault_harness_readiness_report(
+pub fn matrixraft_fault_harness_readiness_report(
     evidence: &[RustRaftFaultScenarioEvidence],
 ) -> RustRaftFaultHarnessReadinessReport {
-    let required_scenarios = rustraft_baseline_raft_fault_scenarios();
+    let required_scenarios = matrixraft_baseline_raft_fault_scenarios();
     let results = required_scenarios
         .iter()
         .map(|requirement| {
             let scenario_evidence = evidence
                 .iter()
                 .find(|item| item.scenario == requirement.scenario);
-            let missing = rustraft_fault_scenario_missing(requirement, scenario_evidence);
+            let missing = matrixraft_fault_scenario_missing(requirement, scenario_evidence);
             RustRaftFaultScenarioResult {
                 scenario: requirement.scenario,
                 ready: missing.is_empty(),
@@ -192,7 +192,7 @@ pub fn rustraft_fault_harness_readiness_report(
     }
 }
 
-fn rustraft_fault_scenario_missing(
+fn matrixraft_fault_scenario_missing(
     requirement: &RustRaftFaultScenarioRequirement,
     evidence: Option<&RustRaftFaultScenarioEvidence>,
 ) -> Vec<String> {
@@ -214,22 +214,22 @@ fn rustraft_fault_scenario_missing(
     if distinct_process_ids.len() < 3 {
         missing.push("distinct_process_ids_at_least_3".to_string());
     }
-    if evidence.scenario_runtime_ms < RUSTRAFT_FAULT_MIN_SCENARIO_RUNTIME_MS {
+    if evidence.scenario_runtime_ms < MATRIXRAFT_FAULT_MIN_SCENARIO_RUNTIME_MS {
         missing.push(format!(
             "scenario_runtime_ms_at_least_{}",
-            RUSTRAFT_FAULT_MIN_SCENARIO_RUNTIME_MS
+            MATRIXRAFT_FAULT_MIN_SCENARIO_RUNTIME_MS
         ));
     }
-    if evidence.client_operation_count < RUSTRAFT_FAULT_MIN_CLIENT_OPERATION_COUNT {
+    if evidence.client_operation_count < MATRIXRAFT_FAULT_MIN_CLIENT_OPERATION_COUNT {
         missing.push(format!(
             "client_operation_count_at_least_{}",
-            RUSTRAFT_FAULT_MIN_CLIENT_OPERATION_COUNT
+            MATRIXRAFT_FAULT_MIN_CLIENT_OPERATION_COUNT
         ));
     }
-    if evidence.injected_fault_count < RUSTRAFT_FAULT_MIN_INJECTED_FAULT_COUNT {
+    if evidence.injected_fault_count < MATRIXRAFT_FAULT_MIN_INJECTED_FAULT_COUNT {
         missing.push(format!(
             "injected_fault_count_at_least_{}",
-            RUSTRAFT_FAULT_MIN_INJECTED_FAULT_COUNT
+            MATRIXRAFT_FAULT_MIN_INJECTED_FAULT_COUNT
         ));
     }
     if !evidence.independent_wal_dirs_observed {

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -13,7 +13,7 @@ use crate::{
     RustRaftLogIndex, RustRaftNodeId, RustRaftRole, RustRaftSnapshotChunk, RustRaftTerm,
 };
 
-pub fn rustraft_apply_entry<S, G, P>(
+pub fn matrixraft_apply_entry<S, G, P>(
     state_machine: &mut S,
     group_id: G,
     entry: RaftLogEntry<P>,
@@ -607,7 +607,7 @@ where
         Ok(report)
     }
 
-    pub fn apply_batch_like_matrixraft(
+    pub fn apply_batch(
         &mut self,
         entries: &[RaftLogEntry<P>],
         max_entries: usize,
@@ -639,7 +639,7 @@ where
 
         for entry in &entries[..apply_count] {
             report.attempted += 1;
-            match rustraft_fsm_entry_kind(entry) {
+            match matrixraft_fsm_entry_kind(entry) {
                 RaftFsmApplyEntryKind::Data => {
                     let outcome = self.apply_entry(entry.clone())?;
                     if outcome.applied {
@@ -727,7 +727,7 @@ where
     }
 }
 
-pub fn rustraft_fsm_entry_kind<P>(entry: &RaftLogEntry<P>) -> RaftFsmApplyEntryKind {
+pub fn matrixraft_fsm_entry_kind<P>(entry: &RaftLogEntry<P>) -> RaftFsmApplyEntryKind {
     if entry.is_command {
         RaftFsmApplyEntryKind::Data
     } else {

--- a/src/heartbeat_merge.rs
+++ b/src/heartbeat_merge.rs
@@ -11,7 +11,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 
-pub const RUSTRAFT_HEARTBEAT_MERGE_BUCKETS: usize = 16;
+pub const MATRIXRAFT_HEARTBEAT_MERGE_BUCKETS: usize = 16;
 
 pub trait RustRaftHeartbeatAddressResolver {
     fn resolve_raft_addr(
@@ -106,7 +106,7 @@ pub struct RustRaftHeartbeatMerger {
 
 impl RustRaftHeartbeatMerger {
     pub fn new(enabled: bool) -> Self {
-        Self::with_bucket_count(enabled, RUSTRAFT_HEARTBEAT_MERGE_BUCKETS)
+        Self::with_bucket_count(enabled, MATRIXRAFT_HEARTBEAT_MERGE_BUCKETS)
     }
 
     pub fn enabled() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 // Lint configuration (the `type_complexity` / `too_many_arguments` allows and the
 // rustdoc broken-intra-doc-links deny) lives in the `[lints]` table of Cargo.toml.
-//! RustRaft is the TemporalStore-owned Raft contract and readiness library.
+//! MatrixRaft is the TemporalStore-owned Raft contract and readiness library.
 //!
 //! The crate intentionally focuses on portable consensus-facing contracts:
 //! request/response types, storage and transport traits, safety decisions,
@@ -16,17 +16,20 @@
 //! Typical integration flow:
 //!
 //! 1. Build a [`RustRaftReadinessSnapshot`] from the serving runtime.
-//! 2. Call [`rustraft_parity_report`] for semantic contract readiness.
+//! 2. Call [`matrixraft_parity_report`] for semantic contract readiness.
 //! 3. Attach live runtime evidence to [`RustRaftProductionReadinessInput`].
-//! 4. Call [`rustraft_production_readiness_report`] and block production claims
+//! 4. Call [`matrixraft_production_readiness_report`] and block production claims
 //!    unless the report is ready.
 //!
 //! The public API is OpenRaft-free by design. Compatibility with existing
-//! TemporalStore deployment semantics is expressed through RustRaft-owned types
-//! and tests instead of upstream-specific type aliases.
-//! BaselineRaft remains the feature and performance reference; RustRaft may expose
-//! more idiomatic Rust traits and error types as long as TemporalStore consumes
-//! it through a stable adapter boundary.
+//! TemporalStore deployment semantics is expressed through MatrixRaft-owned
+//! types and tests instead of upstream-specific type aliases. MatrixRaft is free
+//! to expose idiomatic Rust traits and error types as long as TemporalStore
+//! consumes it through a stable adapter boundary.
+//!
+//! Many public types still carry a `RustRaft` prefix from an earlier name for
+//! this crate. Renaming them is a separate change: seven of them would collide
+//! with distinct types of the same name in the compatibility facade.
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -72,34 +75,35 @@ pub mod unique_id;
 pub mod wal;
 
 pub use benchmark::{
-    rustraft_production_readiness_input_with_benchmark_artifacts,
-    rustraft_production_readiness_input_with_benchmark_summary,
-    rustraft_production_readiness_report_with_benchmark_artifacts,
+    matrixraft_production_readiness_input_with_benchmark_artifacts,
+    matrixraft_production_readiness_input_with_benchmark_summary,
+    matrixraft_production_readiness_report_with_benchmark_artifacts,
     RustRaftBaselineRaftBenchmarkEvidence,
 };
 pub use channel_selector::{
     RustRaftChannelSelection, RustRaftChannelSelector, RustRaftChannelSelectorPolicy,
-    RustRaftMailChannel, RUSTRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS,
+    RustRaftMailChannel, MATRIXRAFT_CHANNEL_SELECTOR_MAX_TIMEOUT_MS,
 };
 pub use checksum::{
-    rustraft_checksum_file_list, rustraft_crc32c, rustraft_murmur32, RustRaftChecksumContext,
+    matrixraft_checksum_file_list, matrixraft_crc32c, matrixraft_murmur32, RustRaftChecksumContext,
     RustRaftChecksumResult, RustRaftChecksumType, RustRaftFileChecksumContext,
     RustRaftFileChecksumResult,
 };
 pub use config::{RaftConfig, RaftConfigError, RustRaftConfig};
-pub use durability::rustraft_durability_parity_report;
+pub use durability::matrixraft_durability_parity_report;
 pub use fsm::{
-    matrixraft_flexible_apply_with_store, matrixraft_flexible_apply_with_store_report,
-    rustraft_apply_entry, rustraft_fsm_entry_kind, MatrixRaftBatchId, MatrixRaftCheckpoint,
-    MatrixRaftConfigurationApplied, MatrixRaftFlexibleApplyReport, MatrixRaftFsm,
-    MatrixRaftFsmEntry, MatrixRaftFsmEntryKind, MatrixRaftFsmIterator, MatrixRaftFsmRuntimeBinding,
-    MatrixRaftFsmRuntimeHookReport, MatrixRaftStoreFsm, RaftApply, RaftFsmAdapter,
-    RaftFsmApplyEntryKind, RaftFsmApplyOutcome, RaftFsmBatchApplyReport, RaftFsmCheckpoint,
-    RaftFsmReplayReport, RaftStateMachine, RustRaftStateMachine, MATRIXRAFT_NON_BATCH,
+    matrixraft_apply_entry, matrixraft_flexible_apply_with_store,
+    matrixraft_flexible_apply_with_store_report, matrixraft_fsm_entry_kind, MatrixRaftBatchId,
+    MatrixRaftCheckpoint, MatrixRaftConfigurationApplied, MatrixRaftFlexibleApplyReport,
+    MatrixRaftFsm, MatrixRaftFsmEntry, MatrixRaftFsmEntryKind, MatrixRaftFsmIterator,
+    MatrixRaftFsmRuntimeBinding, MatrixRaftFsmRuntimeHookReport, MatrixRaftStoreFsm, RaftApply,
+    RaftFsmAdapter, RaftFsmApplyEntryKind, RaftFsmApplyOutcome, RaftFsmBatchApplyReport,
+    RaftFsmCheckpoint, RaftFsmReplayReport, RaftStateMachine, RustRaftStateMachine,
+    MATRIXRAFT_NON_BATCH,
 };
 pub use heartbeat_merge::{
     RustRaftHeartbeatAddressResolver, RustRaftHeartbeatMergeMessage, RustRaftHeartbeatMergeStats,
-    RustRaftHeartbeatMerger, RustRaftMergedHeartbeatBatch, RUSTRAFT_HEARTBEAT_MERGE_BUCKETS,
+    RustRaftHeartbeatMerger, RustRaftMergedHeartbeatBatch, MATRIXRAFT_HEARTBEAT_MERGE_BUCKETS,
 };
 pub use lease::{
     RustRaftFollowerLease, RustRaftLeaderLease, RustRaftLeaderLeaseStatus, RustRaftLeaseEpochId,
@@ -108,27 +112,28 @@ pub use lease::{
 pub use log_buffer::{RustRaftLogBuffer, RustRaftLogBufferFlush, RustRaftLogBufferRelease};
 pub use mailbox::{
     RustRaftMailBox, RustRaftMailBoxFetchPolicy, RustRaftMailPriority,
-    RUSTRAFT_MAILBOX_MAX_TIMEOUT_MS,
+    MATRIXRAFT_MAILBOX_MAX_TIMEOUT_MS,
 };
 pub use membership::{
-    rustraft_learner_promotion_decision, rustraft_membership_readiness_report,
-    rustraft_membership_semantics_evidence_artifact, rustraft_membership_transition_missing,
-    rustraft_validate_membership_semantics_evidence_artifact, RaftLearnerAutoPromoteReport,
+    matrixraft_learner_promotion_decision, matrixraft_membership_readiness_report,
+    matrixraft_membership_semantics_evidence_artifact, matrixraft_membership_transition_missing,
+    matrixraft_validate_membership_semantics_evidence_artifact, RaftLearnerAutoPromoteReport,
     RaftLearnerAutoPromoteState, RaftLearnerCatchUpLoopReport, RaftWitnessQuorumReport,
 };
 pub use metrics::{
-    rustraft_alert_rules, rustraft_alert_rules_json, rustraft_debug_bundle_contract,
-    rustraft_debug_bundle_validation_prometheus, rustraft_debug_snapshot,
-    rustraft_debug_snapshot_json, rustraft_debug_snapshot_metadata_prometheus,
-    rustraft_diagnostic_log_prometheus, rustraft_grafana_dashboard,
-    rustraft_grafana_dashboard_json, rustraft_metric_names, rustraft_observability_provisioning,
-    rustraft_observability_provisioning_json, rustraft_observability_provisioning_runbook_steps,
-    rustraft_observability_provisioning_validation_prometheus,
-    rustraft_operator_runbook_prometheus, rustraft_operator_runbook_steps,
-    rustraft_operator_triage_prometheus, rustraft_operator_triage_summary,
-    rustraft_optimization_report_prometheus, rustraft_validate_debug_snapshot,
-    rustraft_validate_debug_snapshot_json, rustraft_validate_observability_provisioning,
-    rustraft_validate_observability_provisioning_json, RustRaftAlertRule,
+    matrixraft_alert_rules, matrixraft_alert_rules_json, matrixraft_debug_bundle_contract,
+    matrixraft_debug_bundle_validation_prometheus, matrixraft_debug_snapshot,
+    matrixraft_debug_snapshot_json, matrixraft_debug_snapshot_metadata_prometheus,
+    matrixraft_diagnostic_log_prometheus, matrixraft_grafana_dashboard,
+    matrixraft_grafana_dashboard_json, matrixraft_metric_names,
+    matrixraft_observability_provisioning, matrixraft_observability_provisioning_json,
+    matrixraft_observability_provisioning_runbook_steps,
+    matrixraft_observability_provisioning_validation_prometheus,
+    matrixraft_operator_runbook_prometheus, matrixraft_operator_runbook_steps,
+    matrixraft_operator_triage_prometheus, matrixraft_operator_triage_summary,
+    matrixraft_optimization_report_prometheus, matrixraft_validate_debug_snapshot,
+    matrixraft_validate_debug_snapshot_json, matrixraft_validate_observability_provisioning,
+    matrixraft_validate_observability_provisioning_json, RustRaftAlertRule,
     RustRaftDebugBundleContract, RustRaftDebugBundleValidationReport, RustRaftDebugSnapshot,
     RustRaftGrafanaDashboard, RustRaftGrafanaPanel, RustRaftMetricNames,
     RustRaftObservabilityProvisioning, RustRaftOperatorRunbookStep, RustRaftOperatorTriageSummary,
@@ -136,18 +141,18 @@ pub use metrics::{
 };
 pub use node::{
     RustRaftConsensus, RustRaftRequestTimer, RustRaftTickAdmission, RustRaftTickBackpressure,
-    RustRaftTimerTask, RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS,
+    RustRaftTimerTask, MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS,
 };
 pub use operational_evidence::{
-    rustraft_baseline_raft_operational_evidence_bundle,
-    rustraft_validate_baseline_raft_operational_evidence_bundle,
+    matrixraft_baseline_raft_operational_evidence_bundle,
+    matrixraft_validate_baseline_raft_operational_evidence_bundle,
     RustRaftBaselineRaftOperationalEvidenceBundle,
     RustRaftBaselineRaftOperationalEvidenceBundleValidationReport,
 };
 pub use pipeline::{
-    rustraft_apply_batch_outcome_like_matrixraft, rustraft_peer_pipeline_status_from_observed,
-    rustraft_pipeline_evidence, rustraft_replication_pipeline_evidence_artifact,
-    rustraft_validate_replication_pipeline_evidence_artifact, RaftInflightAppend,
+    matrixraft_apply_batch_outcome, matrixraft_peer_pipeline_status_from_observed,
+    matrixraft_pipeline_evidence, matrixraft_replication_pipeline_evidence_artifact,
+    matrixraft_validate_replication_pipeline_evidence_artifact, RaftInflightAppend,
     RaftPeerPipelineState, RaftReplicationPipeline, RaftSnapshotTransferState,
     RustRaftApplyBatchOutcome, RustRaftApplyBatchStatus, RustRaftObservedPeerPipeline,
     RustRaftPeerPipelineStatus, RustRaftPeerProgressState, RustRaftPipelineEvidence,
@@ -159,30 +164,30 @@ pub use rate_limit::{
     RustRaftRateLimiterStats,
 };
 pub use read_safety::{
-    rustraft_append_safety_decision, rustraft_applied_index_fence_report,
-    rustraft_bounded_stale_read_report, rustraft_lease_read_eligibility_report,
-    rustraft_read_safety_decision, rustraft_read_safety_evidence_artifact,
-    rustraft_read_safety_runtime_decision, rustraft_validate_read_safety_evidence_artifact,
+    matrixraft_append_safety_decision, matrixraft_applied_index_fence_report,
+    matrixraft_bounded_stale_read_report, matrixraft_lease_read_eligibility_report,
+    matrixraft_read_safety_decision, matrixraft_read_safety_evidence_artifact,
+    matrixraft_read_safety_runtime_decision, matrixraft_validate_read_safety_evidence_artifact,
     RustRaftPendingReadIndex, RustRaftPendingReadIndexQueue, RustRaftPendingReadIndexResult,
 };
 pub use readiness::{
-    rustraft_baseline_raft_parity_matrix, rustraft_baseline_raft_parity_surface,
-    rustraft_baseline_raft_reference_policy, rustraft_benchmark_interface_names,
-    rustraft_compatibility_report_names, rustraft_embedding_examples, rustraft_open_source_surface,
-    rustraft_parity_contract, rustraft_parity_report, rustraft_parity_report_names,
-    rustraft_public_api_contract, rustraft_public_module_names, rustraft_readiness_evidence,
-    rustraft_require_production_ready, rustraft_requirements, rustraft_standalone_readiness_report,
-    rustraft_temporalstore_adapter_shape, rustraft_temporalstore_extraction_plan,
-    rustraft_validate_deployment_mode, rustraft_validate_deployment_readiness,
-    RustRaftBaselineRaftParityItem, RustRaftBaselineRaftParityStatus,
-    RustRaftBaselineRaftReferencePolicy, RustRaftDeploymentMode, RustRaftExtractionSlice,
-    RustRaftExtractionStatus, RustRaftOpenSourceSurface, RustRaftParityContract,
-    RustRaftParityReport, RustRaftProcessRolloutReadinessReport, RustRaftProductionReadinessError,
-    RustRaftProductionReadinessInput, RustRaftProductionReadinessReport, RustRaftProductionStatus,
-    RustRaftPublicApiContract, RustRaftReadinessEvidence, RustRaftReadinessSnapshot,
-    RustRaftRequirementCategory, RustRaftSemanticRequirement, RustRaftStandaloneCapability,
-    RustRaftStandaloneReadinessReport, RustRaftTemporalStoreAdapterShape,
-    RustRaftTemporalStoreExtractionPlan,
+    matrixraft_baseline_raft_parity_matrix, matrixraft_baseline_raft_parity_surface,
+    matrixraft_baseline_raft_reference_policy, matrixraft_benchmark_interface_names,
+    matrixraft_compatibility_report_names, matrixraft_embedding_examples,
+    matrixraft_open_source_surface, matrixraft_parity_contract, matrixraft_parity_report,
+    matrixraft_parity_report_names, matrixraft_public_api_contract, matrixraft_public_module_names,
+    matrixraft_readiness_evidence, matrixraft_require_production_ready, matrixraft_requirements,
+    matrixraft_standalone_readiness_report, matrixraft_temporalstore_adapter_shape,
+    matrixraft_temporalstore_extraction_plan, matrixraft_validate_deployment_mode,
+    matrixraft_validate_deployment_readiness, RustRaftBaselineRaftParityItem,
+    RustRaftBaselineRaftParityStatus, RustRaftBaselineRaftReferencePolicy, RustRaftDeploymentMode,
+    RustRaftExtractionSlice, RustRaftExtractionStatus, RustRaftOpenSourceSurface,
+    RustRaftParityContract, RustRaftParityReport, RustRaftProcessRolloutReadinessReport,
+    RustRaftProductionReadinessError, RustRaftProductionReadinessInput,
+    RustRaftProductionReadinessReport, RustRaftProductionStatus, RustRaftPublicApiContract,
+    RustRaftReadinessEvidence, RustRaftReadinessSnapshot, RustRaftRequirementCategory,
+    RustRaftSemanticRequirement, RustRaftStandaloneCapability, RustRaftStandaloneReadinessReport,
+    RustRaftTemporalStoreAdapterShape, RustRaftTemporalStoreExtractionPlan,
 };
 pub use scheduler::{
     RustRaftApplyResult, RustRaftApplySnapshotTask, RustRaftApplyTask, RustRaftFlushTask,
@@ -190,32 +195,32 @@ pub use scheduler::{
     RustRaftSchedulerTask, RustRaftStepDownSignal, RustRaftTriggerSnapshotTask,
 };
 pub use snapshot::{
-    rustraft_snapshot_lifecycle_evidence, rustraft_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_snapshot_floor_log_matching, rustraft_validate_snapshot_install,
-    rustraft_validate_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_snapshot_tail_catchup, RustRaftSnapshotLifecycleEvidence,
+    matrixraft_snapshot_lifecycle_evidence, matrixraft_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_snapshot_floor_log_matching, matrixraft_validate_snapshot_install,
+    matrixraft_validate_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_snapshot_tail_catchup, RustRaftSnapshotLifecycleEvidence,
     RustRaftSnapshotLifecycleEvidenceArtifact, RustRaftSnapshotLifecycleEvidenceValidationReport,
 };
 pub use status::{
-    rustraft_admin_diagnostic_json_lines, rustraft_admin_diagnostic_log_entries,
-    rustraft_admin_fatal_blocker_report, rustraft_admin_status_surface_evidence,
-    rustraft_apply_health, rustraft_capability_evidence, rustraft_capability_evidence_from_fields,
-    rustraft_cluster_status_report, rustraft_fatal_blocker_report,
-    rustraft_leader_transfer_admission, rustraft_optimization_report, rustraft_replication_health,
-    rustraft_runtime_admin_report, rustraft_runtime_capability_report_from_evidence,
-    rustraft_runtime_local_status_report, RaftApplyHealth, RaftCapabilityEvidence,
-    RaftClusterStatusReport, RaftHealthStatus, RaftLeaderTransferAdmission,
-    RaftLeaderTransferAdmissionKind, RaftLeaderTransferState, RaftPeerRuntimeState,
-    RaftReplicationHealth, RaftRuntimeAdminReport, RaftRuntimeLocalStatusReport,
-    RaftRuntimeTimerStatus, RustRaftAdminStatusSurfaceEvidence, RustRaftAdminStatusSurfaceInput,
-    RustRaftBaselineRaftRuntimeCapabilityReport, RustRaftBlocker, RustRaftBlockerSeverity,
-    RustRaftDiagnosticLogEntry, RustRaftDiagnosticSeverity, RustRaftFatalBlockerReport,
-    RustRaftOptimizationHint, RustRaftOptimizationHintSeverity, RustRaftOptimizationReport,
-    RustRaftProcessNodeEvidence, RustRaftProcessOperationalSemanticsEvidence,
-    RustRaftProcessReadinessBlocker,
+    matrixraft_admin_diagnostic_json_lines, matrixraft_admin_diagnostic_log_entries,
+    matrixraft_admin_fatal_blocker_report, matrixraft_admin_status_surface_evidence,
+    matrixraft_apply_health, matrixraft_capability_evidence,
+    matrixraft_capability_evidence_from_fields, matrixraft_cluster_status_report,
+    matrixraft_fatal_blocker_report, matrixraft_leader_transfer_admission,
+    matrixraft_optimization_report, matrixraft_replication_health, matrixraft_runtime_admin_report,
+    matrixraft_runtime_capability_report_from_evidence, matrixraft_runtime_local_status_report,
+    RaftApplyHealth, RaftCapabilityEvidence, RaftClusterStatusReport, RaftHealthStatus,
+    RaftLeaderTransferAdmission, RaftLeaderTransferAdmissionKind, RaftLeaderTransferState,
+    RaftPeerRuntimeState, RaftReplicationHealth, RaftRuntimeAdminReport,
+    RaftRuntimeLocalStatusReport, RaftRuntimeTimerStatus, RustRaftAdminStatusSurfaceEvidence,
+    RustRaftAdminStatusSurfaceInput, RustRaftBaselineRaftRuntimeCapabilityReport, RustRaftBlocker,
+    RustRaftBlockerSeverity, RustRaftDiagnosticLogEntry, RustRaftDiagnosticSeverity,
+    RustRaftFatalBlockerReport, RustRaftOptimizationHint, RustRaftOptimizationHintSeverity,
+    RustRaftOptimizationReport, RustRaftProcessNodeEvidence,
+    RustRaftProcessOperationalSemanticsEvidence, RustRaftProcessReadinessBlocker,
 };
 pub use storage::{
-    rustraft_validate_storage_apply_fence, MatrixRaftGroupStorage, MatrixRaftLogCompactionReport,
+    matrixraft_validate_storage_apply_fence, MatrixRaftGroupStorage, MatrixRaftLogCompactionReport,
     MatrixRaftLogRange, MatrixRaftLogSegment, MatrixRaftLogSegmentEvent,
     MatrixRaftLogSegmentEventKind, MatrixRaftLogStorage, MatrixRaftLogStorageOptions,
     MatrixRaftLogStoragePrepareOptions, MatrixRaftLogStorageWriteTask,
@@ -223,23 +228,24 @@ pub use storage::{
 };
 use transport::require_transport_validation;
 pub use transport::{
-    rustraft_validate_append_entries_request, rustraft_validate_append_entries_response,
-    rustraft_validate_install_snapshot_request, rustraft_validate_install_snapshot_response,
-    rustraft_validate_read_index_request, rustraft_validate_read_index_response,
-    rustraft_validate_tcp_transport_request, rustraft_validate_vote_request,
-    rustraft_validate_vote_response, RaftTransport, RustRaftTransport,
+    matrixraft_validate_append_entries_request, matrixraft_validate_append_entries_response,
+    matrixraft_validate_install_snapshot_request, matrixraft_validate_install_snapshot_response,
+    matrixraft_validate_read_index_request, matrixraft_validate_read_index_response,
+    matrixraft_validate_tcp_transport_request, matrixraft_validate_vote_request,
+    matrixraft_validate_vote_response, RaftTransport, RustRaftTransport,
 };
 pub use unique_id::{
-    RustRaftUniqueIdGenerator, RustRaftUniqueIdParts, RUSTRAFT_UNIQUE_ID_COUNTER_BITS,
-    RUSTRAFT_UNIQUE_ID_COUNTER_MASK, RUSTRAFT_UNIQUE_ID_MEMBER_BITS,
-    RUSTRAFT_UNIQUE_ID_MEMBER_MASK, RUSTRAFT_UNIQUE_ID_TIMESTAMP_BITS,
-    RUSTRAFT_UNIQUE_ID_TIMESTAMP_MASK,
+    RustRaftUniqueIdGenerator, RustRaftUniqueIdParts, MATRIXRAFT_UNIQUE_ID_COUNTER_BITS,
+    MATRIXRAFT_UNIQUE_ID_COUNTER_MASK, MATRIXRAFT_UNIQUE_ID_MEMBER_BITS,
+    MATRIXRAFT_UNIQUE_ID_MEMBER_MASK, MATRIXRAFT_UNIQUE_ID_TIMESTAMP_BITS,
+    MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK,
 };
 pub use wal::{
-    rustraft_recover_latest_wal_record, rustraft_validate_apply_snapshot_fence,
-    rustraft_validate_hard_state_persistence, rustraft_validate_wal_lifecycle_evidence_artifact,
-    rustraft_wal_checksum, rustraft_wal_checksum_format, rustraft_wal_checksum_valid,
-    rustraft_wal_lifecycle_evidence, rustraft_wal_lifecycle_evidence_artifact,
+    matrixraft_recover_latest_wal_record, matrixraft_validate_apply_snapshot_fence,
+    matrixraft_validate_hard_state_persistence,
+    matrixraft_validate_wal_lifecycle_evidence_artifact, matrixraft_wal_checksum,
+    matrixraft_wal_checksum_format, matrixraft_wal_checksum_valid,
+    matrixraft_wal_lifecycle_evidence, matrixraft_wal_lifecycle_evidence_artifact,
     RaftLogRetainedRange, RaftWalChecksumFormat, RaftWalCompactionReport, RaftWalRecord,
     RaftWalRecoveryReport, RaftWalSegment, RaftWalSegmentIndex, RaftWalWriteReport,
     RustRaftWalLifecycleEvidence, RustRaftWalLifecycleEvidenceArtifact,

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-pub const RUSTRAFT_MAILBOX_MAX_TIMEOUT_MS: u64 = i64::MAX as u64;
+pub const MATRIXRAFT_MAILBOX_MAX_TIMEOUT_MS: u64 = i64::MAX as u64;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
@@ -40,7 +40,7 @@ impl Default for RustRaftMailBoxFetchPolicy {
     fn default() -> Self {
         Self {
             limit: 1,
-            timeout_ms: RUSTRAFT_MAILBOX_MAX_TIMEOUT_MS,
+            timeout_ms: MATRIXRAFT_MAILBOX_MAX_TIMEOUT_MS,
             include_until: RustRaftMailPriority::Urgent,
         }
     }
@@ -111,7 +111,7 @@ impl<Mail> RustRaftMailBox<Mail> {
 
     pub fn fetch(&self, policy: RustRaftMailBoxFetchPolicy) -> Vec<Mail> {
         let mut inner = self.inner.lock().expect("mailbox mutex poisoned");
-        if !inner.has_new_mail() && policy.timeout_ms == RUSTRAFT_MAILBOX_MAX_TIMEOUT_MS {
+        if !inner.has_new_mail() && policy.timeout_ms == MATRIXRAFT_MAILBOX_MAX_TIMEOUT_MS {
             while !inner.has_new_mail() {
                 inner = self.readable.wait(inner).expect("mailbox mutex poisoned");
             }

--- a/src/membership.rs
+++ b/src/membership.rs
@@ -60,7 +60,7 @@ pub struct RaftWitnessQuorumReport {
     pub witnesses: Vec<RustRaftNodeId>,
 }
 
-pub fn rustraft_membership_readiness_report(
+pub fn matrixraft_membership_readiness_report(
     transitions: &[RustRaftMembershipTransitionEvidence],
 ) -> RustRaftMembershipReadinessReport {
     let required = [
@@ -108,7 +108,7 @@ pub fn rustraft_membership_readiness_report(
             });
             continue;
         };
-        let transition_missing = rustraft_membership_transition_missing(evidence);
+        let transition_missing = matrixraft_membership_transition_missing(evidence);
         if transition_missing.is_empty() {
             satisfied.push(id);
             decisions.push(RustRaftMembershipTransitionDecision {
@@ -140,7 +140,7 @@ pub fn rustraft_membership_readiness_report(
     }
 }
 
-pub fn rustraft_membership_transition_missing(
+pub fn matrixraft_membership_transition_missing(
     evidence: &RustRaftMembershipTransitionEvidence,
 ) -> Vec<String> {
     let mut missing = Vec::new();
@@ -200,7 +200,7 @@ pub fn rustraft_membership_transition_missing(
             if !evidence.joint_consensus_used {
                 missing.push("joint_consensus_used".to_string());
             }
-            if !rustraft_joint_quorum_commit_proven(evidence) {
+            if !matrixraft_joint_quorum_commit_proven(evidence) {
                 missing.push("joint_quorum_commit_proven".to_string());
             }
             if evidence.added_nodes.is_empty() {
@@ -217,7 +217,7 @@ pub fn rustraft_membership_transition_missing(
             if !evidence.joint_consensus_used {
                 missing.push("joint_consensus_used".to_string());
             }
-            if !rustraft_joint_quorum_commit_proven(evidence) {
+            if !matrixraft_joint_quorum_commit_proven(evidence) {
                 missing.push("joint_quorum_commit_proven".to_string());
             }
             if evidence.failed_or_removed_nodes.is_empty() {
@@ -237,7 +237,7 @@ pub fn rustraft_membership_transition_missing(
     missing
 }
 
-fn rustraft_joint_quorum_commit_proven(evidence: &RustRaftMembershipTransitionEvidence) -> bool {
+fn matrixraft_joint_quorum_commit_proven(evidence: &RustRaftMembershipTransitionEvidence) -> bool {
     let joint = RustRaftJointMembership {
         old_voters: evidence.before_voters.clone(),
         new_voters: evidence.after_voters.clone(),
@@ -250,7 +250,7 @@ fn rustraft_joint_quorum_commit_proven(evidence: &RustRaftMembershipTransitionEv
         && computed.joint_quorum_reached
 }
 
-pub fn rustraft_learner_promotion_decision(
+pub fn matrixraft_learner_promotion_decision(
     status: &RustRaftStatusSnapshot,
     learner_id: u64,
     max_lag: u64,
@@ -279,7 +279,7 @@ pub fn rustraft_learner_promotion_decision(
     }
 }
 
-fn rustraft_membership_semantics_transition(
+fn matrixraft_membership_semantics_transition(
     transition: RustRaftMembershipTransitionKind,
 ) -> RustRaftMembershipTransitionEvidence {
     let (before_voters, after_voters, before_learners, after_learners, added, removed) =
@@ -369,11 +369,11 @@ fn rustraft_membership_semantics_transition(
     }
 }
 
-pub fn rustraft_membership_semantics_evidence_artifact(
+pub fn matrixraft_membership_semantics_evidence_artifact(
 ) -> RustRaftMembershipSemanticsEvidenceArtifact {
     RustRaftMembershipSemanticsEvidenceArtifact {
         schema: "rustraft.membership_semantics_evidence.v1".to_string(),
-        learner_add: rustraft_membership_semantics_transition(
+        learner_add: matrixraft_membership_semantics_transition(
             RustRaftMembershipTransitionKind::ScaleUp,
         ),
         learner_catchup: RustRaftLearnerPromotionDecision {
@@ -383,13 +383,13 @@ pub fn rustraft_membership_semantics_evidence_artifact(
             required_match_index: 144,
             reason: "caught_up".to_string(),
         },
-        learner_promote: rustraft_membership_semantics_transition(
+        learner_promote: matrixraft_membership_semantics_transition(
             RustRaftMembershipTransitionKind::ScaleUp,
         ),
-        leader_transfer: rustraft_membership_semantics_transition(
+        leader_transfer: matrixraft_membership_semantics_transition(
             RustRaftMembershipTransitionKind::Failover,
         ),
-        voter_remove: rustraft_membership_semantics_transition(
+        voter_remove: matrixraft_membership_semantics_transition(
             RustRaftMembershipTransitionKind::ScaleDown,
         ),
         auto_promote_learner_observed: true,
@@ -402,7 +402,7 @@ pub fn rustraft_membership_semantics_evidence_artifact(
     }
 }
 
-pub fn rustraft_validate_membership_semantics_evidence_artifact(
+pub fn matrixraft_validate_membership_semantics_evidence_artifact(
     artifact: &RustRaftMembershipSemanticsEvidenceArtifact,
 ) -> RustRaftMembershipSemanticsEvidenceValidationReport {
     let schema_valid = artifact.schema == "rustraft.membership_semantics_evidence.v1";
@@ -416,7 +416,7 @@ pub fn rustraft_validate_membership_semantics_evidence_artifact(
             .contains(&artifact.learner_catchup.learner_id)
         && artifact.learner_add.joint_consensus_used
         && artifact.learner_add.new_majority_reached
-        && rustraft_joint_quorum_commit_proven(&artifact.learner_add);
+        && matrixraft_joint_quorum_commit_proven(&artifact.learner_add);
     let learner_caught_up = artifact.learner_catchup.promotable
         && artifact.learner_catchup.learner_match_index
             >= artifact.learner_catchup.required_match_index
@@ -446,7 +446,7 @@ pub fn rustraft_validate_membership_semantics_evidence_artifact(
             })
         && artifact.voter_remove.old_majority_preserved
         && artifact.voter_remove.new_majority_reached
-        && rustraft_joint_quorum_commit_proven(&artifact.voter_remove);
+        && matrixraft_joint_quorum_commit_proven(&artifact.voter_remove);
     let witness_role_accounted_for = artifact.witness_role_supported
         || artifact
             .witness_role_blocker

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,11 +8,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::rustraft_baseline_raft_runtime_capability_prometheus;
+pub use crate::matrixraft_baseline_raft_runtime_capability_prometheus;
 use crate::status::{
-    rustraft_admin_diagnostic_log_entries, rustraft_optimization_report, RaftRuntimeAdminReport,
-    RustRaftAdminStatusSurfaceInput, RustRaftDiagnosticLogEntry, RustRaftDiagnosticSeverity,
-    RustRaftOptimizationHintSeverity, RustRaftOptimizationReport,
+    matrixraft_admin_diagnostic_log_entries, matrixraft_optimization_report,
+    RaftRuntimeAdminReport, RustRaftAdminStatusSurfaceInput, RustRaftDiagnosticLogEntry,
+    RustRaftDiagnosticSeverity, RustRaftOptimizationHintSeverity, RustRaftOptimizationReport,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -176,7 +176,7 @@ pub struct RustRaftDebugSnapshot {
     pub runbook_steps: Vec<RustRaftOperatorRunbookStep>,
 }
 
-pub fn rustraft_metric_names() -> RustRaftMetricNames {
+pub fn matrixraft_metric_names() -> RustRaftMetricNames {
     RustRaftMetricNames {
         ready: "rustraft_ready".to_string(),
         append_latency_ms: "rustraft_append_latency_ms".to_string(),
@@ -242,8 +242,8 @@ pub fn rustraft_metric_names() -> RustRaftMetricNames {
     }
 }
 
-pub fn rustraft_alert_rules() -> Vec<RustRaftAlertRule> {
-    let metrics = rustraft_metric_names();
+pub fn matrixraft_alert_rules() -> Vec<RustRaftAlertRule> {
+    let metrics = matrixraft_metric_names();
     vec![
         RustRaftAlertRule {
             alert: "RustRaftOptimizationNotReady".to_string(),
@@ -395,13 +395,13 @@ pub fn rustraft_alert_rules() -> Vec<RustRaftAlertRule> {
     ]
 }
 
-pub fn rustraft_alert_rules_json() -> String {
-    serde_json::to_string_pretty(&rustraft_alert_rules())
+pub fn matrixraft_alert_rules_json() -> String {
+    serde_json::to_string_pretty(&matrixraft_alert_rules())
         .expect("RustRaft alert rules must serialize")
 }
 
-pub fn rustraft_observability_provisioning() -> RustRaftObservabilityProvisioning {
-    let metrics = rustraft_metric_names();
+pub fn matrixraft_observability_provisioning() -> RustRaftObservabilityProvisioning {
+    let metrics = matrixraft_metric_names();
     RustRaftObservabilityProvisioning {
         service: "rustraft".to_string(),
         prometheus_format: "prometheus_text_v0.0.4".to_string(),
@@ -489,15 +489,15 @@ pub fn rustraft_observability_provisioning() -> RustRaftObservabilityProvisionin
             "provisioning_runbook_prometheus".to_string(),
             "support_envelope_validation_prometheus".to_string(),
         ],
-        dashboard: rustraft_grafana_dashboard(),
-        alert_rules: rustraft_alert_rules(),
-        runbook_steps: rustraft_observability_provisioning_runbook_steps(),
-        debug_bundle_contract: rustraft_debug_bundle_contract(),
+        dashboard: matrixraft_grafana_dashboard(),
+        alert_rules: matrixraft_alert_rules(),
+        runbook_steps: matrixraft_observability_provisioning_runbook_steps(),
+        debug_bundle_contract: matrixraft_debug_bundle_contract(),
         sample_artifact_command: "cargo run --example debug_artifacts".to_string(),
     }
 }
 
-pub fn rustraft_observability_provisioning_runbook_steps() -> Vec<RustRaftOperatorRunbookStep> {
+pub fn matrixraft_observability_provisioning_runbook_steps() -> Vec<RustRaftOperatorRunbookStep> {
     let triage = RustRaftOperatorTriageSummary {
         status: "needs_attention".to_string(),
         severity: "critical".to_string(),
@@ -507,7 +507,7 @@ pub fn rustraft_observability_provisioning_runbook_steps() -> Vec<RustRaftOperat
         diagnostic_warning_count: 1,
         critical_optimization_count: 1,
         warning_optimization_count: 1,
-        alert_rule_count: rustraft_alert_rules().len(),
+        alert_rule_count: matrixraft_alert_rules().len(),
         top_diagnostic_target: Some("rustraft.observability".to_string()),
         top_diagnostic_message: Some("observability_contract_stale".to_string()),
         top_alert: Some("RustRaftOperatorTriageNeedsAttention".to_string()),
@@ -521,15 +521,15 @@ pub fn rustraft_observability_provisioning_runbook_steps() -> Vec<RustRaftOperat
         hints: vec![],
     };
     let mut steps =
-        rustraft_operator_runbook_steps(&triage, &optimization, &rustraft_alert_rules());
-    steps.push(rustraft_runbook_step(
+        matrixraft_operator_runbook_steps(&triage, &optimization, &matrixraft_alert_rules());
+    steps.push(matrixraft_runbook_step(
         "refresh_debug_snapshot",
         "warning",
         "debug_bundle",
         "Regenerate the RustRaft debug artifact when validation fails, snapshot age is stale, RustRaftDebugSnapshotFreshnessLow warns, or RustRaftDebugSnapshotFreshnessLost fires.",
         "rustraft_debug_bundle_validation_ready is 1, rustraft_debug_snapshot_age_ms is below rustraft_debug_snapshot_max_age_ms, rustraft_debug_snapshot_stale_after_unix_ms is in the future, rustraft_debug_snapshot_remaining_fresh_ms is above rustraft_debug_snapshot_low_fresh_ms, rustraft_debug_snapshot_low_fresh is 1, and rustraft_debug_snapshot_fresh is 1.",
     ));
-    steps.push(rustraft_runbook_step(
+    steps.push(matrixraft_runbook_step(
         "validate_support_envelope",
         "warning",
         "support_envelope",
@@ -539,15 +539,15 @@ pub fn rustraft_observability_provisioning_runbook_steps() -> Vec<RustRaftOperat
     steps
 }
 
-pub fn rustraft_observability_provisioning_json() -> String {
-    serde_json::to_string_pretty(&rustraft_observability_provisioning())
+pub fn matrixraft_observability_provisioning_json() -> String {
+    serde_json::to_string_pretty(&matrixraft_observability_provisioning())
         .expect("RustRaft observability provisioning must serialize")
 }
 
-pub fn rustraft_validate_observability_provisioning(
+pub fn matrixraft_validate_observability_provisioning(
     provisioning: &RustRaftObservabilityProvisioning,
 ) -> RustRaftDebugBundleValidationReport {
-    let expected = rustraft_observability_provisioning();
+    let expected = matrixraft_observability_provisioning();
     let mut issues = Vec::new();
 
     if provisioning != &expected {
@@ -574,13 +574,13 @@ pub fn rustraft_validate_observability_provisioning(
     if provisioning.dashboard != expected.dashboard {
         issues.push("observability_dashboard_mismatch".to_string());
     }
-    if rustraft_dashboard_has_unadvertised_metrics(provisioning) {
+    if matrixraft_dashboard_has_unadvertised_metrics(provisioning) {
         issues.push("observability_dashboard_metric_not_advertised".to_string());
     }
     if provisioning.alert_rules != expected.alert_rules {
         issues.push("observability_alert_rules_mismatch".to_string());
     }
-    if rustraft_alert_rules_have_unadvertised_metrics(provisioning) {
+    if matrixraft_alert_rules_have_unadvertised_metrics(provisioning) {
         issues.push("observability_alert_metric_not_advertised".to_string());
     }
     if provisioning.runbook_steps != expected.runbook_steps {
@@ -593,10 +593,10 @@ pub fn rustraft_validate_observability_provisioning(
         issues.push("observability_sample_artifact_command_mismatch".to_string());
     }
 
-    rustraft_debug_bundle_validation_report(issues)
+    matrixraft_debug_bundle_validation_report(issues)
 }
 
-fn rustraft_alert_rules_have_unadvertised_metrics(
+fn matrixraft_alert_rules_have_unadvertised_metrics(
     provisioning: &RustRaftObservabilityProvisioning,
 ) -> bool {
     let advertised_metrics: BTreeSet<&str> = provisioning
@@ -607,12 +607,12 @@ fn rustraft_alert_rules_have_unadvertised_metrics(
         .collect();
 
     provisioning.alert_rules.iter().any(|rule| {
-        rustraft_alert_expr_metric_name(&rule.expr)
+        matrixraft_alert_expr_metric_name(&rule.expr)
             .is_none_or(|metric| !advertised_metrics.contains(metric))
     })
 }
 
-fn rustraft_dashboard_has_unadvertised_metrics(
+fn matrixraft_dashboard_has_unadvertised_metrics(
     provisioning: &RustRaftObservabilityProvisioning,
 ) -> bool {
     let advertised_metrics: BTreeSet<&str> = provisioning
@@ -625,11 +625,11 @@ fn rustraft_dashboard_has_unadvertised_metrics(
     provisioning.dashboard.panels.iter().any(|panel| {
         !advertised_metrics
             .iter()
-            .any(|metric| rustraft_expr_references_metric(&panel.expr, metric))
+            .any(|metric| matrixraft_expr_references_metric(&panel.expr, metric))
     })
 }
 
-fn rustraft_expr_references_metric(expr: &str, metric: &str) -> bool {
+fn matrixraft_expr_references_metric(expr: &str, metric: &str) -> bool {
     if let Some(start) = expr.find(metric) {
         let end = start + metric.len();
         let before_ok = start == 0
@@ -649,7 +649,7 @@ fn rustraft_expr_references_metric(expr: &str, metric: &str) -> bool {
     }
 }
 
-fn rustraft_alert_expr_metric_name(expr: &str) -> Option<&str> {
+fn matrixraft_alert_expr_metric_name(expr: &str) -> Option<&str> {
     let start = expr.find(|ch: char| ch.is_ascii_alphabetic() || ch == '_')?;
     let end = expr[start..]
         .find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
@@ -658,22 +658,22 @@ fn rustraft_alert_expr_metric_name(expr: &str) -> Option<&str> {
     Some(&expr[start..end])
 }
 
-pub fn rustraft_validate_observability_provisioning_json(
+pub fn matrixraft_validate_observability_provisioning_json(
     json: &str,
 ) -> RustRaftDebugBundleValidationReport {
     match serde_json::from_str::<RustRaftObservabilityProvisioning>(json) {
-        Ok(provisioning) => rustraft_validate_observability_provisioning(&provisioning),
-        Err(_) => rustraft_debug_bundle_validation_report(vec![
+        Ok(provisioning) => matrixraft_validate_observability_provisioning(&provisioning),
+        Err(_) => matrixraft_debug_bundle_validation_report(vec![
             "observability_provisioning_json_parse_error".to_string(),
         ]),
     }
 }
 
-pub fn rustraft_observability_provisioning_validation_prometheus(
+pub fn matrixraft_observability_provisioning_validation_prometheus(
     report: &RustRaftDebugBundleValidationReport,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let mut metric_count = 0_u64;
 
@@ -722,19 +722,19 @@ pub fn rustraft_observability_provisioning_validation_prometheus(
     }
 }
 
-pub fn rustraft_debug_bundle_contract() -> RustRaftDebugBundleContract {
+pub fn matrixraft_debug_bundle_contract() -> RustRaftDebugBundleContract {
     RustRaftDebugBundleContract {
-        name: "rustraft_debug_snapshot".to_string(),
+        name: "matrixraft_debug_snapshot".to_string(),
         version: 1,
         producer: "matrixraft".to_string(),
         schema: "rustraft.debug_snapshot.v1".to_string(),
     }
 }
 
-pub fn rustraft_validate_debug_snapshot(
+pub fn matrixraft_validate_debug_snapshot(
     snapshot: &RustRaftDebugSnapshot,
 ) -> RustRaftDebugBundleValidationReport {
-    let expected = rustraft_debug_bundle_contract();
+    let expected = matrixraft_debug_bundle_contract();
     let mut issues = Vec::new();
 
     if snapshot.contract != expected {
@@ -743,10 +743,10 @@ pub fn rustraft_validate_debug_snapshot(
     if snapshot.generated_at_unix_ms == 0 {
         issues.push("generated_at_missing".to_string());
     } else if snapshot.generated_at_unix_ms
-        > rustraft_debug_snapshot_now_unix_ms().saturating_add(60_000)
+        > matrixraft_debug_snapshot_now_unix_ms().saturating_add(60_000)
     {
         issues.push("generated_at_in_future".to_string());
-    } else if rustraft_debug_snapshot_now_unix_ms().saturating_sub(snapshot.generated_at_unix_ms)
+    } else if matrixraft_debug_snapshot_now_unix_ms().saturating_sub(snapshot.generated_at_unix_ms)
         > 3_600_000
     {
         issues.push("generated_at_stale".to_string());
@@ -759,11 +759,11 @@ pub fn rustraft_validate_debug_snapshot(
     }
     let expected_prometheus_metric_count = 3
         + snapshot.optimization.hints.len() as u64
-        + rustraft_optimization_component_hint_counts(&snapshot.optimization).len() as u64;
+        + matrixraft_optimization_component_hint_counts(&snapshot.optimization).len() as u64;
     if snapshot.optimization_prometheus.metric_count != expected_prometheus_metric_count {
         issues.push("prometheus_metric_count_mismatch".to_string());
     }
-    let metric_names = rustraft_metric_names();
+    let metric_names = matrixraft_metric_names();
     for required_metric in [
         metric_names.optimization_ready.as_str(),
         metric_names.optimization_critical_total.as_str(),
@@ -786,7 +786,7 @@ pub fn rustraft_validate_debug_snapshot(
         }
     }
     for ((component, severity), _) in
-        rustraft_optimization_component_hint_counts(&snapshot.optimization)
+        matrixraft_optimization_component_hint_counts(&snapshot.optimization)
     {
         let component_label = format!(
             "component=\"{}\"",
@@ -805,7 +805,7 @@ pub fn rustraft_validate_debug_snapshot(
     if snapshot.grafana.panels.is_empty() {
         issues.push("grafana_panels_missing".to_string());
     }
-    let expected_grafana = rustraft_grafana_dashboard();
+    let expected_grafana = matrixraft_grafana_dashboard();
     if snapshot.grafana.uid != expected_grafana.uid
         || snapshot.grafana.title != expected_grafana.title
         || snapshot.grafana.schema_version != expected_grafana.schema_version
@@ -832,7 +832,7 @@ pub fn rustraft_validate_debug_snapshot(
     if snapshot.triage.status.is_empty() {
         issues.push("triage_status_missing".to_string());
     }
-    let expected_triage = rustraft_operator_triage_summary(
+    let expected_triage = matrixraft_operator_triage_summary(
         &snapshot.diagnostics,
         &snapshot.optimization,
         &snapshot.alerts,
@@ -840,7 +840,7 @@ pub fn rustraft_validate_debug_snapshot(
     if snapshot.triage != expected_triage {
         issues.push("triage_contract_mismatch".to_string());
     }
-    if snapshot.diagnostics != rustraft_admin_diagnostic_log_entries(&snapshot.admin_report) {
+    if snapshot.diagnostics != matrixraft_admin_diagnostic_log_entries(&snapshot.admin_report) {
         issues.push("diagnostic_log_contract_mismatch".to_string());
     }
     if snapshot.diagnostic_prometheus.format != "prometheus_text_v0.0.4" {
@@ -882,7 +882,7 @@ pub fn rustraft_validate_debug_snapshot(
         );
         let severity_label = format!(
             "severity=\"{}\"",
-            rustraft_diagnostic_severity_label(entry.severity)
+            matrixraft_diagnostic_severity_label(entry.severity)
         );
         let message_label = format!(
             "message=\"{}\"",
@@ -948,7 +948,7 @@ pub fn rustraft_validate_debug_snapshot(
     if snapshot.triage.alert_rule_count != snapshot.alerts.len() {
         issues.push("triage_alert_count_mismatch".to_string());
     }
-    for expected_alert in rustraft_alert_rules() {
+    for expected_alert in matrixraft_alert_rules() {
         match snapshot
             .alerts
             .iter()
@@ -1004,7 +1004,7 @@ pub fn rustraft_validate_debug_snapshot(
         issues.push("runbook_prometheus_metrics_missing".to_string());
     }
     let expected_runbook_metric_count = snapshot.runbook_steps.len() as u64
-        + rustraft_runbook_step_counts(&snapshot.runbook_steps).len() as u64
+        + matrixraft_runbook_step_counts(&snapshot.runbook_steps).len() as u64
         + u64::from(!snapshot.runbook_steps.is_empty());
     if snapshot.runbook_prometheus.metric_count != expected_runbook_metric_count {
         issues.push("runbook_prometheus_metric_count_mismatch".to_string());
@@ -1063,8 +1063,11 @@ pub fn rustraft_validate_debug_snapshot(
             break;
         }
     }
-    let expected_runbook_steps =
-        rustraft_operator_runbook_steps(&snapshot.triage, &snapshot.optimization, &snapshot.alerts);
+    let expected_runbook_steps = matrixraft_operator_runbook_steps(
+        &snapshot.triage,
+        &snapshot.optimization,
+        &snapshot.alerts,
+    );
     if snapshot.runbook_steps.len() != expected_runbook_steps.len() {
         issues.push("runbook_step_count_mismatch".to_string());
     }
@@ -1122,21 +1125,21 @@ pub fn rustraft_validate_debug_snapshot(
         _ => issues.push("triage_status_unknown".to_string()),
     }
 
-    rustraft_debug_bundle_validation_report(issues)
+    matrixraft_debug_bundle_validation_report(issues)
 }
 
-pub fn rustraft_validate_debug_snapshot_json(json: &str) -> RustRaftDebugBundleValidationReport {
+pub fn matrixraft_validate_debug_snapshot_json(json: &str) -> RustRaftDebugBundleValidationReport {
     match serde_json::from_str::<RustRaftDebugSnapshot>(json) {
-        Ok(snapshot) => rustraft_validate_debug_snapshot(&snapshot),
-        Err(_) => rustraft_debug_bundle_validation_report(vec!["json_parse_failed".to_string()]),
+        Ok(snapshot) => matrixraft_validate_debug_snapshot(&snapshot),
+        Err(_) => matrixraft_debug_bundle_validation_report(vec!["json_parse_failed".to_string()]),
     }
 }
 
-pub fn rustraft_debug_bundle_validation_prometheus(
+pub fn matrixraft_debug_bundle_validation_prometheus(
     report: &RustRaftDebugBundleValidationReport,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let mut metric_count = 0_u64;
 
@@ -1185,7 +1188,7 @@ pub fn rustraft_debug_bundle_validation_prometheus(
     }
 }
 
-fn rustraft_debug_bundle_validation_report(
+fn matrixraft_debug_bundle_validation_report(
     issues: Vec<String>,
 ) -> RustRaftDebugBundleValidationReport {
     RustRaftDebugBundleValidationReport {
@@ -1195,14 +1198,14 @@ fn rustraft_debug_bundle_validation_report(
     }
 }
 
-fn rustraft_debug_snapshot_now_unix_ms() -> u64 {
+fn matrixraft_debug_snapshot_now_unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
         .unwrap_or(0)
 }
 
-pub fn rustraft_operator_triage_summary(
+pub fn matrixraft_operator_triage_summary(
     diagnostics: &[RustRaftDiagnosticLogEntry],
     optimization: &RustRaftOptimizationReport,
     alerts: &[RustRaftAlertRule],
@@ -1274,11 +1277,11 @@ pub fn rustraft_operator_triage_summary(
     }
 }
 
-pub fn rustraft_operator_triage_prometheus(
+pub fn matrixraft_operator_triage_prometheus(
     triage: &RustRaftOperatorTriageSummary,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let mut status_labels = labels.to_vec();
     status_labels.push(("status", triage.status.as_str()));
@@ -1380,18 +1383,18 @@ pub fn rustraft_operator_triage_prometheus(
     }
 }
 
-pub fn rustraft_diagnostic_log_prometheus(
+pub fn matrixraft_diagnostic_log_prometheus(
     diagnostics: &[RustRaftDiagnosticLogEntry],
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let mut metric_count = 0_u64;
 
     for severity in ["info", "warn", "error"] {
         let count = diagnostics
             .iter()
-            .filter(|entry| rustraft_diagnostic_severity_label(entry.severity) == severity)
+            .filter(|entry| matrixraft_diagnostic_severity_label(entry.severity) == severity)
             .count() as u64;
         let mut severity_labels = labels.to_vec();
         severity_labels.push(("severity", severity));
@@ -1409,7 +1412,7 @@ pub fn rustraft_diagnostic_log_prometheus(
         entry_labels.push(("target", entry.target.as_str()));
         entry_labels.push((
             "severity",
-            rustraft_diagnostic_severity_label(entry.severity),
+            matrixraft_diagnostic_severity_label(entry.severity),
         ));
         entry_labels.push(("message", entry.message.as_str()));
         push_metric(
@@ -1428,7 +1431,7 @@ pub fn rustraft_diagnostic_log_prometheus(
     }
 }
 
-fn rustraft_diagnostic_severity_label(severity: RustRaftDiagnosticSeverity) -> &'static str {
+fn matrixraft_diagnostic_severity_label(severity: RustRaftDiagnosticSeverity) -> &'static str {
     match severity {
         RustRaftDiagnosticSeverity::Info => "info",
         RustRaftDiagnosticSeverity::Warn => "warn",
@@ -1436,7 +1439,7 @@ fn rustraft_diagnostic_severity_label(severity: RustRaftDiagnosticSeverity) -> &
     }
 }
 
-pub fn rustraft_operator_runbook_steps(
+pub fn matrixraft_operator_runbook_steps(
     triage: &RustRaftOperatorTriageSummary,
     optimization: &RustRaftOptimizationReport,
     alerts: &[RustRaftAlertRule],
@@ -1444,7 +1447,7 @@ pub fn rustraft_operator_runbook_steps(
     let mut steps = Vec::new();
 
     if triage.diagnostic_error_count > 0 {
-        steps.push(rustraft_runbook_step(
+        steps.push(matrixraft_runbook_step(
             "inspect_error_diagnostics",
             "critical",
             "diagnostics",
@@ -1453,7 +1456,7 @@ pub fn rustraft_operator_runbook_steps(
         ));
     }
     if optimization.critical_count > 0 {
-        steps.push(rustraft_runbook_step(
+        steps.push(matrixraft_runbook_step(
             "resolve_critical_optimization_hints",
             "critical",
             "optimization",
@@ -1462,7 +1465,7 @@ pub fn rustraft_operator_runbook_steps(
         ));
     }
     if triage.severity == "critical" && alerts.iter().any(|rule| rule.severity == "critical") {
-        steps.push(rustraft_runbook_step(
+        steps.push(matrixraft_runbook_step(
             "wire_critical_alerts",
             "critical",
             "alerts",
@@ -1471,7 +1474,7 @@ pub fn rustraft_operator_runbook_steps(
         ));
     }
     if triage.diagnostic_warning_count > 0 || optimization.warning_count > 0 {
-        steps.push(rustraft_runbook_step(
+        steps.push(matrixraft_runbook_step(
             "review_warning_signals",
             "warning",
             "diagnostics",
@@ -1480,7 +1483,7 @@ pub fn rustraft_operator_runbook_steps(
         ));
     }
     if steps.is_empty() {
-        steps.push(rustraft_runbook_step(
+        steps.push(matrixraft_runbook_step(
             "continue_normal_observation",
             "info",
             "observability",
@@ -1492,15 +1495,15 @@ pub fn rustraft_operator_runbook_steps(
     steps
 }
 
-pub fn rustraft_operator_runbook_prometheus(
+pub fn matrixraft_operator_runbook_prometheus(
     steps: &[RustRaftOperatorRunbookStep],
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let mut metric_count = 0_u64;
 
-    for ((severity, target), count) in rustraft_runbook_step_counts(steps) {
+    for ((severity, target), count) in matrixraft_runbook_step_counts(steps) {
         let mut step_labels = labels.to_vec();
         step_labels.push(("severity", severity.as_str()));
         step_labels.push(("target", target.as_str()));
@@ -1546,7 +1549,7 @@ pub fn rustraft_operator_runbook_prometheus(
     }
 }
 
-fn rustraft_runbook_step_counts(
+fn matrixraft_runbook_step_counts(
     steps: &[RustRaftOperatorRunbookStep],
 ) -> BTreeMap<(String, String), u64> {
     let mut counts = BTreeMap::new();
@@ -1558,7 +1561,7 @@ fn rustraft_runbook_step_counts(
     counts
 }
 
-fn rustraft_runbook_step(
+fn matrixraft_runbook_step(
     id: &str,
     severity: &str,
     target: &str,
@@ -1574,11 +1577,11 @@ fn rustraft_runbook_step(
     }
 }
 
-pub fn rustraft_optimization_report_prometheus(
+pub fn matrixraft_optimization_report_prometheus(
     report: &RustRaftOptimizationReport,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let mut metric_count = 0_u64;
 
@@ -1617,7 +1620,7 @@ pub fn rustraft_optimization_report_prometheus(
         push_metric(&mut text, &metrics.optimization_hint_total, &hint_labels, 1);
         metric_count += 1;
     }
-    for ((component, severity), count) in rustraft_optimization_component_hint_counts(report) {
+    for ((component, severity), count) in matrixraft_optimization_component_hint_counts(report) {
         let mut component_labels = labels.to_vec();
         component_labels.push(("component", component.as_str()));
         component_labels.push(("severity", severity.as_str()));
@@ -1637,7 +1640,7 @@ pub fn rustraft_optimization_report_prometheus(
     }
 }
 
-fn rustraft_optimization_component_hint_counts(
+fn matrixraft_optimization_component_hint_counts(
     report: &RustRaftOptimizationReport,
 ) -> BTreeMap<(String, String), u64> {
     let mut counts = BTreeMap::new();
@@ -1654,27 +1657,27 @@ fn rustraft_optimization_component_hint_counts(
     counts
 }
 
-pub fn rustraft_debug_snapshot(
+pub fn matrixraft_debug_snapshot(
     admin_report: &RaftRuntimeAdminReport,
     status_surface: &RustRaftAdminStatusSurfaceInput,
     labels: &[(&str, &str)],
 ) -> RustRaftDebugSnapshot {
-    let optimization = rustraft_optimization_report(status_surface);
-    let diagnostics = rustraft_admin_diagnostic_log_entries(admin_report);
-    let diagnostic_prometheus = rustraft_diagnostic_log_prometheus(&diagnostics, labels);
-    let alerts = rustraft_alert_rules();
-    let triage = rustraft_operator_triage_summary(&diagnostics, &optimization, &alerts);
-    let runbook_steps = rustraft_operator_runbook_steps(&triage, &optimization, &alerts);
-    let runbook_prometheus = rustraft_operator_runbook_prometheus(&runbook_steps, labels);
+    let optimization = matrixraft_optimization_report(status_surface);
+    let diagnostics = matrixraft_admin_diagnostic_log_entries(admin_report);
+    let diagnostic_prometheus = matrixraft_diagnostic_log_prometheus(&diagnostics, labels);
+    let alerts = matrixraft_alert_rules();
+    let triage = matrixraft_operator_triage_summary(&diagnostics, &optimization, &alerts);
+    let runbook_steps = matrixraft_operator_runbook_steps(&triage, &optimization, &alerts);
+    let runbook_prometheus = matrixraft_operator_runbook_prometheus(&runbook_steps, labels);
     RustRaftDebugSnapshot {
-        contract: rustraft_debug_bundle_contract(),
-        generated_at_unix_ms: rustraft_debug_snapshot_now_unix_ms(),
+        contract: matrixraft_debug_bundle_contract(),
+        generated_at_unix_ms: matrixraft_debug_snapshot_now_unix_ms(),
         admin_report: admin_report.clone(),
         diagnostics,
         diagnostic_prometheus,
-        optimization_prometheus: rustraft_optimization_report_prometheus(&optimization, labels),
+        optimization_prometheus: matrixraft_optimization_report_prometheus(&optimization, labels),
         optimization,
-        grafana: rustraft_grafana_dashboard(),
+        grafana: matrixraft_grafana_dashboard(),
         alerts,
         triage,
         runbook_prometheus,
@@ -1682,12 +1685,12 @@ pub fn rustraft_debug_snapshot(
     }
 }
 
-pub fn rustraft_debug_snapshot_json(
+pub fn matrixraft_debug_snapshot_json(
     admin_report: &RaftRuntimeAdminReport,
     status_surface: &RustRaftAdminStatusSurfaceInput,
     labels: &[(&str, &str)],
 ) -> String {
-    serde_json::to_string_pretty(&rustraft_debug_snapshot(
+    serde_json::to_string_pretty(&matrixraft_debug_snapshot(
         admin_report,
         status_surface,
         labels,
@@ -1695,14 +1698,14 @@ pub fn rustraft_debug_snapshot_json(
     .expect("RustRaft debug snapshot must serialize")
 }
 
-pub fn rustraft_debug_snapshot_metadata_prometheus(
+pub fn matrixraft_debug_snapshot_metadata_prometheus(
     snapshot: &RustRaftDebugSnapshot,
     labels: &[(&str, &str)],
 ) -> RustRaftPrometheusMetricSet {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     let mut text = String::new();
     let generated_at_unix_ms = snapshot.generated_at_unix_ms;
-    let age_ms = rustraft_debug_snapshot_now_unix_ms().saturating_sub(generated_at_unix_ms);
+    let age_ms = matrixraft_debug_snapshot_now_unix_ms().saturating_sub(generated_at_unix_ms);
     let max_age_ms = 3_600_000u64;
     let low_fresh_ms = 300_000u64;
     let stale_after_unix_ms = generated_at_unix_ms.saturating_add(3_600_000);
@@ -1754,8 +1757,8 @@ pub fn rustraft_debug_snapshot_metadata_prometheus(
     }
 }
 
-pub fn rustraft_grafana_dashboard() -> RustRaftGrafanaDashboard {
-    let metrics = rustraft_metric_names();
+pub fn matrixraft_grafana_dashboard() -> RustRaftGrafanaDashboard {
+    let metrics = matrixraft_metric_names();
     RustRaftGrafanaDashboard {
         title: "RustRaft Runtime Overview".to_string(),
         uid: "rustraft-runtime-overview".to_string(),
@@ -2308,8 +2311,8 @@ pub fn rustraft_grafana_dashboard() -> RustRaftGrafanaDashboard {
     }
 }
 
-pub fn rustraft_grafana_dashboard_json() -> String {
-    serde_json::to_string_pretty(&rustraft_grafana_dashboard())
+pub fn matrixraft_grafana_dashboard_json() -> String {
+    serde_json::to_string_pretty(&matrixraft_grafana_dashboard())
         .expect("RustRaft Grafana dashboard must serialize")
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -52,7 +52,7 @@ pub trait RustRaftConsensus {
     }
 }
 
-pub const RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS: u64 = u64::MAX;
+pub const MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS: u64 = u64::MAX;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RustRaftTimerTask {
@@ -167,7 +167,7 @@ impl RustRaftRequestTimer {
 
     pub fn next_timeout_ms(&self, now_ms: u64) -> u64 {
         let Some(timeout_key) = self.pending_timeouts.iter().next() else {
-            return RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS;
+            return MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS;
         };
         if timeout_key.deadline_ms < now_ms {
             return 0;

--- a/src/operational_evidence.rs
+++ b/src/operational_evidence.rs
@@ -6,15 +6,16 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    rustraft_membership_semantics_evidence_artifact, rustraft_read_safety_evidence_artifact,
-    rustraft_replication_pipeline_evidence_artifact, rustraft_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_membership_semantics_evidence_artifact,
-    rustraft_validate_read_safety_evidence_artifact,
-    rustraft_validate_replication_pipeline_evidence_artifact,
-    rustraft_validate_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_wal_lifecycle_evidence_artifact, rustraft_wal_lifecycle_evidence_artifact,
-    RustRaftMembershipSemanticsEvidenceArtifact, RustRaftPeerPipelineStatus,
-    RustRaftPipelineLimits, RustRaftReadSafetyEvidenceArtifact,
+    matrixraft_membership_semantics_evidence_artifact, matrixraft_read_safety_evidence_artifact,
+    matrixraft_replication_pipeline_evidence_artifact,
+    matrixraft_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_membership_semantics_evidence_artifact,
+    matrixraft_validate_read_safety_evidence_artifact,
+    matrixraft_validate_replication_pipeline_evidence_artifact,
+    matrixraft_validate_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_wal_lifecycle_evidence_artifact,
+    matrixraft_wal_lifecycle_evidence_artifact, RustRaftMembershipSemanticsEvidenceArtifact,
+    RustRaftPeerPipelineStatus, RustRaftPipelineLimits, RustRaftReadSafetyEvidenceArtifact,
     RustRaftReplicationPipelineEvidenceArtifact, RustRaftSnapshotLifecycleEvidenceArtifact,
     RustRaftWalLifecycleEvidenceArtifact, RustRaftWalLifecycleStatus,
 };
@@ -42,7 +43,7 @@ pub struct RustRaftBaselineRaftOperationalEvidenceBundleValidationReport {
     pub missing: Vec<String>,
 }
 
-pub fn rustraft_baseline_raft_operational_evidence_bundle(
+pub fn matrixraft_baseline_raft_operational_evidence_bundle(
     pipeline_peers: Vec<RustRaftPeerPipelineStatus>,
     pipeline_limits: RustRaftPipelineLimits,
     snapshot_peers: Vec<RustRaftPeerPipelineStatus>,
@@ -52,32 +53,32 @@ pub fn rustraft_baseline_raft_operational_evidence_bundle(
 ) -> RustRaftBaselineRaftOperationalEvidenceBundle {
     RustRaftBaselineRaftOperationalEvidenceBundle {
         schema: "rustraft.baseline_raft_operational_evidence_bundle.v1".to_string(),
-        read_safety: rustraft_read_safety_evidence_artifact(),
-        membership: rustraft_membership_semantics_evidence_artifact(),
-        replication_pipeline: rustraft_replication_pipeline_evidence_artifact(
+        read_safety: matrixraft_read_safety_evidence_artifact(),
+        membership: matrixraft_membership_semantics_evidence_artifact(),
+        replication_pipeline: matrixraft_replication_pipeline_evidence_artifact(
             pipeline_peers,
             pipeline_limits,
         ),
-        snapshot_lifecycle: rustraft_snapshot_lifecycle_evidence_artifact(
+        snapshot_lifecycle: matrixraft_snapshot_lifecycle_evidence_artifact(
             snapshot_peers,
             send_snapshot_timeout_ms,
             snapshot_max_inflights_replicate,
         ),
-        wal_lifecycle: rustraft_wal_lifecycle_evidence_artifact(wal_status),
+        wal_lifecycle: matrixraft_wal_lifecycle_evidence_artifact(wal_status),
     }
 }
 
-pub fn rustraft_validate_baseline_raft_operational_evidence_bundle(
+pub fn matrixraft_validate_baseline_raft_operational_evidence_bundle(
     bundle: &RustRaftBaselineRaftOperationalEvidenceBundle,
 ) -> RustRaftBaselineRaftOperationalEvidenceBundleValidationReport {
     let schema_valid = bundle.schema == "rustraft.baseline_raft_operational_evidence_bundle.v1";
-    let read_safety = rustraft_validate_read_safety_evidence_artifact(&bundle.read_safety);
-    let membership = rustraft_validate_membership_semantics_evidence_artifact(&bundle.membership);
+    let read_safety = matrixraft_validate_read_safety_evidence_artifact(&bundle.read_safety);
+    let membership = matrixraft_validate_membership_semantics_evidence_artifact(&bundle.membership);
     let replication_pipeline =
-        rustraft_validate_replication_pipeline_evidence_artifact(&bundle.replication_pipeline);
+        matrixraft_validate_replication_pipeline_evidence_artifact(&bundle.replication_pipeline);
     let snapshot_lifecycle =
-        rustraft_validate_snapshot_lifecycle_evidence_artifact(&bundle.snapshot_lifecycle);
-    let wal_lifecycle = rustraft_validate_wal_lifecycle_evidence_artifact(&bundle.wal_lifecycle);
+        matrixraft_validate_snapshot_lifecycle_evidence_artifact(&bundle.snapshot_lifecycle);
+    let wal_lifecycle = matrixraft_validate_wal_lifecycle_evidence_artifact(&bundle.wal_lifecycle);
 
     let mut missing = Vec::new();
     if !schema_valid {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -260,7 +260,7 @@ pub struct RustRaftApplyBatchOutcome {
     pub pending_entries: Vec<RustRaftLogEntry>,
 }
 
-pub fn rustraft_apply_batch_outcome_like_matrixraft(
+pub fn matrixraft_apply_batch_outcome(
     entries: &[RustRaftLogEntry],
     applied_count: usize,
     status: RustRaftApplyBatchStatus,
@@ -1210,7 +1210,7 @@ impl RustRaftPeerPipelineStatus {
     }
 }
 
-pub fn rustraft_peer_pipeline_status_from_observed(
+pub fn matrixraft_peer_pipeline_status_from_observed(
     observed: &RustRaftObservedPeerPipeline,
 ) -> RustRaftPeerPipelineStatus {
     RustRaftPeerPipelineStatus {
@@ -1296,7 +1296,7 @@ pub fn rustraft_peer_pipeline_status_from_observed(
     }
 }
 
-pub fn rustraft_pipeline_evidence(
+pub fn matrixraft_pipeline_evidence(
     peers: &[RustRaftPeerPipelineStatus],
     limits: RustRaftPipelineLimits,
 ) -> RustRaftPipelineEvidence {
@@ -1363,11 +1363,11 @@ pub fn rustraft_pipeline_evidence(
     }
 }
 
-pub fn rustraft_replication_pipeline_evidence_artifact(
+pub fn matrixraft_replication_pipeline_evidence_artifact(
     peers: Vec<RustRaftPeerPipelineStatus>,
     limits: RustRaftPipelineLimits,
 ) -> RustRaftReplicationPipelineEvidenceArtifact {
-    let evidence = rustraft_pipeline_evidence(&peers, limits);
+    let evidence = matrixraft_pipeline_evidence(&peers, limits);
     RustRaftReplicationPipelineEvidenceArtifact {
         schema: "rustraft.replication_pipeline_evidence.v1".to_string(),
         limits,
@@ -1376,11 +1376,11 @@ pub fn rustraft_replication_pipeline_evidence_artifact(
     }
 }
 
-pub fn rustraft_validate_replication_pipeline_evidence_artifact(
+pub fn matrixraft_validate_replication_pipeline_evidence_artifact(
     artifact: &RustRaftReplicationPipelineEvidenceArtifact,
 ) -> RustRaftReplicationPipelineEvidenceValidationReport {
     let schema_valid = artifact.schema == "rustraft.replication_pipeline_evidence.v1";
-    let recomputed = rustraft_pipeline_evidence(&artifact.peers, artifact.limits);
+    let recomputed = matrixraft_pipeline_evidence(&artifact.peers, artifact.limits);
     let peer_state_present =
         !artifact.peers.is_empty() && recomputed.per_peer_pipeline_state_present;
     let append_backpressure_enforced =

--- a/src/read_safety.rs
+++ b/src/read_safety.rs
@@ -109,7 +109,7 @@ impl RustRaftPendingReadIndex {
     }
 }
 
-pub fn rustraft_append_safety_decision(
+pub fn matrixraft_append_safety_decision(
     first_retained_log_index: u64,
     snapshot_index: u64,
     request: &RustRaftAppendEntriesRequest,
@@ -140,7 +140,7 @@ pub fn rustraft_append_safety_decision(
     }
 }
 
-pub fn rustraft_read_safety_decision(
+pub fn matrixraft_read_safety_decision(
     status: &RustRaftStatusSnapshot,
     request: &RustRaftReadIndexRequest,
 ) -> RustRaftReadSafetyDecision {
@@ -176,7 +176,7 @@ pub fn rustraft_read_safety_decision(
     }
 }
 
-pub fn rustraft_applied_index_fence_report(
+pub fn matrixraft_applied_index_fence_report(
     min_commit_index: RustRaftLogIndex,
     commit_index: RustRaftLogIndex,
     applied_index: RustRaftLogIndex,
@@ -197,7 +197,7 @@ pub fn rustraft_applied_index_fence_report(
     }
 }
 
-pub fn rustraft_lease_read_eligibility_report(
+pub fn matrixraft_lease_read_eligibility_report(
     node_id: RustRaftNodeId,
     leader_id: Option<RustRaftNodeId>,
     config_enabled: bool,
@@ -229,7 +229,7 @@ pub fn rustraft_lease_read_eligibility_report(
     }
 }
 
-pub fn rustraft_bounded_stale_read_report(
+pub fn matrixraft_bounded_stale_read_report(
     node_id: RustRaftNodeId,
     leader_id: RustRaftNodeId,
     node_commit_index: RustRaftLogIndex,
@@ -254,7 +254,7 @@ pub fn rustraft_bounded_stale_read_report(
     }
 }
 
-pub fn rustraft_read_safety_runtime_decision(
+pub fn matrixraft_read_safety_runtime_decision(
     input: RustRaftReadSafetyRuntimeInput,
 ) -> RustRaftReadSafetyRuntimeDecision {
     let is_follower = input.node_id != input.leader_id;
@@ -368,22 +368,24 @@ pub fn rustraft_read_safety_runtime_decision(
     }
 }
 
-pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArtifact {
+pub fn matrixraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArtifact {
     RustRaftReadSafetyEvidenceArtifact {
         schema: "rustraft.read_safety_evidence.v1".to_string(),
-        stale_leader_lease: rustraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
-            operation: RustRaftReadSafetyOperation::LeaseRead,
-            node_id: 1,
-            leader_id: 1,
-            node_alive: true,
-            role_can_serve_data: true,
-            leader_lease_valid: false,
-            has_majority: true,
-            node_commit_index: 10,
-            leader_commit_index: 10,
-            max_stale_index_lag: 0,
-        }),
-        lagging_follower_read: rustraft_read_safety_runtime_decision(
+        stale_leader_lease: matrixraft_read_safety_runtime_decision(
+            RustRaftReadSafetyRuntimeInput {
+                operation: RustRaftReadSafetyOperation::LeaseRead,
+                node_id: 1,
+                leader_id: 1,
+                node_alive: true,
+                role_can_serve_data: true,
+                leader_lease_valid: false,
+                has_majority: true,
+                node_commit_index: 10,
+                leader_commit_index: 10,
+                max_stale_index_lag: 0,
+            },
+        ),
+        lagging_follower_read: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::ReadIndex,
                 node_id: 2,
@@ -397,7 +399,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
                 max_stale_index_lag: 0,
             },
         ),
-        stale_follower_write: rustraft_read_safety_runtime_decision(
+        stale_follower_write: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::Write,
                 node_id: 2,
@@ -411,7 +413,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
                 max_stale_index_lag: 0,
             },
         ),
-        bounded_stale_read_accept: rustraft_read_safety_runtime_decision(
+        bounded_stale_read_accept: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::BoundedStaleRead,
                 node_id: 2,
@@ -425,7 +427,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
                 max_stale_index_lag: 1,
             },
         ),
-        bounded_stale_read_reject: rustraft_read_safety_runtime_decision(
+        bounded_stale_read_reject: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::BoundedStaleRead,
                 node_id: 2,
@@ -439,7 +441,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
                 max_stale_index_lag: 1,
             },
         ),
-        minority_partition_read: rustraft_read_safety_runtime_decision(
+        minority_partition_read: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::ReadIndex,
                 node_id: 1,
@@ -453,7 +455,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
                 max_stale_index_lag: 0,
             },
         ),
-        minority_partition_write: rustraft_read_safety_runtime_decision(
+        minority_partition_write: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::Write,
                 node_id: 1,
@@ -467,7 +469,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
                 max_stale_index_lag: 0,
             },
         ),
-        healed_follower_catchup: rustraft_read_safety_runtime_decision(
+        healed_follower_catchup: matrixraft_read_safety_runtime_decision(
             RustRaftReadSafetyRuntimeInput {
                 operation: RustRaftReadSafetyOperation::ReadIndex,
                 node_id: 2,
@@ -484,7 +486,7 @@ pub fn rustraft_read_safety_evidence_artifact() -> RustRaftReadSafetyEvidenceArt
     }
 }
 
-pub fn rustraft_validate_read_safety_evidence_artifact(
+pub fn matrixraft_validate_read_safety_evidence_artifact(
     artifact: &RustRaftReadSafetyEvidenceArtifact,
 ) -> RustRaftReadSafetyEvidenceValidationReport {
     let schema_valid = artifact.schema == "rustraft.read_safety_evidence.v1";

--- a/src/readiness.rs
+++ b/src/readiness.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::rustraft_metric_names;
+use crate::matrixraft_metric_names;
 use crate::{
     fault, RustRaftAdminStatusSurfaceEvidence, RustRaftBaselineRaftBenchmarkEvidence,
     RustRaftDataNodeProcessRolloutReport, RustRaftMembershipTransitionEvidence,
@@ -15,8 +15,8 @@ use crate::{
 };
 
 pub use crate::{
-    rustraft_data_node_process_rollout_readiness_report,
-    rustraft_meta_process_rollout_readiness_report, rustraft_production_readiness_report,
+    matrixraft_data_node_process_rollout_readiness_report,
+    matrixraft_meta_process_rollout_readiness_report, matrixraft_production_readiness_report,
     RustRaftBaselineRaftParitySurface,
 };
 
@@ -166,16 +166,16 @@ pub struct RustRaftReadinessEvidence {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RustRaftReadinessSnapshot {
-    pub rustraft_leader_write_authority_present: bool,
-    pub rustraft_operator_observability_present: bool,
-    pub rustraft_rpc_transport_contract_present: bool,
-    pub rustraft_log_retention_snapshot_trigger_present: bool,
-    pub rustraft_apply_snapshot_fence_present: bool,
+    pub matrixraft_leader_write_authority_present: bool,
+    pub matrixraft_operator_observability_present: bool,
+    pub matrixraft_rpc_transport_contract_present: bool,
+    pub matrixraft_log_retention_snapshot_trigger_present: bool,
+    pub matrixraft_apply_snapshot_fence_present: bool,
     pub raft_storage_apply_fence_present: bool,
-    pub rustraft_snapshot_floor_log_matching_present: bool,
-    pub rustraft_snapshot_tail_catchup_present: bool,
-    pub rustraft_compacted_entry_rejection_present: bool,
-    pub rustraft_metaserver_snapshot_floor_election_present: bool,
+    pub matrixraft_snapshot_floor_log_matching_present: bool,
+    pub matrixraft_snapshot_tail_catchup_present: bool,
+    pub matrixraft_compacted_entry_rejection_present: bool,
+    pub matrixraft_metaserver_snapshot_floor_election_present: bool,
     pub learner_catchup_promotion_present: bool,
     pub metaserver_membership_workflow_present: bool,
 }
@@ -220,7 +220,7 @@ pub struct RustRaftOpenSourceSurface {
     pub baseline_raft_parity_matrix: Vec<String>,
     pub benchmark_harness_interface: Vec<String>,
     pub compatibility_reports: Vec<String>,
-    pub rustraft_owned: Vec<String>,
+    pub matrixraft_owned: Vec<String>,
     pub temporalstore_adapter_boundary: Vec<String>,
 }
 
@@ -233,7 +233,7 @@ pub struct RustRaftTemporalStoreAdapterShape {
     pub transport_type_parameter: String,
     pub codec_field: String,
     pub engine_field: String,
-    pub rustraft_owned: Vec<String>,
+    pub matrixraft_owned: Vec<String>,
     pub temporalstore_owned: Vec<String>,
     pub example: String,
 }
@@ -250,7 +250,7 @@ pub enum RustRaftExtractionStatus {
 pub struct RustRaftExtractionSlice {
     pub id: String,
     pub status: RustRaftExtractionStatus,
-    pub rustraft_owner: String,
+    pub matrixraft_owner: String,
     pub temporalstore_boundary: String,
     pub next_evidence: String,
 }
@@ -261,18 +261,18 @@ pub struct RustRaftTemporalStoreExtractionPlan {
     pub slices: Vec<RustRaftExtractionSlice>,
 }
 
-pub fn rustraft_validate_deployment_mode(
+pub fn matrixraft_validate_deployment_mode(
     mode: RustRaftDeploymentMode,
     readiness: &RustRaftProductionReadinessReport,
 ) -> Result<(), RustRaftProductionReadinessError> {
-    rustraft_validate_deployment_readiness(
+    matrixraft_validate_deployment_readiness(
         mode,
         readiness.ready,
         readiness_missing_reasons(readiness),
     )
 }
 
-pub fn rustraft_validate_deployment_readiness(
+pub fn matrixraft_validate_deployment_readiness(
     mode: RustRaftDeploymentMode,
     production_ready: bool,
     missing: Vec<String>,
@@ -294,10 +294,10 @@ pub fn rustraft_validate_deployment_readiness(
     }
 }
 
-pub fn rustraft_require_production_ready(
+pub fn matrixraft_require_production_ready(
     readiness: &RustRaftProductionReadinessReport,
 ) -> Result<(), RustRaftProductionReadinessError> {
-    rustraft_validate_deployment_mode(RustRaftDeploymentMode::ProductionDistributed, readiness)
+    matrixraft_validate_deployment_mode(RustRaftDeploymentMode::ProductionDistributed, readiness)
 }
 
 fn readiness_missing_reasons(readiness: &RustRaftProductionReadinessReport) -> Vec<String> {
@@ -313,10 +313,10 @@ fn readiness_missing_reasons(readiness: &RustRaftProductionReadinessReport) -> V
     missing
 }
 
-pub fn rustraft_readiness_evidence(
+pub fn matrixraft_readiness_evidence(
     snapshot: &RustRaftReadinessSnapshot,
 ) -> Vec<RustRaftReadinessEvidence> {
-    rustraft_requirements()
+    matrixraft_requirements()
         .into_iter()
         .map(|requirement| RustRaftReadinessEvidence {
             present: readiness_field_present(snapshot, &requirement.readiness_field),
@@ -326,7 +326,7 @@ pub fn rustraft_readiness_evidence(
         .collect()
 }
 
-pub fn rustraft_requirements() -> Vec<RustRaftSemanticRequirement> {
+pub fn matrixraft_requirements() -> Vec<RustRaftSemanticRequirement> {
     use RustRaftRequirementCategory::*;
     [
         (
@@ -405,28 +405,30 @@ pub fn rustraft_requirements() -> Vec<RustRaftSemanticRequirement> {
 fn readiness_field_present(snapshot: &RustRaftReadinessSnapshot, field: &str) -> bool {
     match field {
         "rustraft_leader_write_authority_present" => {
-            snapshot.rustraft_leader_write_authority_present
+            snapshot.matrixraft_leader_write_authority_present
         }
         "rustraft_operator_observability_present" => {
-            snapshot.rustraft_operator_observability_present
+            snapshot.matrixraft_operator_observability_present
         }
         "rustraft_rpc_transport_contract_present" => {
-            snapshot.rustraft_rpc_transport_contract_present
+            snapshot.matrixraft_rpc_transport_contract_present
         }
         "rustraft_log_retention_snapshot_trigger_present" => {
-            snapshot.rustraft_log_retention_snapshot_trigger_present
+            snapshot.matrixraft_log_retention_snapshot_trigger_present
         }
-        "rustraft_apply_snapshot_fence_present" => snapshot.rustraft_apply_snapshot_fence_present,
+        "rustraft_apply_snapshot_fence_present" => snapshot.matrixraft_apply_snapshot_fence_present,
         "raft_storage_apply_fence_present" => snapshot.raft_storage_apply_fence_present,
         "rustraft_snapshot_floor_log_matching_present" => {
-            snapshot.rustraft_snapshot_floor_log_matching_present
+            snapshot.matrixraft_snapshot_floor_log_matching_present
         }
-        "rustraft_snapshot_tail_catchup_present" => snapshot.rustraft_snapshot_tail_catchup_present,
+        "rustraft_snapshot_tail_catchup_present" => {
+            snapshot.matrixraft_snapshot_tail_catchup_present
+        }
         "rustraft_compacted_entry_rejection_present" => {
-            snapshot.rustraft_compacted_entry_rejection_present
+            snapshot.matrixraft_compacted_entry_rejection_present
         }
         "rustraft_metaserver_snapshot_floor_election_present" => {
-            snapshot.rustraft_metaserver_snapshot_floor_election_present
+            snapshot.matrixraft_metaserver_snapshot_floor_election_present
         }
         "learner_catchup_promotion_present" => snapshot.learner_catchup_promotion_present,
         "metaserver_membership_workflow_present" => snapshot.metaserver_membership_workflow_present,
@@ -434,17 +436,17 @@ fn readiness_field_present(snapshot: &RustRaftReadinessSnapshot, field: &str) ->
     }
 }
 
-pub fn rustraft_parity_contract() -> RustRaftParityContract {
+pub fn matrixraft_parity_contract() -> RustRaftParityContract {
     RustRaftParityContract {
         library_name: "rustraft".to_string(),
         consensus_backend_boundary: "temporalstore_rust::raft::DataRaftConsensusBackend"
             .to_string(),
         openraft_dependency_removed: true,
-        requirements: rustraft_requirements(),
+        requirements: matrixraft_requirements(),
     }
 }
 
-pub fn rustraft_baseline_raft_parity_surface() -> RustRaftBaselineRaftParitySurface {
+pub fn matrixraft_baseline_raft_parity_surface() -> RustRaftBaselineRaftParitySurface {
     RustRaftBaselineRaftParitySurface {
         node_lifecycle: vec![
             "create".to_string(),
@@ -497,7 +499,7 @@ pub fn rustraft_baseline_raft_parity_surface() -> RustRaftBaselineRaftParitySurf
     }
 }
 
-pub fn rustraft_baseline_raft_reference_policy() -> RustRaftBaselineRaftReferencePolicy {
+pub fn matrixraft_baseline_raft_reference_policy() -> RustRaftBaselineRaftReferencePolicy {
     RustRaftBaselineRaftReferencePolicy {
         feature_reference: "BaselineRaft is the feature reference for Raft behavior parity.".to_string(),
         performance_reference:
@@ -512,7 +514,7 @@ pub fn rustraft_baseline_raft_reference_policy() -> RustRaftBaselineRaftReferenc
     }
 }
 
-pub fn rustraft_baseline_raft_parity_matrix(
+pub fn matrixraft_baseline_raft_parity_matrix(
     snapshot: &RustRaftReadinessSnapshot,
 ) -> Vec<RustRaftBaselineRaftParityItem> {
     use RustRaftBaselineRaftParityStatus::*;
@@ -544,8 +546,8 @@ pub fn rustraft_baseline_raft_parity_matrix(
         item(
             "log_replication",
             status(
-                snapshot.rustraft_leader_write_authority_present
-                    && snapshot.rustraft_rpc_transport_contract_present,
+                snapshot.matrixraft_leader_write_authority_present
+                    && snapshot.matrixraft_rpc_transport_contract_present,
             ),
             &[
                 "rustraft_leader_write_authority_present",
@@ -556,8 +558,8 @@ pub fn rustraft_baseline_raft_parity_matrix(
         item(
             "leader_election",
             status(
-                snapshot.rustraft_leader_write_authority_present
-                    && snapshot.rustraft_metaserver_snapshot_floor_election_present,
+                snapshot.matrixraft_leader_write_authority_present
+                    && snapshot.matrixraft_metaserver_snapshot_floor_election_present,
             ),
             &[
                 "rustraft_leader_write_authority_present",
@@ -567,13 +569,13 @@ pub fn rustraft_baseline_raft_parity_matrix(
         ),
         item(
             "pre_vote",
-            status(snapshot.rustraft_rpc_transport_contract_present),
+            status(snapshot.matrixraft_rpc_transport_contract_present),
             &["rustraft_rpc_transport_contract_present", "RustRaftVoteRequest.pre_vote"],
             "pre-vote is represented in the vote RPC contract",
         ),
         item(
             "lease_read",
-            status(snapshot.rustraft_leader_write_authority_present),
+            status(snapshot.matrixraft_leader_write_authority_present),
             &[
                 "rustraft_leader_write_authority_present",
                 "RustRaftReadIndexRequest.allow_lease_read",
@@ -582,7 +584,7 @@ pub fn rustraft_baseline_raft_parity_matrix(
         ),
         item(
             "read_index",
-            status(snapshot.rustraft_operator_observability_present),
+            status(snapshot.matrixraft_operator_observability_present),
             &[
                 "rustraft_operator_observability_present",
                 "RustRaftReadIndexRequest",
@@ -611,8 +613,8 @@ pub fn rustraft_baseline_raft_parity_matrix(
         item(
             "log_compaction",
             status(
-                snapshot.rustraft_compacted_entry_rejection_present
-                    && snapshot.rustraft_log_retention_snapshot_trigger_present,
+                snapshot.matrixraft_compacted_entry_rejection_present
+                    && snapshot.matrixraft_log_retention_snapshot_trigger_present,
             ),
             &[
                 "rustraft_compacted_entry_rejection_present",
@@ -623,9 +625,9 @@ pub fn rustraft_baseline_raft_parity_matrix(
         item(
             "snapshot_trigger_install",
             status(
-                snapshot.rustraft_log_retention_snapshot_trigger_present
-                    && snapshot.rustraft_snapshot_tail_catchup_present
-                    && snapshot.rustraft_snapshot_floor_log_matching_present,
+                snapshot.matrixraft_log_retention_snapshot_trigger_present
+                    && snapshot.matrixraft_snapshot_tail_catchup_present
+                    && snapshot.matrixraft_snapshot_floor_log_matching_present,
             ),
             &[
                 "rustraft_log_retention_snapshot_trigger_present",
@@ -638,7 +640,7 @@ pub fn rustraft_baseline_raft_parity_matrix(
             "restart_recovery",
             status(
                 snapshot.raft_storage_apply_fence_present
-                    && snapshot.rustraft_apply_snapshot_fence_present,
+                    && snapshot.matrixraft_apply_snapshot_fence_present,
             ),
             &[
                 "raft_storage_apply_fence_present",
@@ -654,16 +656,16 @@ pub fn rustraft_baseline_raft_parity_matrix(
         ),
         item(
             "observability_status",
-            status(snapshot.rustraft_operator_observability_present),
+            status(snapshot.matrixraft_operator_observability_present),
             &["rustraft_operator_observability_present", "RustRaftStatusSnapshot"],
             "status snapshots and metric names are part of the public contract",
         ),
     ]
 }
 
-pub fn rustraft_parity_report(snapshot: &RustRaftReadinessSnapshot) -> RustRaftParityReport {
-    let contract = rustraft_parity_contract();
-    let evidence = rustraft_readiness_evidence(snapshot);
+pub fn matrixraft_parity_report(snapshot: &RustRaftReadinessSnapshot) -> RustRaftParityReport {
+    let contract = matrixraft_parity_contract();
+    let evidence = matrixraft_readiness_evidence(snapshot);
     let satisfied = evidence
         .iter()
         .filter(|item| item.present)
@@ -682,7 +684,7 @@ pub fn rustraft_parity_report(snapshot: &RustRaftReadinessSnapshot) -> RustRaftP
         })
         .map(|requirement| format!("{:?}:{}", requirement.category, requirement.id).to_lowercase())
         .collect::<Vec<_>>();
-    let baseline_raft_parity_matrix = rustraft_baseline_raft_parity_matrix(snapshot);
+    let baseline_raft_parity_matrix = matrixraft_baseline_raft_parity_matrix(snapshot);
     let baseline_raft_gaps = baseline_raft_parity_matrix
         .iter()
         .filter(|item| item.status == RustRaftBaselineRaftParityStatus::Gap)
@@ -696,7 +698,7 @@ pub fn rustraft_parity_report(snapshot: &RustRaftReadinessSnapshot) -> RustRaftP
     let ready = missing.is_empty() && production_blockers.is_empty();
     RustRaftParityReport {
         contract,
-        baseline_raft_reference_policy: rustraft_baseline_raft_reference_policy(),
+        baseline_raft_reference_policy: matrixraft_baseline_raft_reference_policy(),
         ready,
         production_status: if ready {
             RustRaftProductionStatus::ProductionReady
@@ -712,11 +714,11 @@ pub fn rustraft_parity_report(snapshot: &RustRaftReadinessSnapshot) -> RustRaftP
     }
 }
 
-pub fn rustraft_public_api_contract() -> RustRaftPublicApiContract {
+pub fn matrixraft_public_api_contract() -> RustRaftPublicApiContract {
     RustRaftPublicApiContract {
         storage_trait: "RustRaftStorage".to_string(),
         transport_trait: "RaftTransport".to_string(),
-        public_modules: rustraft_public_module_names(),
+        public_modules: matrixraft_public_module_names(),
         rpc_messages: vec![
             "AppendEntriesRequest".to_string(),
             "AppendEntriesResponse".to_string(),
@@ -735,20 +737,20 @@ pub fn rustraft_public_api_contract() -> RustRaftPublicApiContract {
             "TcpRaftTransport".to_string(),
         ],
         safety_helpers: vec![
-            "rustraft_read_safety_decision".to_string(),
-            "rustraft_append_safety_decision".to_string(),
-            "rustraft_learner_promotion_decision".to_string(),
-            "rustraft_fatal_blocker_report".to_string(),
+            "matrixraft_read_safety_decision".to_string(),
+            "matrixraft_append_safety_decision".to_string(),
+            "matrixraft_learner_promotion_decision".to_string(),
+            "matrixraft_fatal_blocker_report".to_string(),
         ],
-        embedding_examples: rustraft_embedding_examples(),
-        parity_reports: rustraft_parity_report_names(),
-        benchmark_interfaces: rustraft_benchmark_interface_names(),
-        compatibility_reports: rustraft_compatibility_report_names(),
-        metrics: rustraft_metric_names(),
+        embedding_examples: matrixraft_embedding_examples(),
+        parity_reports: matrixraft_parity_report_names(),
+        benchmark_interfaces: matrixraft_benchmark_interface_names(),
+        compatibility_reports: matrixraft_compatibility_report_names(),
+        metrics: matrixraft_metric_names(),
     }
 }
 
-pub fn rustraft_public_module_names() -> Vec<String> {
+pub fn matrixraft_public_module_names() -> Vec<String> {
     [
         "node",
         "cluster",
@@ -771,7 +773,7 @@ pub fn rustraft_public_module_names() -> Vec<String> {
     .collect()
 }
 
-pub fn rustraft_embedding_examples() -> Vec<String> {
+pub fn matrixraft_embedding_examples() -> Vec<String> {
     [
         "examples/readiness_report.rs",
         "examples/read_safety.rs",
@@ -784,58 +786,58 @@ pub fn rustraft_embedding_examples() -> Vec<String> {
     .collect()
 }
 
-pub fn rustraft_parity_report_names() -> Vec<String> {
+pub fn matrixraft_parity_report_names() -> Vec<String> {
     [
-        "rustraft_parity_report",
-        "rustraft_baseline_raft_parity_matrix",
-        "rustraft_baseline_raft_parity_surface",
-        "rustraft_baseline_raft_reference_policy",
-        "rustraft_durability_parity_report",
+        "matrixraft_parity_report",
+        "matrixraft_baseline_raft_parity_matrix",
+        "matrixraft_baseline_raft_parity_surface",
+        "matrixraft_baseline_raft_reference_policy",
+        "matrixraft_durability_parity_report",
     ]
     .into_iter()
     .map(str::to_string)
     .collect()
 }
 
-pub fn rustraft_benchmark_interface_names() -> Vec<String> {
+pub fn matrixraft_benchmark_interface_names() -> Vec<String> {
     [
         "RustRaftBenchmarkRunner",
         "RustRaftExternalBaselineRaftRunner",
         "RustRaftRuntimeBenchmarkRunner",
         "RustRaftBenchmarkOptions",
         "RustRaftBenchmarkReport",
-        "rustraft_baseline_raft_benchmark_workloads",
-        "rustraft_run_baseline_raft_parity_benchmark",
-        "rustraft_assert_baseline_raft_parity",
-        "rustraft_assert_production_baseline_raft_parity",
-        "rustraft_baseline_raft_benchmark_evidence",
+        "matrixraft_baseline_raft_benchmark_workloads",
+        "matrixraft_run_baseline_raft_parity_benchmark",
+        "matrixraft_assert_baseline_raft_parity",
+        "matrixraft_assert_production_baseline_raft_parity",
+        "matrixraft_baseline_raft_benchmark_evidence",
     ]
     .into_iter()
     .map(str::to_string)
     .collect()
 }
 
-pub fn rustraft_compatibility_report_names() -> Vec<String> {
+pub fn matrixraft_compatibility_report_names() -> Vec<String> {
     [
-        "rustraft_public_api_contract",
-        "rustraft_standalone_readiness_report",
-        "rustraft_production_readiness_report",
-        "rustraft_data_node_process_rollout_readiness_report",
-        "rustraft_meta_process_rollout_readiness_report",
-        "rustraft_baseline_raft_runtime_capability_report",
-        "rustraft_runtime_local_status_report",
-        "rustraft_runtime_admin_report",
-        "rustraft_fatal_blocker_report",
-        "rustraft_baseline_raft_runtime_capability_prometheus",
-        "rustraft_temporalstore_extraction_plan",
+        "matrixraft_public_api_contract",
+        "matrixraft_standalone_readiness_report",
+        "matrixraft_production_readiness_report",
+        "matrixraft_data_node_process_rollout_readiness_report",
+        "matrixraft_meta_process_rollout_readiness_report",
+        "matrixraft_baseline_raft_runtime_capability_report",
+        "matrixraft_runtime_local_status_report",
+        "matrixraft_runtime_admin_report",
+        "matrixraft_fatal_blocker_report",
+        "matrixraft_baseline_raft_runtime_capability_prometheus",
+        "matrixraft_temporalstore_extraction_plan",
     ]
     .into_iter()
     .map(str::to_string)
     .collect()
 }
 
-pub fn rustraft_standalone_readiness_report() -> RustRaftStandaloneReadinessReport {
-    let capabilities = rustraft_standalone_capabilities();
+pub fn matrixraft_standalone_readiness_report() -> RustRaftStandaloneReadinessReport {
+    let capabilities = matrixraft_standalone_capabilities();
     let missing = capabilities
         .iter()
         .flat_map(|capability| {
@@ -869,7 +871,7 @@ pub fn rustraft_standalone_readiness_report() -> RustRaftStandaloneReadinessRepo
     }
 }
 
-fn rustraft_standalone_capabilities() -> Vec<RustRaftStandaloneCapability> {
+fn matrixraft_standalone_capabilities() -> Vec<RustRaftStandaloneCapability> {
     vec![
         standalone_capability(
             "node_lifecycle",
@@ -906,7 +908,7 @@ fn rustraft_standalone_capabilities() -> Vec<RustRaftStandaloneCapability> {
             "wal_recovery",
             &[
                 "wal::LocalRaftWal and PersistentRaftWalOptions provide segmented WAL persistence",
-                "rustraft_recover_latest_wal_record validates checksums and corrupt-tail truncation",
+                "matrixraft_recover_latest_wal_record validates checksums and corrupt-tail truncation",
                 "RaftHardState and RaftWalRecord preserve term, vote, commit, and log records",
             ],
         ),
@@ -930,7 +932,7 @@ fn rustraft_standalone_capabilities() -> Vec<RustRaftStandaloneCapability> {
             "status_metrics_readiness",
             &[
                 "status::RustRaftStatusSnapshot and cluster status reports expose runtime state",
-                "metrics::rustraft_metric_names names replication, WAL, snapshot, read, and blocker metrics",
+                "metrics::matrixraft_metric_names names replication, WAL, snapshot, read, and blocker metrics",
                 "readiness reports cover BaselineRaft parity, production gates, and fatal blockers",
             ],
         ),
@@ -946,24 +948,24 @@ fn standalone_capability(id: &str, evidence: &[&str]) -> RustRaftStandaloneCapab
     }
 }
 
-pub fn rustraft_open_source_surface() -> RustRaftOpenSourceSurface {
+pub fn matrixraft_open_source_surface() -> RustRaftOpenSourceSurface {
     RustRaftOpenSourceSurface {
         crate_name: "rustraft".to_string(),
-        public_modules: rustraft_public_module_names(),
+        public_modules: matrixraft_public_module_names(),
         embedding_docs: vec!["README.md".to_string(), "docs/gap_plan.md".to_string()],
-        embedding_examples: rustraft_embedding_examples(),
-        baseline_raft_parity_matrix: rustraft_baseline_raft_parity_matrix(
+        embedding_examples: matrixraft_embedding_examples(),
+        baseline_raft_parity_matrix: matrixraft_baseline_raft_parity_matrix(
             &RustRaftReadinessSnapshot {
-                rustraft_leader_write_authority_present: true,
-                rustraft_operator_observability_present: true,
-                rustraft_rpc_transport_contract_present: true,
-                rustraft_log_retention_snapshot_trigger_present: true,
-                rustraft_apply_snapshot_fence_present: true,
+                matrixraft_leader_write_authority_present: true,
+                matrixraft_operator_observability_present: true,
+                matrixraft_rpc_transport_contract_present: true,
+                matrixraft_log_retention_snapshot_trigger_present: true,
+                matrixraft_apply_snapshot_fence_present: true,
                 raft_storage_apply_fence_present: true,
-                rustraft_snapshot_floor_log_matching_present: true,
-                rustraft_snapshot_tail_catchup_present: true,
-                rustraft_compacted_entry_rejection_present: true,
-                rustraft_metaserver_snapshot_floor_election_present: true,
+                matrixraft_snapshot_floor_log_matching_present: true,
+                matrixraft_snapshot_tail_catchup_present: true,
+                matrixraft_compacted_entry_rejection_present: true,
+                matrixraft_metaserver_snapshot_floor_election_present: true,
                 learner_catchup_promotion_present: true,
                 metaserver_membership_workflow_present: true,
             },
@@ -971,9 +973,9 @@ pub fn rustraft_open_source_surface() -> RustRaftOpenSourceSurface {
         .into_iter()
         .map(|item| item.id)
         .collect(),
-        benchmark_harness_interface: rustraft_benchmark_interface_names(),
-        compatibility_reports: rustraft_compatibility_report_names(),
-        rustraft_owned: vec![
+        benchmark_harness_interface: matrixraft_benchmark_interface_names(),
+        compatibility_reports: matrixraft_compatibility_report_names(),
+        matrixraft_owned: vec![
             "public Raft modules and generic types".to_string(),
             "BaselineRaft parity matrix and readiness reports".to_string(),
             "benchmark harness traits and pass/fail reports".to_string(),
@@ -990,7 +992,7 @@ pub fn rustraft_open_source_surface() -> RustRaftOpenSourceSurface {
     }
 }
 
-pub fn rustraft_temporalstore_adapter_shape() -> RustRaftTemporalStoreAdapterShape {
+pub fn matrixraft_temporalstore_adapter_shape() -> RustRaftTemporalStoreAdapterShape {
     RustRaftTemporalStoreAdapterShape {
         backend_type: "TemporalRaftConsensusBackend".to_string(),
         node_field: "node".to_string(),
@@ -1001,7 +1003,7 @@ pub fn rustraft_temporalstore_adapter_shape() -> RustRaftTemporalStoreAdapterSha
         transport_type_parameter: "TemporalTransport".to_string(),
         codec_field: "codec: TemporalCommandCodec".to_string(),
         engine_field: "engine: TemporalEngine".to_string(),
-        rustraft_owned: vec![
+        matrixraft_owned: vec![
             "consensus node runtime".to_string(),
             "leader election and campaign/pre-vote".to_string(),
             "replication, read-index, lease-read safety".to_string(),
@@ -1025,56 +1027,56 @@ pub fn rustraft_temporalstore_adapter_shape() -> RustRaftTemporalStoreAdapterSha
     }
 }
 
-pub fn rustraft_temporalstore_extraction_plan() -> RustRaftTemporalStoreExtractionPlan {
+pub fn matrixraft_temporalstore_extraction_plan() -> RustRaftTemporalStoreExtractionPlan {
     RustRaftTemporalStoreExtractionPlan {
         policy: "RustRaft owns reusable consensus contracts, safety decisions, membership state, WAL/snapshot models, transport/storage traits, pipeline metrics, and deterministic harness logic; TemporalStore keeps only command codecs, process startup, shard FSM adapters, and storage-engine integration.".to_string(),
         slices: vec![
             RustRaftExtractionSlice {
                 id: "read_safety".to_string(),
                 status: RustRaftExtractionStatus::InLibrary,
-                rustraft_owner: "read-index, lease-read, bounded-stale, lagging-follower, stale-leader, and minority-partition decisions".to_string(),
+                matrixraft_owner: "read-index, lease-read, bounded-stale, lagging-follower, stale-leader, and minority-partition decisions".to_string(),
                 temporalstore_boundary: "translate data-node and metaserver runtime status into RustRaft read-safety inputs".to_string(),
                 next_evidence: "multi-process TemporalStore harness must attach observed read-index and lease responses".to_string(),
             },
             RustRaftExtractionSlice {
                 id: "membership_workflow".to_string(),
                 status: RustRaftExtractionStatus::InLibrary,
-                rustraft_owner: "learner add/catch-up/promote, voter add/remove, witness add, leader transfer validation, rollback reports, and joint consensus summaries".to_string(),
+                matrixraft_owner: "learner add/catch-up/promote, voter add/remove, witness add, leader transfer validation, rollback reports, and joint consensus summaries".to_string(),
                 temporalstore_boundary: "metaserver scheduler invokes RustRaft workflow and applies accepted operations through data-node process APIs".to_string(),
                 next_evidence: "scheduler-owned data-node membership report with stale-token rejection and restart replay".to_string(),
             },
             RustRaftExtractionSlice {
                 id: "wal_snapshot_models".to_string(),
                 status: RustRaftExtractionStatus::InLibrary,
-                rustraft_owner: "hard state, WAL records, segment status, snapshot metadata, apply snapshot fences, and snapshot lifecycle reports".to_string(),
+                matrixraft_owner: "hard state, WAL records, segment status, snapshot metadata, apply snapshot fences, and snapshot lifecycle reports".to_string(),
                 temporalstore_boundary: "persist records in TemporalStore-owned directories and bind apply fences to storage mutations".to_string(),
                 next_evidence: "crash between WAL persistence, storage mutation, and snapshot install recovers deterministically".to_string(),
             },
             RustRaftExtractionSlice {
                 id: "transport_storage_traits".to_string(),
                 status: RustRaftExtractionStatus::InLibrary,
-                rustraft_owner: "generic storage and transport traits plus AppendEntries, Vote, PreVote, InstallSnapshot, snapshot chunk, and ReadIndex messages".to_string(),
+                matrixraft_owner: "generic storage and transport traits plus AppendEntries, Vote, PreVote, InstallSnapshot, snapshot chunk, and ReadIndex messages".to_string(),
                 temporalstore_boundary: "HTTP/tonic/process adapters implement the traits without leaking TemporalStore command types into RustRaft".to_string(),
                 next_evidence: "data-node and metaserver process paths consume trait adapters in scale/failover harnesses".to_string(),
             },
             RustRaftExtractionSlice {
                 id: "fault_harness_contract".to_string(),
                 status: RustRaftExtractionStatus::InLibrary,
-                rustraft_owner: "BaselineRaft-derived fault scenario catalog and readiness report for process-path evidence".to_string(),
+                matrixraft_owner: "BaselineRaft-derived fault scenario catalog and readiness report for process-path evidence".to_string(),
                 temporalstore_boundary: "TemporalStore process harnesses run the real data-node and metaserver binaries and feed observed evidence into RustRaft reports".to_string(),
                 next_evidence: "packet loss, slow WAL, snapshot during membership, leader transfer under load, compacted-log rejoin, and rolling restart reports all pass".to_string(),
             },
             RustRaftExtractionSlice {
                 id: "replication_pipeline_runtime".to_string(),
                 status: RustRaftExtractionStatus::PendingMigration,
-                rustraft_owner: "inflight limits, append/apply queue limits, max replicate bytes, oversized-log rejection, reorder queue, and pressure counters".to_string(),
+                matrixraft_owner: "inflight limits, append/apply queue limits, max replicate bytes, oversized-log rejection, reorder queue, and pressure counters".to_string(),
                 temporalstore_boundary: "runtime should feed per-peer process observations into RustRaft pipeline evidence".to_string(),
                 next_evidence: "BaselineRaft-derived packet-loss, out-of-order append, slow WAL, and pressure tests pass through process harnesses".to_string(),
             },
             RustRaftExtractionSlice {
                 id: "domain_fsm_adapters".to_string(),
                 status: RustRaftExtractionStatus::AdapterOnly,
-                rustraft_owner: "opaque bytes/state-machine trait contracts only".to_string(),
+                matrixraft_owner: "opaque bytes/state-machine trait contracts only".to_string(),
                 temporalstore_boundary: "TemporalStore owns data-shard commands, metaserver mutations, object/block storage, and admin surfaces".to_string(),
                 next_evidence: "integration tests prove adapters implement RustRaft traits without moving domain codecs into the library".to_string(),
             },

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -68,7 +68,7 @@ pub struct RustRaftSnapshotLifecycleEvidenceValidationReport {
     pub missing: Vec<String>,
 }
 
-pub fn rustraft_validate_snapshot_floor_log_matching(
+pub fn matrixraft_validate_snapshot_floor_log_matching(
     snapshot: &RustRaftSnapshotMeta,
     first_retained_log_index: RustRaftLogIndex,
     prev_log_id: Option<&RustRaftLogId>,
@@ -95,7 +95,7 @@ pub fn rustraft_validate_snapshot_floor_log_matching(
     Ok(())
 }
 
-pub fn rustraft_validate_snapshot_install(
+pub fn matrixraft_validate_snapshot_install(
     snapshot: &RaftSnapshot,
     fence: &RustRaftApplySnapshotFence,
 ) -> Result<(), RustRaftError> {
@@ -104,14 +104,14 @@ pub fn rustraft_validate_snapshot_install(
             "snapshot install fence does not match snapshot last log index".to_string(),
         ));
     }
-    rustraft_validate_snapshot_floor_log_matching(
+    matrixraft_validate_snapshot_floor_log_matching(
         &snapshot.meta,
         fence.first_retained_log_index,
         Some(&snapshot.meta.last_log_id),
     )
 }
 
-pub fn rustraft_validate_snapshot_tail_catchup(
+pub fn matrixraft_validate_snapshot_tail_catchup(
     snapshot: &RustRaftSnapshotMeta,
     tail_entries: &[RustRaftLogEntry],
 ) -> Result<(), RustRaftError> {
@@ -131,7 +131,7 @@ pub fn rustraft_validate_snapshot_tail_catchup(
     Ok(())
 }
 
-pub fn rustraft_snapshot_lifecycle_evidence(
+pub fn matrixraft_snapshot_lifecycle_evidence(
     peers: &[RustRaftPeerPipelineStatus],
     send_snapshot_timeout_ms: u64,
     max_inflights_replicate: u64,
@@ -198,12 +198,12 @@ pub fn rustraft_snapshot_lifecycle_evidence(
     }
 }
 
-pub fn rustraft_snapshot_lifecycle_evidence_artifact(
+pub fn matrixraft_snapshot_lifecycle_evidence_artifact(
     peers: Vec<RustRaftPeerPipelineStatus>,
     send_snapshot_timeout_ms: u64,
     max_inflights_replicate: u64,
 ) -> RustRaftSnapshotLifecycleEvidenceArtifact {
-    let evidence = rustraft_snapshot_lifecycle_evidence(
+    let evidence = matrixraft_snapshot_lifecycle_evidence(
         &peers,
         send_snapshot_timeout_ms,
         max_inflights_replicate,
@@ -217,11 +217,11 @@ pub fn rustraft_snapshot_lifecycle_evidence_artifact(
     }
 }
 
-pub fn rustraft_validate_snapshot_lifecycle_evidence_artifact(
+pub fn matrixraft_validate_snapshot_lifecycle_evidence_artifact(
     artifact: &RustRaftSnapshotLifecycleEvidenceArtifact,
 ) -> RustRaftSnapshotLifecycleEvidenceValidationReport {
     let schema_valid = artifact.schema == "rustraft.snapshot_lifecycle_evidence.v1";
-    let recomputed = rustraft_snapshot_lifecycle_evidence(
+    let recomputed = matrixraft_snapshot_lifecycle_evidence(
         &artifact.peers,
         artifact.send_snapshot_timeout_ms,
         artifact.max_inflights_replicate,

--- a/src/status.rs
+++ b/src/status.rs
@@ -8,33 +8,34 @@ use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    rustraft_parity_report, rustraft_public_api_contract, rustraft_readiness_evidence,
+    matrixraft_parity_report, matrixraft_public_api_contract, matrixraft_readiness_evidence,
     RaftPeerPipelineState, RustRaftGroupId, RustRaftLogIndex, RustRaftNodeId, RustRaftParityReport,
     RustRaftPeerPipelineStatus, RustRaftPublicApiContract, RustRaftReadinessSnapshot,
     RustRaftReplicaRole, RustRaftRole, RustRaftStatusSnapshot,
 };
 
 pub use crate::{
-    rustraft_baseline_raft_operational_evidence_bundle,
-    rustraft_baseline_raft_runtime_capability_report,
-    rustraft_cross_plane_process_evidence_artifact,
-    rustraft_cross_plane_process_evidence_prometheus,
-    rustraft_cross_plane_process_evidence_summary,
-    rustraft_cross_plane_process_readiness_blocker_report,
-    rustraft_cross_plane_process_readiness_report, rustraft_data_node_process_rollout_blockers,
-    rustraft_data_node_strict_process_rollout_validated, rustraft_meta_process_rollout_blockers,
-    rustraft_meta_strict_process_rollout_validated, rustraft_named_readiness_blockers,
-    rustraft_pipeline_evidence, rustraft_process_readiness_blocker,
-    rustraft_process_readiness_field_detail, rustraft_require_production_ready,
-    rustraft_validate_baseline_raft_operational_evidence_bundle,
-    rustraft_validate_cross_plane_process_evidence_artifact, rustraft_validate_deployment_mode,
-    rustraft_validate_deployment_readiness,
-    rustraft_validate_membership_semantics_evidence_artifact,
-    rustraft_validate_read_safety_evidence_artifact,
-    rustraft_validate_replication_pipeline_evidence_artifact,
-    rustraft_validate_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_wal_lifecycle_evidence_artifact, rustraft_wal_lifecycle_evidence_artifact,
-    RustRaftBaselineRaftOperationalEvidenceBundle,
+    matrixraft_baseline_raft_operational_evidence_bundle,
+    matrixraft_baseline_raft_runtime_capability_report,
+    matrixraft_cross_plane_process_evidence_artifact,
+    matrixraft_cross_plane_process_evidence_prometheus,
+    matrixraft_cross_plane_process_evidence_summary,
+    matrixraft_cross_plane_process_readiness_blocker_report,
+    matrixraft_cross_plane_process_readiness_report, matrixraft_data_node_process_rollout_blockers,
+    matrixraft_data_node_strict_process_rollout_validated,
+    matrixraft_meta_process_rollout_blockers, matrixraft_meta_strict_process_rollout_validated,
+    matrixraft_named_readiness_blockers, matrixraft_pipeline_evidence,
+    matrixraft_process_readiness_blocker, matrixraft_process_readiness_field_detail,
+    matrixraft_require_production_ready,
+    matrixraft_validate_baseline_raft_operational_evidence_bundle,
+    matrixraft_validate_cross_plane_process_evidence_artifact, matrixraft_validate_deployment_mode,
+    matrixraft_validate_deployment_readiness,
+    matrixraft_validate_membership_semantics_evidence_artifact,
+    matrixraft_validate_read_safety_evidence_artifact,
+    matrixraft_validate_replication_pipeline_evidence_artifact,
+    matrixraft_validate_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_wal_lifecycle_evidence_artifact,
+    matrixraft_wal_lifecycle_evidence_artifact, RustRaftBaselineRaftOperationalEvidenceBundle,
     RustRaftBaselineRaftOperationalEvidenceBundleValidationReport,
     RustRaftCrossPlaneProcessEvidenceArtifact,
     RustRaftCrossPlaneProcessEvidenceArtifactValidationReport,
@@ -51,7 +52,7 @@ pub use crate::{
 };
 
 pub use crate::fault::{
-    rustraft_baseline_raft_fault_scenarios, rustraft_fault_harness_readiness_report,
+    matrixraft_baseline_raft_fault_scenarios, matrixraft_fault_harness_readiness_report,
     RustRaftFaultHarnessReadinessReport, RustRaftFaultScenario, RustRaftFaultScenarioEvidence,
     RustRaftFaultScenarioRequirement, RustRaftFaultScenarioResult,
 };
@@ -135,7 +136,7 @@ impl RaftLeaderTransferAdmission {
     }
 }
 
-pub fn rustraft_leader_transfer_admission(
+pub fn matrixraft_leader_transfer_admission(
     local_id: RustRaftNodeId,
     transferee_id: RustRaftNodeId,
     current_transferee_id: Option<RustRaftNodeId>,
@@ -577,7 +578,7 @@ pub struct RustRaftOptimizationReport {
     pub hints: Vec<RustRaftOptimizationHint>,
 }
 
-pub fn rustraft_fatal_blocker_report(
+pub fn matrixraft_fatal_blocker_report(
     source: impl Into<String>,
     blockers: Vec<String>,
     fatal_blockers: Vec<String>,
@@ -613,18 +614,18 @@ pub fn rustraft_fatal_blocker_report(
     }
 }
 
-pub fn rustraft_admin_fatal_blocker_report(
+pub fn matrixraft_admin_fatal_blocker_report(
     report: &RaftRuntimeAdminReport,
     fatal_blockers: Vec<String>,
 ) -> RustRaftFatalBlockerReport {
-    rustraft_fatal_blocker_report(
+    matrixraft_fatal_blocker_report(
         "rustraft_admin_report",
         report.blockers.clone(),
         fatal_blockers,
     )
 }
 
-pub fn rustraft_admin_diagnostic_log_entries(
+pub fn matrixraft_admin_diagnostic_log_entries(
     report: &RaftRuntimeAdminReport,
 ) -> Vec<RustRaftDiagnosticLogEntry> {
     let cluster = &report.cluster_status;
@@ -721,8 +722,8 @@ pub fn rustraft_admin_diagnostic_log_entries(
     entries
 }
 
-pub fn rustraft_admin_diagnostic_json_lines(report: &RaftRuntimeAdminReport) -> String {
-    rustraft_admin_diagnostic_log_entries(report)
+pub fn matrixraft_admin_diagnostic_json_lines(report: &RaftRuntimeAdminReport) -> String {
+    matrixraft_admin_diagnostic_log_entries(report)
         .into_iter()
         .map(|entry| {
             serde_json::to_string(&entry).expect("RustRaft diagnostic entry must serialize")
@@ -739,7 +740,7 @@ fn health_severity(status: RaftHealthStatus) -> RustRaftDiagnosticSeverity {
     }
 }
 
-pub fn rustraft_replication_health(
+pub fn matrixraft_replication_health(
     status: &RustRaftStatusSnapshot,
     peer_pipeline: &[RaftPeerPipelineState],
 ) -> RaftReplicationHealth {
@@ -783,7 +784,7 @@ pub fn rustraft_replication_health(
     }
 }
 
-pub fn rustraft_apply_health(status: &RustRaftStatusSnapshot) -> RaftApplyHealth {
+pub fn matrixraft_apply_health(status: &RustRaftStatusSnapshot) -> RaftApplyHealth {
     let apply_lag = status.commit_index.saturating_sub(status.applied_index);
     let status_value = if status.leader_id.is_none() {
         RaftHealthStatus::Unavailable
@@ -805,13 +806,13 @@ pub fn rustraft_apply_health(status: &RustRaftStatusSnapshot) -> RaftApplyHealth
     }
 }
 
-pub fn rustraft_runtime_local_status_report(
+pub fn matrixraft_runtime_local_status_report(
     node_status: RustRaftStatusSnapshot,
     peer_pipeline: Vec<RaftPeerPipelineState>,
     readiness: RustRaftReadinessSnapshot,
 ) -> RaftRuntimeLocalStatusReport {
-    let replication_health = rustraft_replication_health(&node_status, &peer_pipeline);
-    let apply_health = rustraft_apply_health(&node_status);
+    let replication_health = matrixraft_replication_health(&node_status, &peer_pipeline);
+    let apply_health = matrixraft_apply_health(&node_status);
     let mut blockers = Vec::new();
     if replication_health.status != RaftHealthStatus::Healthy {
         blockers.push(replication_health.reason.clone());
@@ -819,7 +820,7 @@ pub fn rustraft_runtime_local_status_report(
     if apply_health.status != RaftHealthStatus::Healthy {
         blockers.push(apply_health.reason.clone());
     }
-    if !readiness.rustraft_operator_observability_present {
+    if !readiness.matrixraft_operator_observability_present {
         blockers.push("operator_observability_missing".to_string());
     }
     let ready = blockers.is_empty();
@@ -834,7 +835,7 @@ pub fn rustraft_runtime_local_status_report(
     }
 }
 
-pub fn rustraft_admin_status_surface_evidence(
+pub fn matrixraft_admin_status_surface_evidence(
     input: &RustRaftAdminStatusSurfaceInput,
 ) -> RustRaftAdminStatusSurfaceEvidence {
     let quorum_peer_ids = input
@@ -932,7 +933,7 @@ pub fn rustraft_admin_status_surface_evidence(
     }
 }
 
-pub fn rustraft_optimization_report(
+pub fn matrixraft_optimization_report(
     input: &RustRaftAdminStatusSurfaceInput,
 ) -> RustRaftOptimizationReport {
     let mut hints = Vec::new();
@@ -1098,7 +1099,7 @@ fn optimization_hint(
     }
 }
 
-pub fn rustraft_cluster_status_report(
+pub fn matrixraft_cluster_status_report(
     group_id: RustRaftGroupId,
     leader_id: Option<RustRaftNodeId>,
     leader_transfer: Option<RaftLeaderTransferState>,
@@ -1110,8 +1111,8 @@ pub fn rustraft_cluster_status_report(
         .or_else(|| nodes.first());
     let (replication_health, apply_health) = if let Some(status) = representative {
         (
-            rustraft_replication_health(status, &[]),
-            rustraft_apply_health(status),
+            matrixraft_replication_health(status, &[]),
+            matrixraft_apply_health(status),
         )
     } else {
         (
@@ -1163,10 +1164,10 @@ pub fn rustraft_cluster_status_report(
     }
 }
 
-pub fn rustraft_capability_evidence(
+pub fn matrixraft_capability_evidence(
     readiness: &RustRaftReadinessSnapshot,
 ) -> Vec<RaftCapabilityEvidence> {
-    rustraft_readiness_evidence(readiness)
+    matrixraft_readiness_evidence(readiness)
         .into_iter()
         .map(|evidence| RaftCapabilityEvidence {
             capability: evidence.requirement_id,
@@ -1177,7 +1178,7 @@ pub fn rustraft_capability_evidence(
         .collect()
 }
 
-pub fn rustraft_capability_evidence_from_fields<C, R, I, S>(
+pub fn matrixraft_capability_evidence_from_fields<C, R, I, S>(
     capability: C,
     source_reference: R,
     fields: I,
@@ -1206,7 +1207,7 @@ where
     }
 }
 
-pub fn rustraft_runtime_capability_report_from_evidence<I, S>(
+pub fn matrixraft_runtime_capability_report_from_evidence<I, S>(
     capability_evidence: Vec<RaftCapabilityEvidence>,
     product_blockers: I,
 ) -> RustRaftBaselineRaftRuntimeCapabilityReport
@@ -1250,13 +1251,13 @@ where
     }
 }
 
-pub fn rustraft_runtime_admin_report(
+pub fn matrixraft_runtime_admin_report(
     cluster_status: RaftClusterStatusReport,
     readiness: RustRaftReadinessSnapshot,
     capability_evidence: Vec<RaftCapabilityEvidence>,
 ) -> RaftRuntimeAdminReport {
-    let parity = rustraft_parity_report(&readiness);
-    let public_api = rustraft_public_api_contract();
+    let parity = matrixraft_parity_report(&readiness);
+    let public_api = matrixraft_public_api_contract();
     let mut blockers = cluster_status.blockers.clone();
     blockers.extend(
         capability_evidence

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,7 +4,7 @@
 //! Generic log, state-machine, apply, and storage contracts.
 
 pub use crate::{
-    rustraft_apply_entry, EntryPayload, RaftApply, RaftApplyRequest, RaftApplyResponse,
+    matrixraft_apply_entry, EntryPayload, RaftApply, RaftApplyRequest, RaftApplyResponse,
     RaftFsmAdapter, RaftFsmApplyOutcome, RaftFsmCheckpoint, RaftFsmReplayReport, RaftLogEntry,
     RaftStateMachine, RaftStorageApplyFence, RustRaftApplyRequest, RustRaftApplyResponse,
     RustRaftGenericApplyRequest, RustRaftGenericApplyResponse, RustRaftGenericLogEntry,
@@ -816,7 +816,7 @@ impl MatrixRaftGroupStorage for MatrixRaftMemoryGroupStorage {
     }
 }
 
-pub fn rustraft_validate_storage_apply_fence(
+pub fn matrixraft_validate_storage_apply_fence(
     fence: &RustRaftStorageApplyFence,
 ) -> Result<(), RustRaftError> {
     if fence.applied_index > fence.committed_index {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -88,7 +88,7 @@ pub(crate) fn require_transport_validation(
     }
 }
 
-pub fn rustraft_validate_append_entries_request(
+pub fn matrixraft_validate_append_entries_request(
     request: &AppendEntriesRequest,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -114,7 +114,7 @@ pub fn rustraft_validate_append_entries_request(
     RustRaftTransportValidationReport::new("append_entries_request", blockers)
 }
 
-pub fn rustraft_validate_append_entries_response(
+pub fn matrixraft_validate_append_entries_response(
     response: &AppendEntriesResponse,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -128,7 +128,9 @@ pub fn rustraft_validate_append_entries_response(
     RustRaftTransportValidationReport::new("append_entries_response", blockers)
 }
 
-pub fn rustraft_validate_vote_request(request: &VoteRequest) -> RustRaftTransportValidationReport {
+pub fn matrixraft_validate_vote_request(
+    request: &VoteRequest,
+) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
     validate_positive_id(&mut blockers, "group_id", request.group_id);
     validate_positive_id(&mut blockers, "candidate_id", request.candidate_id);
@@ -138,7 +140,7 @@ pub fn rustraft_validate_vote_request(request: &VoteRequest) -> RustRaftTranspor
     RustRaftTransportValidationReport::new("vote_request", blockers)
 }
 
-pub fn rustraft_validate_vote_response(
+pub fn matrixraft_validate_vote_response(
     response: &VoteResponse,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -146,7 +148,7 @@ pub fn rustraft_validate_vote_response(
     RustRaftTransportValidationReport::new("vote_response", blockers)
 }
 
-pub fn rustraft_validate_install_snapshot_request(
+pub fn matrixraft_validate_install_snapshot_request(
     request: &InstallSnapshotRequest,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -166,7 +168,7 @@ pub fn rustraft_validate_install_snapshot_request(
     RustRaftTransportValidationReport::new("install_snapshot_request", blockers)
 }
 
-pub fn rustraft_validate_install_snapshot_response(
+pub fn matrixraft_validate_install_snapshot_response(
     response: &InstallSnapshotResponse,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -174,7 +176,7 @@ pub fn rustraft_validate_install_snapshot_response(
     RustRaftTransportValidationReport::new("install_snapshot_response", blockers)
 }
 
-pub fn rustraft_validate_read_index_request(
+pub fn matrixraft_validate_read_index_request(
     request: &ReadIndexRequest,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -183,7 +185,7 @@ pub fn rustraft_validate_read_index_request(
     RustRaftTransportValidationReport::new("read_index_request", blockers)
 }
 
-pub fn rustraft_validate_read_index_response(
+pub fn matrixraft_validate_read_index_response(
     response: &ReadIndexResponse,
 ) -> RustRaftTransportValidationReport {
     let mut blockers = Vec::new();
@@ -194,19 +196,19 @@ pub fn rustraft_validate_read_index_response(
     RustRaftTransportValidationReport::new("read_index_response", blockers)
 }
 
-pub fn rustraft_validate_tcp_transport_request(
+pub fn matrixraft_validate_tcp_transport_request(
     request: &TcpRaftTransportRequest,
 ) -> RustRaftTransportValidationReport {
     let mut report = match request {
         TcpRaftTransportRequest::AppendEntries { request, .. } => {
-            rustraft_validate_append_entries_request(request)
+            matrixraft_validate_append_entries_request(request)
         }
-        TcpRaftTransportRequest::Vote { request, .. } => rustraft_validate_vote_request(request),
+        TcpRaftTransportRequest::Vote { request, .. } => matrixraft_validate_vote_request(request),
         TcpRaftTransportRequest::InstallSnapshot { request, .. } => {
-            rustraft_validate_install_snapshot_request(request)
+            matrixraft_validate_install_snapshot_request(request)
         }
         TcpRaftTransportRequest::ReadIndex { request, .. } => {
-            rustraft_validate_read_index_request(request)
+            matrixraft_validate_read_index_request(request)
         }
         TcpRaftTransportRequest::Batch { requests } => {
             let mut blockers = Vec::new();
@@ -218,7 +220,7 @@ pub fn rustraft_validate_tcp_transport_request(
                     blockers.push(format!("batch request {index} must not be nested"));
                     continue;
                 }
-                let report = rustraft_validate_tcp_transport_request(request);
+                let report = matrixraft_validate_tcp_transport_request(request);
                 blockers.extend(
                     report
                         .blockers

--- a/src/unique_id.rs
+++ b/src/unique_id.rs
@@ -5,12 +5,13 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-pub const RUSTRAFT_UNIQUE_ID_MEMBER_BITS: u32 = 16;
-pub const RUSTRAFT_UNIQUE_ID_TIMESTAMP_BITS: u32 = 40;
-pub const RUSTRAFT_UNIQUE_ID_COUNTER_BITS: u32 = 8;
-pub const RUSTRAFT_UNIQUE_ID_COUNTER_MASK: u64 = (1u64 << RUSTRAFT_UNIQUE_ID_COUNTER_BITS) - 1;
-pub const RUSTRAFT_UNIQUE_ID_TIMESTAMP_MASK: u64 = (1u64 << RUSTRAFT_UNIQUE_ID_TIMESTAMP_BITS) - 1;
-pub const RUSTRAFT_UNIQUE_ID_MEMBER_MASK: u64 = (1u64 << RUSTRAFT_UNIQUE_ID_MEMBER_BITS) - 1;
+pub const MATRIXRAFT_UNIQUE_ID_MEMBER_BITS: u32 = 16;
+pub const MATRIXRAFT_UNIQUE_ID_TIMESTAMP_BITS: u32 = 40;
+pub const MATRIXRAFT_UNIQUE_ID_COUNTER_BITS: u32 = 8;
+pub const MATRIXRAFT_UNIQUE_ID_COUNTER_MASK: u64 = (1u64 << MATRIXRAFT_UNIQUE_ID_COUNTER_BITS) - 1;
+pub const MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK: u64 =
+    (1u64 << MATRIXRAFT_UNIQUE_ID_TIMESTAMP_BITS) - 1;
+pub const MATRIXRAFT_UNIQUE_ID_MEMBER_MASK: u64 = (1u64 << MATRIXRAFT_UNIQUE_ID_MEMBER_BITS) - 1;
 
 #[derive(Debug)]
 pub struct RustRaftUniqueIdGenerator {
@@ -20,10 +21,10 @@ pub struct RustRaftUniqueIdGenerator {
 
 impl RustRaftUniqueIdGenerator {
     pub fn new(member_id: u64, time_millis: u64) -> Self {
-        let member_prefix = (member_id & RUSTRAFT_UNIQUE_ID_MEMBER_MASK)
-            << (RUSTRAFT_UNIQUE_ID_TIMESTAMP_BITS + RUSTRAFT_UNIQUE_ID_COUNTER_BITS);
-        let timestamp_and_counter =
-            (time_millis & RUSTRAFT_UNIQUE_ID_TIMESTAMP_MASK) << RUSTRAFT_UNIQUE_ID_COUNTER_BITS;
+        let member_prefix = (member_id & MATRIXRAFT_UNIQUE_ID_MEMBER_MASK)
+            << (MATRIXRAFT_UNIQUE_ID_TIMESTAMP_BITS + MATRIXRAFT_UNIQUE_ID_COUNTER_BITS);
+        let timestamp_and_counter = (time_millis & MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK)
+            << MATRIXRAFT_UNIQUE_ID_COUNTER_BITS;
         Self {
             member_prefix,
             timestamp_and_counter: AtomicU64::new(timestamp_and_counter),
@@ -35,18 +36,18 @@ impl RustRaftUniqueIdGenerator {
         self.member_prefix
             | low_bits(
                 timestamp_and_counter,
-                RUSTRAFT_UNIQUE_ID_TIMESTAMP_BITS + RUSTRAFT_UNIQUE_ID_COUNTER_BITS,
+                MATRIXRAFT_UNIQUE_ID_TIMESTAMP_BITS + MATRIXRAFT_UNIQUE_ID_COUNTER_BITS,
             )
     }
 
     pub fn decode(id: u64) -> RustRaftUniqueIdParts {
         RustRaftUniqueIdParts {
             member_id: (id
-                >> (RUSTRAFT_UNIQUE_ID_TIMESTAMP_BITS + RUSTRAFT_UNIQUE_ID_COUNTER_BITS))
-                & RUSTRAFT_UNIQUE_ID_MEMBER_MASK,
-            timestamp_millis: (id >> RUSTRAFT_UNIQUE_ID_COUNTER_BITS)
-                & RUSTRAFT_UNIQUE_ID_TIMESTAMP_MASK,
-            counter: id & RUSTRAFT_UNIQUE_ID_COUNTER_MASK,
+                >> (MATRIXRAFT_UNIQUE_ID_TIMESTAMP_BITS + MATRIXRAFT_UNIQUE_ID_COUNTER_BITS))
+                & MATRIXRAFT_UNIQUE_ID_MEMBER_MASK,
+            timestamp_millis: (id >> MATRIXRAFT_UNIQUE_ID_COUNTER_BITS)
+                & MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK,
+            counter: id & MATRIXRAFT_UNIQUE_ID_COUNTER_MASK,
         }
     }
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 pub use crate::{
-    rustraft_durability_parity_report, FileRaftWal, LocalRaftWal, PersistentRaftWal,
+    matrixraft_durability_parity_report, FileRaftWal, LocalRaftWal, PersistentRaftWal,
     PersistentRaftWalOptions, RaftHardState, RustRaftDurabilityParityReport, RustRaftHardState,
 };
 
@@ -170,7 +170,7 @@ pub struct RustRaftWalLifecycleEvidenceValidationReport {
     pub missing: Vec<String>,
 }
 
-pub fn rustraft_wal_checksum(record: &RaftWalRecord) -> String {
+pub fn matrixraft_wal_checksum(record: &RaftWalRecord) -> String {
     let mut hash = 14_695_981_039_346_656_037_u64;
     let mut mix = |value: u64| {
         for byte in value.to_le_bytes() {
@@ -202,7 +202,7 @@ pub fn rustraft_wal_checksum(record: &RaftWalRecord) -> String {
     format!("{hash:016x}")
 }
 
-pub fn rustraft_wal_checksum_format() -> RaftWalChecksumFormat {
+pub fn matrixraft_wal_checksum_format() -> RaftWalChecksumFormat {
     RaftWalChecksumFormat {
         algorithm: "fnv1a64-rustraft-v1".to_string(),
         encoding: "lower_hex_16".to_string(),
@@ -220,11 +220,11 @@ pub fn rustraft_wal_checksum_format() -> RaftWalChecksumFormat {
     }
 }
 
-pub fn rustraft_wal_checksum_valid(record: &RaftWalRecord) -> bool {
-    record.checksum == rustraft_wal_checksum(record)
+pub fn matrixraft_wal_checksum_valid(record: &RaftWalRecord) -> bool {
+    record.checksum == matrixraft_wal_checksum(record)
 }
 
-pub fn rustraft_validate_hard_state_persistence(
+pub fn matrixraft_validate_hard_state_persistence(
     record: &RustRaftWalRecord,
 ) -> Result<(), RustRaftError> {
     if let Some(committed) = &record.hard_state.committed {
@@ -252,7 +252,7 @@ pub fn rustraft_validate_hard_state_persistence(
     Ok(())
 }
 
-pub fn rustraft_validate_apply_snapshot_fence(
+pub fn matrixraft_validate_apply_snapshot_fence(
     record: &RustRaftWalRecord,
 ) -> Result<(), RustRaftError> {
     let fence = &record.apply_snapshot_fence;
@@ -289,18 +289,18 @@ pub fn rustraft_validate_apply_snapshot_fence(
     Ok(())
 }
 
-pub fn rustraft_recover_latest_wal_record(
+pub fn matrixraft_recover_latest_wal_record(
     records: &[RustRaftWalRecord],
 ) -> Result<RustRaftWalRecord, RustRaftError> {
     let valid_records = records
         .iter()
-        .take_while(|record| rustraft_wal_checksum_valid(record))
+        .take_while(|record| matrixraft_wal_checksum_valid(record))
         .collect::<Vec<_>>();
     let Some(record) = valid_records
         .into_iter()
         .filter(|record| {
-            rustraft_validate_hard_state_persistence(record).is_ok()
-                && rustraft_validate_apply_snapshot_fence(record).is_ok()
+            matrixraft_validate_hard_state_persistence(record).is_ok()
+                && matrixraft_validate_apply_snapshot_fence(record).is_ok()
         })
         .max_by_key(|record| {
             record
@@ -318,7 +318,7 @@ pub fn rustraft_recover_latest_wal_record(
     Ok(record.clone())
 }
 
-pub fn rustraft_wal_lifecycle_evidence(
+pub fn matrixraft_wal_lifecycle_evidence(
     status: &RustRaftWalLifecycleStatus,
 ) -> RustRaftWalLifecycleEvidence {
     RustRaftWalLifecycleEvidence {
@@ -340,10 +340,10 @@ pub fn rustraft_wal_lifecycle_evidence(
     }
 }
 
-pub fn rustraft_wal_lifecycle_evidence_artifact(
+pub fn matrixraft_wal_lifecycle_evidence_artifact(
     status: RustRaftWalLifecycleStatus,
 ) -> RustRaftWalLifecycleEvidenceArtifact {
-    let evidence = rustraft_wal_lifecycle_evidence(&status);
+    let evidence = matrixraft_wal_lifecycle_evidence(&status);
     RustRaftWalLifecycleEvidenceArtifact {
         schema: "rustraft.wal_lifecycle_evidence.v1".to_string(),
         status,
@@ -351,11 +351,11 @@ pub fn rustraft_wal_lifecycle_evidence_artifact(
     }
 }
 
-pub fn rustraft_validate_wal_lifecycle_evidence_artifact(
+pub fn matrixraft_validate_wal_lifecycle_evidence_artifact(
     artifact: &RustRaftWalLifecycleEvidenceArtifact,
 ) -> RustRaftWalLifecycleEvidenceValidationReport {
     let schema_valid = artifact.schema == "rustraft.wal_lifecycle_evidence.v1";
-    let recomputed = rustraft_wal_lifecycle_evidence(&artifact.status);
+    let recomputed = matrixraft_wal_lifecycle_evidence(&artifact.status);
     let segment_lifecycle_present =
         recomputed.segment_lifecycle_present && artifact.evidence.segment_lifecycle_present;
     let retained_range_present =

--- a/tests/baseline_raft_parity_matrix.rs
+++ b/tests/baseline_raft_parity_matrix.rs
@@ -2,22 +2,22 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_baseline_raft_parity_matrix, rustraft_baseline_raft_reference_policy,
-    rustraft_parity_report, RustRaftBaselineRaftParityStatus, RustRaftReadinessSnapshot,
+    matrixraft_baseline_raft_parity_matrix, matrixraft_baseline_raft_reference_policy,
+    matrixraft_parity_report, RustRaftBaselineRaftParityStatus, RustRaftReadinessSnapshot,
 };
 
 fn ready_snapshot() -> RustRaftReadinessSnapshot {
     RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     }
@@ -25,7 +25,7 @@ fn ready_snapshot() -> RustRaftReadinessSnapshot {
 
 #[test]
 fn baseline_raft_parity_matrix_tracks_all_required_capabilities() {
-    let matrix = rustraft_baseline_raft_parity_matrix(&ready_snapshot());
+    let matrix = matrixraft_baseline_raft_parity_matrix(&ready_snapshot());
     let ids = matrix
         .iter()
         .map(|item| item.id.as_str())
@@ -58,10 +58,10 @@ fn baseline_raft_parity_matrix_tracks_all_required_capabilities() {
 #[test]
 fn baseline_raft_parity_report_tracks_gaps_and_intentional_differences() {
     let mut snapshot = ready_snapshot();
-    snapshot.rustraft_rpc_transport_contract_present = false;
+    snapshot.matrixraft_rpc_transport_contract_present = false;
     snapshot.learner_catchup_promotion_present = false;
 
-    let report = rustraft_parity_report(&snapshot);
+    let report = matrixraft_parity_report(&snapshot);
 
     assert!(report
         .baseline_raft_gaps
@@ -88,7 +88,7 @@ fn baseline_raft_parity_report_tracks_gaps_and_intentional_differences() {
 
 #[test]
 fn ready_baseline_raft_matrix_has_only_declared_runtime_split_difference() {
-    let report = rustraft_parity_report(&ready_snapshot());
+    let report = matrixraft_parity_report(&ready_snapshot());
 
     assert!(report.baseline_raft_gaps.is_empty(), "{report:#?}");
     assert_eq!(
@@ -107,7 +107,7 @@ fn ready_baseline_raft_matrix_has_only_declared_runtime_split_difference() {
 
 #[test]
 fn baseline_raft_is_feature_and_performance_reference_but_rust_api_can_be_idiomatic() {
-    let policy = rustraft_baseline_raft_reference_policy();
+    let policy = matrixraft_baseline_raft_reference_policy();
     assert!(policy.feature_reference.contains("BaselineRaft"));
     assert!(policy.performance_reference.contains("BaselineRaft"));
     assert!(policy.performance_reference.contains("p50/p99"));
@@ -116,6 +116,6 @@ fn baseline_raft_is_feature_and_performance_reference_but_rust_api_can_be_idioma
         .temporalstore_consumption_boundary
         .contains("DataRaftConsensusBackend"));
 
-    let report = rustraft_parity_report(&ready_snapshot());
+    let report = matrixraft_parity_report(&ready_snapshot());
     assert_eq!(report.baseline_raft_reference_policy, policy);
 }

--- a/tests/baseline_raft_runtime_capability.rs
+++ b/tests/baseline_raft_runtime_capability.rs
@@ -2,31 +2,32 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    fault, rustraft_admin_status_surface_evidence,
-    rustraft_baseline_raft_operational_evidence_bundle,
-    rustraft_baseline_raft_runtime_capability_prometheus,
-    rustraft_baseline_raft_runtime_capability_report, rustraft_capability_evidence_from_fields,
-    rustraft_cross_plane_process_evidence_artifact,
-    rustraft_cross_plane_process_evidence_prometheus,
-    rustraft_cross_plane_process_evidence_summary,
-    rustraft_cross_plane_process_readiness_blocker_report,
-    rustraft_cross_plane_process_readiness_report, rustraft_data_node_process_rollout_blockers,
-    rustraft_data_node_strict_process_rollout_validated,
-    rustraft_membership_semantics_evidence_artifact, rustraft_meta_process_rollout_blockers,
-    rustraft_meta_strict_process_rollout_validated, rustraft_named_readiness_blockers,
-    rustraft_process_readiness_blocker, rustraft_production_readiness_report,
-    rustraft_read_safety_evidence_artifact, rustraft_replication_pipeline_evidence_artifact,
-    rustraft_require_production_ready, rustraft_runtime_capability_report_from_evidence,
-    rustraft_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_baseline_raft_operational_evidence_bundle,
-    rustraft_validate_cross_plane_process_evidence_artifact, rustraft_validate_deployment_mode,
-    rustraft_validate_deployment_readiness,
-    rustraft_validate_membership_semantics_evidence_artifact,
-    rustraft_validate_read_safety_evidence_artifact,
-    rustraft_validate_replication_pipeline_evidence_artifact,
-    rustraft_validate_snapshot_lifecycle_evidence_artifact,
-    rustraft_validate_wal_lifecycle_evidence_artifact, rustraft_wal_lifecycle_evidence_artifact,
-    RaftCapabilityEvidence, RustRaftAdminStatusSurfaceEvidence, RustRaftAdminStatusSurfaceInput,
+    fault, matrixraft_admin_status_surface_evidence,
+    matrixraft_baseline_raft_operational_evidence_bundle,
+    matrixraft_baseline_raft_runtime_capability_prometheus,
+    matrixraft_baseline_raft_runtime_capability_report, matrixraft_capability_evidence_from_fields,
+    matrixraft_cross_plane_process_evidence_artifact,
+    matrixraft_cross_plane_process_evidence_prometheus,
+    matrixraft_cross_plane_process_evidence_summary,
+    matrixraft_cross_plane_process_readiness_blocker_report,
+    matrixraft_cross_plane_process_readiness_report, matrixraft_data_node_process_rollout_blockers,
+    matrixraft_data_node_strict_process_rollout_validated,
+    matrixraft_membership_semantics_evidence_artifact, matrixraft_meta_process_rollout_blockers,
+    matrixraft_meta_strict_process_rollout_validated, matrixraft_named_readiness_blockers,
+    matrixraft_process_readiness_blocker, matrixraft_production_readiness_report,
+    matrixraft_read_safety_evidence_artifact, matrixraft_replication_pipeline_evidence_artifact,
+    matrixraft_require_production_ready, matrixraft_runtime_capability_report_from_evidence,
+    matrixraft_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_baseline_raft_operational_evidence_bundle,
+    matrixraft_validate_cross_plane_process_evidence_artifact, matrixraft_validate_deployment_mode,
+    matrixraft_validate_deployment_readiness,
+    matrixraft_validate_membership_semantics_evidence_artifact,
+    matrixraft_validate_read_safety_evidence_artifact,
+    matrixraft_validate_replication_pipeline_evidence_artifact,
+    matrixraft_validate_snapshot_lifecycle_evidence_artifact,
+    matrixraft_validate_wal_lifecycle_evidence_artifact,
+    matrixraft_wal_lifecycle_evidence_artifact, RaftCapabilityEvidence,
+    RustRaftAdminStatusSurfaceEvidence, RustRaftAdminStatusSurfaceInput,
     RustRaftDataNodeProcessRolloutReport, RustRaftDeploymentMode, RustRaftLearnerPromotionDecision,
     RustRaftMembershipScope, RustRaftMembershipTransitionEvidence,
     RustRaftMembershipTransitionKind, RustRaftMetaProcessRolloutReport, RustRaftPeerPipelineStatus,
@@ -38,16 +39,16 @@ use matrixraft::{
 
 fn ready_snapshot() -> RustRaftReadinessSnapshot {
     RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     }
@@ -345,7 +346,7 @@ fn ready_admin_status_surface() -> RustRaftAdminStatusSurfaceEvidence {
     peer_3.inflight_entries = 1;
     peer_3.inflight_bytes = 128;
 
-    rustraft_admin_status_surface_evidence(&RustRaftAdminStatusSurfaceInput {
+    matrixraft_admin_status_surface_evidence(&RustRaftAdminStatusSurfaceInput {
         commit_index: 104,
         max_observed_node_commit_index: 104,
         quorum_size: 2,
@@ -431,7 +432,7 @@ fn complete_wal_lifecycle_status() -> RustRaftWalLifecycleStatus {
 }
 
 fn ready_fault_harness() -> fault::RustRaftFaultHarnessReadinessReport {
-    let evidence = fault::rustraft_baseline_raft_fault_scenarios()
+    let evidence = fault::matrixraft_baseline_raft_fault_scenarios()
         .into_iter()
         .map(|requirement| fault::RustRaftFaultScenarioEvidence {
             scenario: requirement.scenario,
@@ -450,7 +451,7 @@ fn ready_fault_harness() -> fault::RustRaftFaultHarnessReadinessReport {
             report_path: Some(format!("reports/{}.json", requirement.scenario.id())),
         })
         .collect::<Vec<_>>();
-    fault::rustraft_fault_harness_readiness_report(&evidence)
+    fault::matrixraft_fault_harness_readiness_report(&evidence)
 }
 
 fn ready_input() -> RustRaftProductionReadinessInput {
@@ -503,12 +504,12 @@ fn ready_input() -> RustRaftProductionReadinessInput {
         membership_transitions: transitions(),
         baseline_raft_benchmark: Some(matrixraft::RustRaftBaselineRaftBenchmarkEvidence {
             real_baseline_raft: true,
-            rustraft_runtime: true,
+            matrixraft_runtime: true,
             baseline_raft_reference: true,
-            rustraft_rust_candidate: true,
+            matrixraft_rust_candidate: true,
             correctness_passed: true,
             performance_within_threshold: true,
-            workloads: matrixraft::benchmark::rustraft_baseline_raft_benchmark_workloads()
+            workloads: matrixraft::benchmark::matrixraft_baseline_raft_benchmark_workloads()
                 .into_iter()
                 .map(|workload| workload.id().to_string())
                 .collect(),
@@ -523,7 +524,7 @@ fn ready_input() -> RustRaftProductionReadinessInput {
 
 #[test]
 fn baseline_raft_runtime_capability_report_accepts_complete_evidence() {
-    let report = rustraft_baseline_raft_runtime_capability_report(&ready_input());
+    let report = matrixraft_baseline_raft_runtime_capability_report(&ready_input());
     assert!(report.ready, "{report:#?}");
     assert!(report.missing.is_empty());
     assert!(report.blockers.is_empty());
@@ -537,7 +538,7 @@ fn baseline_raft_runtime_capability_report_accepts_complete_evidence() {
 
 #[test]
 fn capability_evidence_from_fields_formats_present_and_missing_rows() {
-    let evidence = rustraft_capability_evidence_from_fields(
+    let evidence = matrixraft_capability_evidence_from_fields(
         "wal_segment_lifecycle",
         "product_admin_report",
         [
@@ -560,7 +561,7 @@ fn capability_evidence_from_fields_formats_present_and_missing_rows() {
 
 #[test]
 fn runtime_capability_report_builder_accepts_product_evidence_rows() {
-    let report = rustraft_runtime_capability_report_from_evidence(
+    let report = matrixraft_runtime_capability_report_from_evidence(
         vec![
             RaftCapabilityEvidence {
                 capability: "process_path_rollout_evidence".to_string(),
@@ -611,7 +612,7 @@ fn baseline_raft_runtime_capability_report_fails_closed_on_missing_wal_lifecycle
         compaction_after_slow_fsync_observed: false,
     });
 
-    let report = rustraft_baseline_raft_runtime_capability_report(&input);
+    let report = matrixraft_baseline_raft_runtime_capability_report(&input);
     assert!(!report.ready);
     assert!(report
         .missing
@@ -635,7 +636,7 @@ fn baseline_raft_runtime_capability_report_names_process_path_missing_fields() {
         .unwrap()
         .per_node_log_store_inspection_count = 0;
 
-    let report = rustraft_baseline_raft_runtime_capability_report(&input);
+    let report = matrixraft_baseline_raft_runtime_capability_report(&input);
     assert!(!report.ready);
     assert!(report
         .missing
@@ -653,7 +654,7 @@ fn cross_plane_process_readiness_requires_real_three_process_evidence() {
     let data = ready_data_rollout_three_processes();
     let meta = ready_meta_rollout_three_processes();
 
-    let report = rustraft_cross_plane_process_readiness_report(&data, &meta);
+    let report = matrixraft_cross_plane_process_readiness_report(&data, &meta);
 
     assert!(report.ready);
     assert!(report.multi_process_data_node_and_metaserver_raft);
@@ -671,7 +672,7 @@ fn cross_plane_process_readiness_names_missing_evidence_fields() {
     data.independent_wal_dirs = false;
     meta.operational_semantics.read_index_validated = false;
 
-    let report = rustraft_cross_plane_process_readiness_report(&data, &meta);
+    let report = matrixraft_cross_plane_process_readiness_report(&data, &meta);
 
     assert!(!report.ready);
     assert!(!report.multi_process_data_node_and_metaserver_raft);
@@ -685,7 +686,7 @@ fn cross_plane_process_readiness_names_missing_evidence_fields() {
 
 #[test]
 fn process_readiness_blocker_classifier_is_library_owned() {
-    let blocker = rustraft_process_readiness_blocker("data_node_report.independent_wal_dirs");
+    let blocker = matrixraft_process_readiness_blocker("data_node_report.independent_wal_dirs");
 
     assert_eq!(
         blocker.blocker,
@@ -700,7 +701,7 @@ fn process_readiness_blocker_classifier_is_library_owned() {
         "each process must use an independent WAL directory"
     );
 
-    let operational = rustraft_process_readiness_blocker(
+    let operational = matrixraft_process_readiness_blocker(
         "metaserver_report.operational_semantics.read_index_validated",
     );
     assert_eq!(
@@ -711,7 +712,7 @@ fn process_readiness_blocker_classifier_is_library_owned() {
 
 #[test]
 fn process_rollout_blocker_expansion_is_library_owned() {
-    let missing = rustraft_data_node_process_rollout_blockers("data_node_report", None);
+    let missing = matrixraft_data_node_process_rollout_blockers("data_node_report", None);
     assert_eq!(missing.len(), 1);
     assert_eq!(missing[0].blocker, "data_node_report_missing");
     assert_eq!(missing[0].evidence_field, "data_node_report");
@@ -721,7 +722,7 @@ fn process_rollout_blocker_expansion_is_library_owned() {
     data.independent_wal_dirs = false;
     data.read_index_responses_observed = 0;
     let data_blockers =
-        rustraft_data_node_process_rollout_blockers("data_node_report", Some(&data));
+        matrixraft_data_node_process_rollout_blockers("data_node_report", Some(&data));
     assert!(data_blockers.iter().any(|blocker| {
         blocker.evidence_field == "data_node_report.independent_wal_dirs"
             && blocker.detail == "each process must use an independent WAL directory"
@@ -732,7 +733,7 @@ fn process_rollout_blocker_expansion_is_library_owned() {
 
     let mut meta = ready_meta_rollout_three_processes();
     meta.operational_semantics.read_index_validated = false;
-    let meta_blockers = rustraft_meta_process_rollout_blockers("metaserver_report", Some(&meta));
+    let meta_blockers = matrixraft_meta_process_rollout_blockers("metaserver_report", Some(&meta));
     assert!(meta_blockers.iter().any(|blocker| {
         blocker.evidence_field == "metaserver_report.operational_semantics.read_index_validated"
             && blocker.detail
@@ -748,8 +749,8 @@ fn cross_plane_blocker_report_is_library_owned() {
     meta.operational_semantics
         .follower_rejoin_after_compaction_validated = false;
 
-    let string_report = rustraft_cross_plane_process_readiness_report(&data, &meta);
-    let blocker_report = rustraft_cross_plane_process_readiness_blocker_report(&data, &meta);
+    let string_report = matrixraft_cross_plane_process_readiness_report(&data, &meta);
+    let blocker_report = matrixraft_cross_plane_process_readiness_blocker_report(&data, &meta);
 
     assert_eq!(blocker_report.ready, string_report.ready);
     assert_eq!(
@@ -781,7 +782,7 @@ fn cross_plane_process_evidence_summary_is_library_owned() {
     let data = ready_data_rollout_three_processes();
     let meta = ready_meta_rollout_three_processes();
 
-    let summary = rustraft_cross_plane_process_evidence_summary(&data, &meta);
+    let summary = matrixraft_cross_plane_process_evidence_summary(&data, &meta);
 
     assert_eq!(summary.data_node_spawned_process_count, 3);
     assert_eq!(summary.metaserver_spawned_process_count, 3);
@@ -804,9 +805,9 @@ fn cross_plane_process_evidence_summary_is_library_owned() {
 fn cross_plane_process_evidence_prometheus_is_library_owned() {
     let data = ready_data_rollout_three_processes();
     let meta = ready_meta_rollout_three_processes();
-    let summary = rustraft_cross_plane_process_evidence_summary(&data, &meta);
+    let summary = matrixraft_cross_plane_process_evidence_summary(&data, &meta);
 
-    let metrics = rustraft_cross_plane_process_evidence_prometheus(
+    let metrics = matrixraft_cross_plane_process_evidence_prometheus(
         &summary,
         &[("cluster", "a\"b\\c\n"), ("source", "process")],
     );
@@ -837,7 +838,7 @@ fn cross_plane_process_evidence_artifact_is_library_owned() {
     let meta = ready_meta_rollout_three_processes();
 
     let artifact =
-        rustraft_cross_plane_process_evidence_artifact(&data, &meta, &[("cluster", "raft-a")]);
+        matrixraft_cross_plane_process_evidence_artifact(&data, &meta, &[("cluster", "raft-a")]);
     let json = serde_json::to_string(&artifact).expect("serialize process evidence artifact");
 
     assert_eq!(artifact.schema, "rustraft.cross_plane_process_evidence.v1");
@@ -859,9 +860,9 @@ fn cross_plane_process_evidence_artifact_validator_is_library_owned() {
     let data = ready_data_rollout_three_processes();
     let meta = ready_meta_rollout_three_processes();
     let artifact =
-        rustraft_cross_plane_process_evidence_artifact(&data, &meta, &[("cluster", "raft-a")]);
+        matrixraft_cross_plane_process_evidence_artifact(&data, &meta, &[("cluster", "raft-a")]);
 
-    let validation = rustraft_validate_cross_plane_process_evidence_artifact(&artifact);
+    let validation = matrixraft_validate_cross_plane_process_evidence_artifact(&artifact);
 
     assert!(validation.valid);
     assert!(validation.schema_valid);
@@ -876,7 +877,7 @@ fn cross_plane_process_evidence_artifact_validator_reports_missing_fields() {
     let data = ready_data_rollout_three_processes();
     let meta = ready_meta_rollout_three_processes();
     let mut artifact =
-        rustraft_cross_plane_process_evidence_artifact(&data, &meta, &[("cluster", "raft-a")]);
+        matrixraft_cross_plane_process_evidence_artifact(&data, &meta, &[("cluster", "raft-a")]);
     artifact.schema = "old.schema".to_string();
     artifact.readiness.ready = false;
     artifact.summary.total_spawned_process_count = 2;
@@ -885,7 +886,7 @@ fn cross_plane_process_evidence_artifact_validator_reports_missing_fields() {
     artifact.prometheus.metric_count = 0;
     artifact.prometheus.text.clear();
 
-    let validation = rustraft_validate_cross_plane_process_evidence_artifact(&artifact);
+    let validation = matrixraft_validate_cross_plane_process_evidence_artifact(&artifact);
 
     assert!(!validation.valid);
     assert!(!validation.schema_valid);
@@ -911,7 +912,7 @@ fn cross_plane_process_evidence_artifact_validator_reports_missing_fields() {
 
 #[test]
 fn read_safety_evidence_artifact_is_library_owned() {
-    let artifact = rustraft_read_safety_evidence_artifact();
+    let artifact = matrixraft_read_safety_evidence_artifact();
 
     assert_eq!(artifact.schema, "rustraft.read_safety_evidence.v1");
     assert!(!artifact.stale_leader_lease.allowed);
@@ -948,8 +949,8 @@ fn read_safety_evidence_artifact_is_library_owned() {
 
 #[test]
 fn read_safety_evidence_artifact_validator_reports_missing_fields() {
-    let artifact = rustraft_read_safety_evidence_artifact();
-    let valid = rustraft_validate_read_safety_evidence_artifact(&artifact);
+    let artifact = matrixraft_read_safety_evidence_artifact();
+    let valid = matrixraft_validate_read_safety_evidence_artifact(&artifact);
     assert!(valid.valid);
     assert!(valid.missing.is_empty());
 
@@ -958,7 +959,7 @@ fn read_safety_evidence_artifact_validator_reports_missing_fields() {
     broken.stale_leader_lease.allowed = true;
     broken.bounded_stale_read_accept.allowed = false;
     broken.minority_partition_write.reason = "write_authority".to_string();
-    let invalid = rustraft_validate_read_safety_evidence_artifact(&broken);
+    let invalid = matrixraft_validate_read_safety_evidence_artifact(&broken);
 
     assert!(!invalid.valid);
     assert!(!invalid.schema_valid);
@@ -979,7 +980,7 @@ fn read_safety_evidence_artifact_validator_reports_missing_fields() {
 
 #[test]
 fn membership_semantics_evidence_artifact_is_library_owned() {
-    let artifact = rustraft_membership_semantics_evidence_artifact();
+    let artifact = matrixraft_membership_semantics_evidence_artifact();
 
     assert_eq!(artifact.schema, "rustraft.membership_semantics_evidence.v1");
     assert!(artifact
@@ -1006,8 +1007,8 @@ fn membership_semantics_evidence_artifact_is_library_owned() {
 
 #[test]
 fn membership_semantics_evidence_artifact_validator_reports_missing_fields() {
-    let artifact = rustraft_membership_semantics_evidence_artifact();
-    let valid = rustraft_validate_membership_semantics_evidence_artifact(&artifact);
+    let artifact = matrixraft_membership_semantics_evidence_artifact();
+    let valid = matrixraft_validate_membership_semantics_evidence_artifact(&artifact);
     assert!(valid.valid);
     assert!(valid.missing.is_empty());
 
@@ -1034,7 +1035,7 @@ fn membership_semantics_evidence_artifact_validator_reports_missing_fields() {
     broken.witness_promotion_rejected_observed = false;
     broken.witness_role_blocker = None;
 
-    let invalid = rustraft_validate_membership_semantics_evidence_artifact(&broken);
+    let invalid = matrixraft_validate_membership_semantics_evidence_artifact(&broken);
 
     assert!(!invalid.valid);
     assert!(!invalid.schema_valid);
@@ -1067,13 +1068,13 @@ fn membership_semantics_evidence_artifact_validator_reports_missing_fields() {
 
 #[test]
 fn membership_semantics_evidence_requires_joint_quorum_commit_proof() {
-    let mut artifact = rustraft_membership_semantics_evidence_artifact();
+    let mut artifact = matrixraft_membership_semantics_evidence_artifact();
     artifact.learner_add.joint_acknowledged_voters = vec![1, 2];
     artifact.learner_add.joint_new_majority_acked = false;
     artifact.voter_remove.joint_acknowledged_voters = vec![1, 2];
     artifact.voter_remove.joint_old_majority_acked = false;
 
-    let invalid = rustraft_validate_membership_semantics_evidence_artifact(&artifact);
+    let invalid = matrixraft_validate_membership_semantics_evidence_artifact(&artifact);
 
     assert!(!invalid.valid);
     assert!(!invalid.learner_added);
@@ -1085,7 +1086,7 @@ fn membership_semantics_evidence_requires_joint_quorum_commit_proof() {
 #[test]
 fn replication_pipeline_evidence_artifact_is_library_owned() {
     let limits = RustRaftPipelineLimits::production_default();
-    let artifact = rustraft_replication_pipeline_evidence_artifact(
+    let artifact = matrixraft_replication_pipeline_evidence_artifact(
         complete_replication_pipeline_peers(),
         limits,
     );
@@ -1111,11 +1112,11 @@ fn replication_pipeline_evidence_artifact_is_library_owned() {
 #[test]
 fn replication_pipeline_evidence_artifact_validator_reports_missing_fields() {
     let limits = RustRaftPipelineLimits::production_default();
-    let artifact = rustraft_replication_pipeline_evidence_artifact(
+    let artifact = matrixraft_replication_pipeline_evidence_artifact(
         complete_replication_pipeline_peers(),
         limits,
     );
-    let valid = rustraft_validate_replication_pipeline_evidence_artifact(&artifact);
+    let valid = matrixraft_validate_replication_pipeline_evidence_artifact(&artifact);
     assert!(valid.valid);
     assert!(valid.missing.is_empty());
 
@@ -1129,7 +1130,7 @@ fn replication_pipeline_evidence_artifact_validator_reports_missing_fields() {
     broken.evidence.packet_loss_reorder_same_peer_recovered = false;
     broken.evidence.reorder_queue_enabled = false;
 
-    let invalid = rustraft_validate_replication_pipeline_evidence_artifact(&broken);
+    let invalid = matrixraft_validate_replication_pipeline_evidence_artifact(&broken);
 
     assert!(!invalid.valid);
     assert!(!invalid.schema_valid);
@@ -1166,8 +1167,8 @@ fn replication_pipeline_evidence_requires_recovery_after_packet_loss_and_reorder
     recovered_peer.match_index = recovered_peer.next_index.saturating_sub(2);
     recovered_peer.reorder_queue_depth = 1;
 
-    let artifact = rustraft_replication_pipeline_evidence_artifact(peers, limits);
-    let invalid = rustraft_validate_replication_pipeline_evidence_artifact(&artifact);
+    let artifact = matrixraft_replication_pipeline_evidence_artifact(peers, limits);
+    let invalid = matrixraft_validate_replication_pipeline_evidence_artifact(&artifact);
 
     assert!(!invalid.valid);
     assert!(invalid.packet_loss_probe_present);
@@ -1203,8 +1204,8 @@ fn replication_pipeline_evidence_rejects_split_peer_packet_loss_and_reorder_reco
     reorder_peer.match_index = reorder_peer.next_index.saturating_sub(1);
     reorder_peer.reorder_queue_depth = 0;
 
-    let artifact = rustraft_replication_pipeline_evidence_artifact(peers, limits);
-    let invalid = rustraft_validate_replication_pipeline_evidence_artifact(&artifact);
+    let artifact = matrixraft_replication_pipeline_evidence_artifact(peers, limits);
+    let invalid = matrixraft_validate_replication_pipeline_evidence_artifact(&artifact);
 
     assert!(!invalid.valid);
     assert!(invalid.packet_loss_recovery_present);
@@ -1217,7 +1218,7 @@ fn replication_pipeline_evidence_rejects_split_peer_packet_loss_and_reorder_reco
 
 #[test]
 fn snapshot_lifecycle_evidence_artifact_is_library_owned() {
-    let artifact = rustraft_snapshot_lifecycle_evidence_artifact(
+    let artifact = matrixraft_snapshot_lifecycle_evidence_artifact(
         complete_snapshot_lifecycle_peers(),
         1_000,
         1,
@@ -1245,12 +1246,12 @@ fn snapshot_lifecycle_evidence_artifact_is_library_owned() {
 
 #[test]
 fn snapshot_lifecycle_evidence_artifact_validator_reports_missing_fields() {
-    let artifact = rustraft_snapshot_lifecycle_evidence_artifact(
+    let artifact = matrixraft_snapshot_lifecycle_evidence_artifact(
         complete_snapshot_lifecycle_peers(),
         1_000,
         1,
     );
-    let valid = rustraft_validate_snapshot_lifecycle_evidence_artifact(&artifact);
+    let valid = matrixraft_validate_snapshot_lifecycle_evidence_artifact(&artifact);
     assert!(valid.valid);
     assert!(valid.missing.is_empty());
 
@@ -1264,7 +1265,7 @@ fn snapshot_lifecycle_evidence_artifact_validator_reports_missing_fields() {
     broken.evidence.sustained_downloader_completion_present = false;
     broken.evidence.install_rollback_present = false;
 
-    let invalid = rustraft_validate_snapshot_lifecycle_evidence_artifact(&broken);
+    let invalid = matrixraft_validate_snapshot_lifecycle_evidence_artifact(&broken);
 
     assert!(!invalid.valid);
     assert!(!invalid.schema_valid);
@@ -1308,8 +1309,8 @@ fn snapshot_lifecycle_evidence_requires_sustained_completion() {
     downloader.snapshot_installing = true;
     downloader.snapshot_install_progress_per_mille = 750;
 
-    let artifact = rustraft_snapshot_lifecycle_evidence_artifact(peers, 1_000, 1);
-    let invalid = rustraft_validate_snapshot_lifecycle_evidence_artifact(&artifact);
+    let artifact = matrixraft_snapshot_lifecycle_evidence_artifact(peers, 1_000, 1);
+    let invalid = matrixraft_validate_snapshot_lifecycle_evidence_artifact(&artifact);
 
     assert!(!invalid.valid);
     assert!(invalid.sustained_sender_load_present);
@@ -1326,7 +1327,7 @@ fn snapshot_lifecycle_evidence_requires_sustained_completion() {
 
 #[test]
 fn wal_lifecycle_evidence_artifact_is_library_owned() {
-    let artifact = rustraft_wal_lifecycle_evidence_artifact(complete_wal_lifecycle_status());
+    let artifact = matrixraft_wal_lifecycle_evidence_artifact(complete_wal_lifecycle_status());
 
     assert_eq!(artifact.schema, "rustraft.wal_lifecycle_evidence.v1");
     assert_eq!(artifact.status.segment_count, 3);
@@ -1343,8 +1344,8 @@ fn wal_lifecycle_evidence_artifact_is_library_owned() {
 
 #[test]
 fn wal_lifecycle_evidence_artifact_validator_reports_missing_fields() {
-    let artifact = rustraft_wal_lifecycle_evidence_artifact(complete_wal_lifecycle_status());
-    let valid = rustraft_validate_wal_lifecycle_evidence_artifact(&artifact);
+    let artifact = matrixraft_wal_lifecycle_evidence_artifact(complete_wal_lifecycle_status());
+    let valid = matrixraft_validate_wal_lifecycle_evidence_artifact(&artifact);
     assert!(valid.valid);
     assert!(valid.missing.is_empty());
 
@@ -1358,7 +1359,7 @@ fn wal_lifecycle_evidence_artifact_validator_reports_missing_fields() {
     broken.status.compacted_after_slow_fsync_count = 0;
     broken.evidence.retained_range_present = false;
 
-    let invalid = rustraft_validate_wal_lifecycle_evidence_artifact(&broken);
+    let invalid = matrixraft_validate_wal_lifecycle_evidence_artifact(&broken);
 
     assert!(!invalid.valid);
     assert!(!invalid.schema_valid);
@@ -1385,7 +1386,7 @@ fn wal_lifecycle_evidence_artifact_validator_reports_missing_fields() {
 
 #[test]
 fn baseline_raft_operational_evidence_bundle_is_library_owned() {
-    let bundle = rustraft_baseline_raft_operational_evidence_bundle(
+    let bundle = matrixraft_baseline_raft_operational_evidence_bundle(
         complete_replication_pipeline_peers(),
         RustRaftPipelineLimits::production_default(),
         complete_snapshot_lifecycle_peers(),
@@ -1398,7 +1399,7 @@ fn baseline_raft_operational_evidence_bundle_is_library_owned() {
         bundle.schema,
         "rustraft.baseline_raft_operational_evidence_bundle.v1"
     );
-    let validation = rustraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
+    let validation = matrixraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
     assert!(validation.valid, "{validation:#?}");
     assert!(validation.read_safety_valid);
     assert!(validation.membership_valid);
@@ -1410,7 +1411,7 @@ fn baseline_raft_operational_evidence_bundle_is_library_owned() {
 
 #[test]
 fn baseline_raft_operational_evidence_bundle_validator_prefixes_missing_fields() {
-    let mut bundle = rustraft_baseline_raft_operational_evidence_bundle(
+    let mut bundle = matrixraft_baseline_raft_operational_evidence_bundle(
         complete_replication_pipeline_peers(),
         RustRaftPipelineLimits::production_default(),
         complete_snapshot_lifecycle_peers(),
@@ -1424,7 +1425,7 @@ fn baseline_raft_operational_evidence_bundle_validator_prefixes_missing_fields()
     bundle.snapshot_lifecycle.peers.clear();
     bundle.wal_lifecycle.status.released_segment_count = 0;
 
-    let validation = rustraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
+    let validation = matrixraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
 
     assert!(!validation.valid);
     assert!(!validation.schema_valid);
@@ -1447,14 +1448,16 @@ fn baseline_raft_operational_evidence_bundle_validator_prefixes_missing_fields()
 fn strict_process_rollout_helpers_require_crash_window_evidence() {
     let mut data = ready_data_rollout_three_processes();
     let mut meta = ready_meta_rollout_three_processes();
-    assert!(rustraft_data_node_strict_process_rollout_validated(&data));
-    assert!(rustraft_meta_strict_process_rollout_validated(&meta));
+    assert!(matrixraft_data_node_strict_process_rollout_validated(&data));
+    assert!(matrixraft_meta_strict_process_rollout_validated(&meta));
 
     data.crash_after_storage_mutation_recovered = false;
     meta.crash_during_meta_snapshot_install_recovered = false;
 
-    assert!(!rustraft_data_node_strict_process_rollout_validated(&data));
-    assert!(!rustraft_meta_strict_process_rollout_validated(&meta));
+    assert!(!matrixraft_data_node_strict_process_rollout_validated(
+        &data
+    ));
+    assert!(!matrixraft_meta_strict_process_rollout_validated(&meta));
 }
 
 #[test]
@@ -1467,7 +1470,7 @@ fn baseline_raft_runtime_capability_report_requires_read_safety_on_both_planes()
         .operational_semantics
         .minority_partition_read_rejection_observed = false;
 
-    let report = rustraft_baseline_raft_runtime_capability_report(&input);
+    let report = matrixraft_baseline_raft_runtime_capability_report(&input);
     assert!(!report.ready);
     assert!(report
         .missing
@@ -1483,8 +1486,8 @@ fn baseline_raft_runtime_capability_prometheus_exports_generic_metrics() {
     let mut input = ready_input();
     input.wal_lifecycle.as_mut().unwrap().compaction_observed = false;
 
-    let report = rustraft_baseline_raft_runtime_capability_report(&input);
-    let metrics = rustraft_baseline_raft_runtime_capability_prometheus(
+    let report = matrixraft_baseline_raft_runtime_capability_report(&input);
+    let metrics = matrixraft_baseline_raft_runtime_capability_prometheus(
         &report,
         &[("plane", "data_node"), ("cluster", "a\"b\\c\n")],
     );
@@ -1511,17 +1514,17 @@ fn baseline_raft_runtime_capability_prometheus_exports_generic_metrics() {
 
 #[test]
 fn deployment_mode_validation_is_library_owned_and_fails_closed() {
-    let ready = rustraft_production_readiness_report(&ready_input());
+    let ready = matrixraft_production_readiness_report(&ready_input());
     assert!(ready.ready);
-    assert!(rustraft_validate_deployment_mode(
+    assert!(matrixraft_validate_deployment_mode(
         RustRaftDeploymentMode::ProductionDistributed,
         &ready
     )
     .is_ok());
-    assert!(rustraft_require_production_ready(&ready).is_ok());
+    assert!(matrixraft_require_production_ready(&ready).is_ok());
 
-    let local_err =
-        rustraft_validate_deployment_mode(RustRaftDeploymentMode::LocalModel, &ready).unwrap_err();
+    let local_err = matrixraft_validate_deployment_mode(RustRaftDeploymentMode::LocalModel, &ready)
+        .unwrap_err();
     assert_eq!(local_err.mode, RustRaftDeploymentMode::LocalModel);
     assert!(local_err
         .message
@@ -1529,10 +1532,12 @@ fn deployment_mode_validation_is_library_owned_and_fails_closed() {
 
     let mut blocked_input = ready_input();
     blocked_input.peer_pipeline = None;
-    let blocked = rustraft_production_readiness_report(&blocked_input);
-    let production_err =
-        rustraft_validate_deployment_mode(RustRaftDeploymentMode::ProductionDistributed, &blocked)
-            .unwrap_err();
+    let blocked = matrixraft_production_readiness_report(&blocked_input);
+    let production_err = matrixraft_validate_deployment_mode(
+        RustRaftDeploymentMode::ProductionDistributed,
+        &blocked,
+    )
+    .unwrap_err();
     assert_eq!(
         production_err.mode,
         RustRaftDeploymentMode::ProductionDistributed
@@ -1544,7 +1549,7 @@ fn deployment_mode_validation_is_library_owned_and_fails_closed() {
         .missing
         .contains(&"pipeline:evidence_present".to_string()));
 
-    let direct_err = rustraft_validate_deployment_readiness(
+    let direct_err = matrixraft_validate_deployment_readiness(
         RustRaftDeploymentMode::ProductionDistributed,
         false,
         vec!["process_path:missing".to_string()],
@@ -1555,7 +1560,7 @@ fn deployment_mode_validation_is_library_owned_and_fails_closed() {
 
 #[test]
 fn named_readiness_blockers_expand_component_missing_details() {
-    let blockers = rustraft_named_readiness_blockers(
+    let blockers = matrixraft_named_readiness_blockers(
         "transport_security_missing",
         "transport_security.{mtls,auth}",
         ["mtls disabled", "auth token missing"],

--- a/tests/channel_selector.rs
+++ b/tests/channel_selector.rs
@@ -9,7 +9,7 @@ use matrixraft::{
 };
 
 #[test]
-fn channel_selector_selects_unique_active_channels_like_matrixraft() {
+fn channel_selector_selects_unique_active_channels() {
     let selector = RustRaftChannelSelector::<u64>::new();
     let channel_1 = RustRaftMailChannel::<u64>::new(1, 100);
     let channel_2 = RustRaftMailChannel::<u64>::new(2, 100);
@@ -42,7 +42,7 @@ fn channel_selector_selects_unique_active_channels_like_matrixraft() {
 }
 
 #[test]
-fn mail_channel_fetch_drains_priority_lanes_like_matrixraft() {
+fn mail_channel_fetch_drains_priority_lanes() {
     let selector = RustRaftChannelSelector::new();
     let channel = RustRaftMailChannel::new(9, 100);
 
@@ -85,7 +85,7 @@ fn channel_selector_delivers_global_mails_and_rearranged_inputs() {
 }
 
 #[test]
-fn channel_selector_group_count_drives_channel_overflow_like_matrixraft() {
+fn channel_selector_group_count_drives_channel_overflow() {
     let selector = RustRaftChannelSelector::new();
     let channel = RustRaftMailChannel::new(5, 2);
 

--- a/tests/checksum.rs
+++ b/tests/checksum.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_checksum_file_list, rustraft_crc32c, rustraft_murmur32, RustRaftChecksumContext,
+    matrixraft_checksum_file_list, matrixraft_crc32c, matrixraft_murmur32, RustRaftChecksumContext,
     RustRaftChecksumType, RustRaftFileChecksumContext,
 };
 use std::fs;
@@ -22,8 +22,8 @@ fn temp_dir(name: &str) -> PathBuf {
 
 #[test]
 fn checksum_context_matches_known_crc32c_and_murmur32_vectors() {
-    assert_eq!(rustraft_crc32c(b"123456789"), 0xe306_9283);
-    assert_eq!(rustraft_murmur32(b"hello"), 0x248b_fa47);
+    assert_eq!(matrixraft_crc32c(b"123456789"), 0xe306_9283);
+    assert_eq!(matrixraft_murmur32(b"hello"), 0x248b_fa47);
 
     let mut crc = RustRaftChecksumContext::new(RustRaftChecksumType::Crc32);
     crc.extend(b"123").expect("extend");
@@ -62,7 +62,7 @@ fn checksum_context_rejects_invalid_type_and_extend_after_finalize() {
 }
 
 #[test]
-fn file_checksum_context_reads_file_in_blocks_like_matrixraft() {
+fn file_checksum_context_reads_file_in_blocks() {
     let dir = temp_dir("file");
     fs::create_dir_all(&dir).expect("create dir");
     let file = dir.join("segment.log");
@@ -74,7 +74,7 @@ fn file_checksum_context_reads_file_in_blocks_like_matrixraft() {
 
     assert_eq!(result.files, vec![file.clone()]);
     assert_eq!(result.block_size, 3);
-    assert_eq!(result.checksum.value, rustraft_crc32c(b"abcdefghi"));
+    assert_eq!(result.checksum.value, matrixraft_crc32c(b"abcdefghi"));
     assert_eq!(result.checksum.chunks, 3);
     assert_eq!(result.checksum.bytes, 9);
 
@@ -90,7 +90,7 @@ fn directory_checksum_uses_recursive_sorted_file_order() {
     fs::write(dir.join("a.log"), b"a").expect("write a");
     fs::write(nested.join("c.log"), b"c").expect("write c");
 
-    let files = rustraft_checksum_file_list(&dir).expect("list files");
+    let files = matrixraft_checksum_file_list(&dir).expect("list files");
     assert_eq!(
         files
             .iter()

--- a/tests/durability_parity.rs
+++ b/tests/durability_parity.rs
@@ -2,11 +2,11 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    snapshot::{rustraft_validate_snapshot_tail_catchup, RaftSnapshot, RustRaftSnapshotMeta},
-    storage::{rustraft_validate_storage_apply_fence, RustRaftStorageApplyFence},
+    snapshot::{matrixraft_validate_snapshot_tail_catchup, RaftSnapshot, RustRaftSnapshotMeta},
+    storage::{matrixraft_validate_storage_apply_fence, RustRaftStorageApplyFence},
     wal::{
-        rustraft_durability_parity_report, rustraft_validate_hard_state_persistence,
-        rustraft_wal_checksum, LocalRaftWal, RaftWalRecord, RustRaftHardState,
+        matrixraft_durability_parity_report, matrixraft_validate_hard_state_persistence,
+        matrixraft_wal_checksum, LocalRaftWal, RaftWalRecord, RustRaftHardState,
     },
     RaftMembership, RustRaftApplySnapshotFence, RustRaftLogEntry, RustRaftLogId,
 };
@@ -58,7 +58,7 @@ fn wal_record(committed_index: u64) -> RaftWalRecord {
         },
         checksum: String::new(),
     };
-    record.checksum = rustraft_wal_checksum(&record);
+    record.checksum = matrixraft_wal_checksum(&record);
     record
 }
 
@@ -86,7 +86,7 @@ fn durability_report_accepts_generic_wal_snapshot_and_storage_fences() {
     let recovery = wal.recover().expect("recover and truncate corrupt tail");
     let recovered = recovery.recovered.clone().expect("recovered record");
     assert_eq!(recovered.hard_state.committed.as_ref().unwrap().index, 11);
-    rustraft_validate_hard_state_persistence(&recovered).expect("hard-state persisted");
+    matrixraft_validate_hard_state_persistence(&recovered).expect("hard-state persisted");
 
     let snapshot = RaftSnapshot {
         group_id: 404,
@@ -94,10 +94,10 @@ fn durability_report_accepts_generic_wal_snapshot_and_storage_fences() {
         payload: b"opaque snapshot bytes".to_vec(),
     };
     let tail = vec![tail_entry(11)];
-    rustraft_validate_snapshot_tail_catchup(&snapshot.meta, &tail).expect("tail catch-up");
-    rustraft_validate_storage_apply_fence(&storage_fence()).expect("storage apply fence");
+    matrixraft_validate_snapshot_tail_catchup(&snapshot.meta, &tail).expect("tail catch-up");
+    matrixraft_validate_storage_apply_fence(&storage_fence()).expect("storage apply fence");
 
-    let report = rustraft_durability_parity_report(
+    let report = matrixraft_durability_parity_report(
         &recovered,
         &recovery,
         Some(&snapshot),
@@ -118,7 +118,7 @@ fn storage_apply_fence_rejects_durable_apply_ahead_of_memory_apply() {
     let mut fence = storage_fence();
     fence.durable_applied_index = 12;
 
-    let err = rustraft_validate_storage_apply_fence(&fence).expect_err("invalid fence");
+    let err = matrixraft_validate_storage_apply_fence(&fence).expect_err("invalid fence");
     assert!(err.to_string().contains("durable applied index"));
 }
 
@@ -126,13 +126,13 @@ fn storage_apply_fence_rejects_durable_apply_ahead_of_memory_apply() {
 fn snapshot_tail_catchup_rejects_overlap_and_gaps_after_snapshot_floor() {
     let meta = snapshot_meta();
     let overlap = vec![tail_entry(10)];
-    assert!(rustraft_validate_snapshot_tail_catchup(&meta, &overlap)
+    assert!(matrixraft_validate_snapshot_tail_catchup(&meta, &overlap)
         .unwrap_err()
         .to_string()
         .contains("overlaps installed snapshot"));
 
     let gap = vec![tail_entry(12)];
-    assert!(rustraft_validate_snapshot_tail_catchup(&meta, &gap)
+    assert!(matrixraft_validate_snapshot_tail_catchup(&meta, &gap)
         .unwrap_err()
         .to_string()
         .contains("not contiguous"));

--- a/tests/fault_harness_contract.rs
+++ b/tests/fault_harness_contract.rs
@@ -2,12 +2,12 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::fault::{
-    rustraft_baseline_raft_fault_scenarios, rustraft_fault_harness_readiness_report,
+    matrixraft_baseline_raft_fault_scenarios, matrixraft_fault_harness_readiness_report,
     RustRaftFaultScenario, RustRaftFaultScenarioEvidence,
 };
 
 fn passing_evidence(scenario: RustRaftFaultScenario) -> RustRaftFaultScenarioEvidence {
-    let observed_acceptance = rustraft_baseline_raft_fault_scenarios()
+    let observed_acceptance = matrixraft_baseline_raft_fault_scenarios()
         .into_iter()
         .find(|requirement| requirement.scenario == scenario)
         .expect("scenario requirement")
@@ -32,7 +32,7 @@ fn passing_evidence(scenario: RustRaftFaultScenario) -> RustRaftFaultScenarioEvi
 
 #[test]
 fn baseline_raft_fault_contract_names_required_process_scenarios() {
-    let scenarios = rustraft_baseline_raft_fault_scenarios()
+    let scenarios = matrixraft_baseline_raft_fault_scenarios()
         .into_iter()
         .map(|item| item.scenario.id())
         .collect::<std::collections::BTreeSet<_>>();
@@ -55,7 +55,7 @@ fn baseline_raft_fault_contract_names_required_process_scenarios() {
 
 #[test]
 fn fault_harness_readiness_fails_closed_on_missing_process_evidence() {
-    let report = rustraft_fault_harness_readiness_report(&[]);
+    let report = matrixraft_fault_harness_readiness_report(&[]);
 
     assert!(!report.ready);
     assert!(report
@@ -71,7 +71,7 @@ fn fault_harness_readiness_fails_closed_on_missing_process_evidence() {
 
 #[test]
 fn fault_harness_readiness_requires_independent_stores_safety_recovery_and_metrics() {
-    let report = rustraft_fault_harness_readiness_report(&[RustRaftFaultScenarioEvidence {
+    let report = matrixraft_fault_harness_readiness_report(&[RustRaftFaultScenarioEvidence {
         scenario: RustRaftFaultScenario::PacketLossMajority,
         process_path_observed: true,
         spawned_process_count: 3,
@@ -107,7 +107,7 @@ fn fault_harness_readiness_requires_nontrivial_workload_and_fault_injection() {
     evidence.client_operation_count = 0;
     evidence.injected_fault_count = 0;
 
-    let report = rustraft_fault_harness_readiness_report(&[evidence]);
+    let report = matrixraft_fault_harness_readiness_report(&[evidence]);
 
     assert!(!report.ready);
     assert!(report
@@ -128,7 +128,7 @@ fn fault_harness_readiness_requires_distinct_real_process_evidence() {
     evidence.observed_process_ids = vec![10_001, 10_001, 10_001];
     evidence.report_path = None;
 
-    let report = rustraft_fault_harness_readiness_report(&[evidence]);
+    let report = matrixraft_fault_harness_readiness_report(&[evidence]);
 
     assert!(!report.ready);
     assert!(report
@@ -149,7 +149,7 @@ fn fault_harness_readiness_requires_exact_baseline_raft_acceptance_markers() {
         .observed_acceptance
         .retain(|item| item != "read_eligible_after_heal_catchup");
 
-    let report = rustraft_fault_harness_readiness_report(&[evidence]);
+    let report = matrixraft_fault_harness_readiness_report(&[evidence]);
 
     assert!(!report.ready);
     assert!(report
@@ -159,11 +159,11 @@ fn fault_harness_readiness_requires_exact_baseline_raft_acceptance_markers() {
 
 #[test]
 fn fault_harness_readiness_accepts_complete_baseline_raft_style_evidence() {
-    let evidence = rustraft_baseline_raft_fault_scenarios()
+    let evidence = matrixraft_baseline_raft_fault_scenarios()
         .into_iter()
         .map(|requirement| passing_evidence(requirement.scenario))
         .collect::<Vec<_>>();
-    let report = rustraft_fault_harness_readiness_report(&evidence);
+    let report = matrixraft_fault_harness_readiness_report(&evidence);
 
     assert!(report.ready, "{report:#?}");
     assert!(report.missing.is_empty());
@@ -175,7 +175,7 @@ fn leader_transfer_under_load_requires_exact_once_report_path() {
     let mut evidence = passing_evidence(RustRaftFaultScenario::LeaderTransferUnderLoad);
     evidence.report_path = None;
 
-    let report = rustraft_fault_harness_readiness_report(&[evidence]);
+    let report = matrixraft_fault_harness_readiness_report(&[evidence]);
 
     assert!(!report.ready);
     assert!(report

--- a/tests/fsm_adapter.rs
+++ b/tests/fsm_adapter.rs
@@ -111,11 +111,11 @@ fn fsm_adapter_replay_report_tracks_applied_and_skipped_entries() {
 }
 
 #[test]
-fn fsm_adapter_batch_apply_skips_noops_and_defers_suffix_like_matrixraft() {
+fn fsm_adapter_batch_apply_skips_noops_and_defers_suffix() {
     let mut adapter = RaftFsmAdapter::new(7, CountingFsm::default());
 
     let report = adapter
-        .apply_batch_like_matrixraft(
+        .apply_batch(
             &[
                 noop(1, 1),
                 entry(1, 2, b"set-a"),
@@ -148,10 +148,10 @@ fn fsm_adapter_batch_apply_replays_noop_idempotently() {
     let mut adapter = RaftFsmAdapter::new(7, CountingFsm::default());
 
     adapter
-        .apply_batch_like_matrixraft(&[noop(1, 1), entry(1, 2, b"set-a")], 16)
+        .apply_batch(&[noop(1, 1), entry(1, 2, b"set-a")], 16)
         .expect("first batch");
     let replay = adapter
-        .apply_batch_like_matrixraft(&[noop(1, 1), entry(1, 2, b"set-a")], 16)
+        .apply_batch(&[noop(1, 1), entry(1, 2, b"set-a")], 16)
         .expect("replay batch");
 
     assert_eq!(replay.attempted, 2);

--- a/tests/generic_model_contract.rs
+++ b/tests/generic_model_contract.rs
@@ -94,7 +94,7 @@ fn generic_models_accept_domain_payload_and_group_ids() {
 }
 
 #[test]
-fn rustraft_core_does_not_export_temporalstore_command_or_shard_names() {
+fn matrixraft_core_does_not_export_temporalstore_command_or_shard_names() {
     let lib_rs = include_str!("../src/lib.rs");
 
     assert!(!lib_rs.contains("pub struct Command"));

--- a/tests/lease.rs
+++ b/tests/lease.rs
@@ -24,7 +24,7 @@ fn peers_with_roles(items: &[(u64, RustRaftReplicaRole)]) -> Vec<RustRaftLeasePe
 }
 
 #[test]
-fn leader_lease_renews_from_quorum_confirmations_like_matrixraft() {
+fn leader_lease_renews_from_quorum_confirmations() {
     let mut lease = RustRaftLeaderLease::new(1, 50);
     lease.update_members(voters(&[1, 2, 3]));
     lease.reset(1);

--- a/tests/log_buffer.rs
+++ b/tests/log_buffer.rs
@@ -16,7 +16,7 @@ fn range(start: u64, end: u64, term: u64) -> Vec<RustRaftLogEntry> {
 }
 
 #[test]
-fn log_buffer_tracks_range_terms_and_bounded_load_like_matrixraft() {
+fn log_buffer_tracks_range_terms_and_bounded_load() {
     let mut buffer = RustRaftLogBuffer::new(1000, RustRaftLogId { term: 0, index: 0 });
     assert_eq!(buffer.range(), (1, 1));
     assert_eq!(buffer.last_index(), 0);
@@ -56,7 +56,7 @@ fn log_buffer_tracks_range_terms_and_bounded_load_like_matrixraft() {
 }
 
 #[test]
-fn log_buffer_flush_and_apply_append_result_handles_rollback_like_matrixraft() {
+fn log_buffer_flush_and_apply_append_result_handles_rollback() {
     let mut buffer = RustRaftLogBuffer::new(1000, RustRaftLogId { term: 0, index: 0 });
     buffer.append_many(range(1, 6, 1)).expect("append stable");
     buffer.mark_all_stabled();
@@ -84,7 +84,7 @@ fn log_buffer_flush_and_apply_append_result_handles_rollback_like_matrixraft() {
 }
 
 #[test]
-fn log_buffer_apply_append_result_skips_expired_flush_like_matrixraft() {
+fn log_buffer_apply_append_result_skips_expired_flush() {
     let mut buffer = RustRaftLogBuffer::new(1000, RustRaftLogId { term: 0, index: 0 });
     buffer.append_many(range(1, 6, 1)).expect("append stable");
     buffer.mark_all_stabled();
@@ -106,7 +106,7 @@ fn log_buffer_apply_append_result_skips_expired_flush_like_matrixraft() {
 }
 
 #[test]
-fn log_buffer_reset_truncate_and_release_memory_like_matrixraft() {
+fn log_buffer_reset_truncate_and_release_memory() {
     let mut buffer = RustRaftLogBuffer::new(128, RustRaftLogId { term: 0, index: 0 });
     buffer
         .append_many((1..=10).map(|index| entry(index, 1)).collect())

--- a/tests/mailbox.rs
+++ b/tests/mailbox.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use matrixraft::{RustRaftMailBox, RustRaftMailBoxFetchPolicy, RustRaftMailPriority};
 
 #[test]
-fn mailbox_try_send_applies_per_priority_high_watermark_like_matrixraft() {
+fn mailbox_try_send_applies_per_priority_high_watermark() {
     let mailbox = RustRaftMailBox::new(2);
 
     assert!(mailbox.try_send(RustRaftMailPriority::Normal, 1));
@@ -21,7 +21,7 @@ fn mailbox_try_send_applies_per_priority_high_watermark_like_matrixraft() {
 }
 
 #[test]
-fn mailbox_fetch_prioritizes_urgent_and_limits_included_lanes_like_matrixraft() {
+fn mailbox_fetch_prioritizes_urgent_and_limits_included_lanes() {
     let mailbox = RustRaftMailBox::new(8);
     mailbox.send(RustRaftMailPriority::Slowly, "slow-1");
     mailbox.send(RustRaftMailPriority::Normal, "normal-1");

--- a/tests/membership_executor.rs
+++ b/tests/membership_executor.rs
@@ -259,7 +259,7 @@ fn pending_membership_change_fence_matches_baseline_raft_config_change_rule() {
 }
 
 #[test]
-fn saving_membership_change_blocks_next_config_until_stabled_like_matrixraft() {
+fn saving_membership_change_blocks_next_config_until_stabled() {
     let mut cluster = RaftCluster::new(
         70,
         Default::default(),
@@ -316,7 +316,7 @@ fn saving_membership_change_blocks_next_config_until_stabled_like_matrixraft() {
 }
 
 #[test]
-fn snapshot_applied_clears_covered_membership_change_like_matrixraft() {
+fn snapshot_applied_clears_covered_membership_change() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),

--- a/tests/membership_wal_snapshot.rs
+++ b/tests/membership_wal_snapshot.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_validate_snapshot_floor_log_matching, rustraft_validate_snapshot_install,
-    rustraft_wal_checksum, rustraft_wal_checksum_valid, JointConsensusMembership, LocalRaftWal,
+    matrixraft_validate_snapshot_floor_log_matching, matrixraft_validate_snapshot_install,
+    matrixraft_wal_checksum, matrixraft_wal_checksum_valid, JointConsensusMembership, LocalRaftWal,
     RaftCluster, RaftHardState, RaftMembership, RaftSnapshot, RaftSnapshotInstallState,
     RaftWalRecord, RustRaftApplySnapshotFence, RustRaftLogEntry, RustRaftLogId, RustRaftPeer,
     RustRaftReplicaRole, RustRaftSnapshotChunk, RustRaftSnapshotMeta,
@@ -49,7 +49,7 @@ fn wal_record(index: u64) -> RaftWalRecord {
         },
         checksum: String::new(),
     };
-    record.checksum = rustraft_wal_checksum(&record);
+    record.checksum = matrixraft_wal_checksum(&record);
     record
 }
 
@@ -215,7 +215,7 @@ fn local_raft_wal_segments_recovers_and_truncates_corrupt_tail() {
     wal.append(wal_record(2)).expect("append");
     wal.append(wal_record(3)).expect("append");
     assert_eq!(wal.segments().len(), 2);
-    assert!(rustraft_wal_checksum_valid(&wal.records()[2]));
+    assert!(matrixraft_wal_checksum_valid(&wal.records()[2]));
 
     wal.corrupt_tail_for_test().expect("corrupt tail");
     let report = wal.recover().expect("recover");
@@ -268,14 +268,14 @@ fn chunked_snapshot_install_validates_offsets_and_snapshot_fence() {
         installed_snapshot_index: 10,
         first_retained_log_index: 11,
     };
-    rustraft_validate_snapshot_install(&snapshot, &fence).expect("valid install");
-    rustraft_validate_snapshot_floor_log_matching(
+    matrixraft_validate_snapshot_install(&snapshot, &fence).expect("valid install");
+    matrixraft_validate_snapshot_floor_log_matching(
         &meta,
         11,
         Some(&RustRaftLogId { term: 4, index: 10 }),
     )
     .expect("floor matches");
-    assert!(rustraft_validate_snapshot_floor_log_matching(
+    assert!(matrixraft_validate_snapshot_floor_log_matching(
         &meta,
         11,
         Some(&RustRaftLogId { term: 3, index: 10 }),

--- a/tests/module_contract.rs
+++ b/tests/module_contract.rs
@@ -8,18 +8,18 @@ use matrixraft::{
         JointConsensusMembership, RaftMembershipExecutor, RaftMembershipOperation, RustRaftPeer,
         RustRaftReplicaRole,
     },
-    metrics::rustraft_metric_names,
+    metrics::matrixraft_metric_names,
     node::{RaftNodeRuntime, RustRaftNodeOptions},
     readiness::{
-        rustraft_open_source_surface, rustraft_parity_report, rustraft_public_api_contract,
-        rustraft_standalone_readiness_report, rustraft_temporalstore_adapter_shape,
+        matrixraft_open_source_surface, matrixraft_parity_report, matrixraft_public_api_contract,
+        matrixraft_standalone_readiness_report, matrixraft_temporalstore_adapter_shape,
         RustRaftReadinessSnapshot,
     },
     snapshot::{
         PersistentRaftSnapshotStoreOptions, RaftSnapshot, RustRaftApplySnapshotFence,
         RustRaftSnapshotMeta,
     },
-    status::{rustraft_cluster_status_report, RaftHealthStatus},
+    status::{matrixraft_cluster_status_report, RaftHealthStatus},
     transport::{AppendEntriesRequest, ReadIndexRequest, RustRaftTransport, VoteRequest},
     wal::{PersistentRaftWalOptions, RaftHardState, RaftWalRecord},
 };
@@ -130,7 +130,7 @@ fn public_modules_expose_temporalstore_consumption_boundary() {
     assert!(membership.witnesses.contains(&5));
     assert!(!membership.voters.contains(&3));
 
-    let report = rustraft_cluster_status_report(
+    let report = matrixraft_cluster_status_report(
         cluster.group_id,
         cluster.leader_id(),
         cluster.leader_transfer_state(),
@@ -140,26 +140,26 @@ fn public_modules_expose_temporalstore_consumption_boundary() {
     assert_eq!(report.leader_id, Some(1));
 
     let readiness = RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     };
-    assert!(rustraft_parity_report(&readiness).ready);
-    assert!(!rustraft_metric_names().append_latency_ms.is_empty());
+    assert!(matrixraft_parity_report(&readiness).ready);
+    assert!(!matrixraft_metric_names().append_latency_ms.is_empty());
 }
 
 #[test]
 fn standalone_readiness_report_covers_non_temporalstore_embedding_status() {
-    let report = rustraft_standalone_readiness_report();
+    let report = matrixraft_standalone_readiness_report();
     assert!(report.standalone, "{:?}", report.missing);
     assert_eq!(
         report.production_status,
@@ -208,14 +208,14 @@ fn standalone_readiness_report_covers_non_temporalstore_embedding_status() {
         .iter()
         .all(|item| !item.contains("TemporalStore")));
 
-    let api = rustraft_public_api_contract();
+    let api = matrixraft_public_api_contract();
     assert!(api
         .compatibility_reports
-        .contains(&"rustraft_standalone_readiness_report".to_string()));
-    let surface = rustraft_open_source_surface();
+        .contains(&"matrixraft_standalone_readiness_report".to_string()));
+    let surface = matrixraft_open_source_surface();
     assert!(surface
         .compatibility_reports
-        .contains(&"rustraft_standalone_readiness_report".to_string()));
+        .contains(&"matrixraft_standalone_readiness_report".to_string()));
 }
 
 #[test]
@@ -243,7 +243,7 @@ fn public_modules_export_runtime_storage_wal_snapshot_and_transport_types() {
 
 #[test]
 fn open_source_surface_names_modules_examples_reports_and_adapter_boundary() {
-    let api = rustraft_public_api_contract();
+    let api = matrixraft_public_api_contract();
     for module in [
         "node",
         "cluster",
@@ -268,9 +268,9 @@ fn open_source_surface_names_modules_examples_reports_and_adapter_boundary() {
         .contains(&"RustRaftBenchmarkRunner".to_string()));
     assert!(api
         .compatibility_reports
-        .contains(&"rustraft_production_readiness_report".to_string()));
+        .contains(&"matrixraft_production_readiness_report".to_string()));
 
-    let surface = rustraft_open_source_surface();
+    let surface = matrixraft_open_source_surface();
     assert_eq!(surface.crate_name, "rustraft");
     assert!(surface.public_modules.contains(&"wal".to_string()));
     assert!(surface.embedding_docs.contains(&"README.md".to_string()));
@@ -279,15 +279,15 @@ fn open_source_surface_names_modules_examples_reports_and_adapter_boundary() {
         .contains(&"leader_election".to_string()));
     assert!(surface
         .benchmark_harness_interface
-        .contains(&"rustraft_run_baseline_raft_parity_benchmark".to_string()));
+        .contains(&"matrixraft_run_baseline_raft_parity_benchmark".to_string()));
     assert!(surface
         .compatibility_reports
-        .contains(&"rustraft_public_api_contract".to_string()));
+        .contains(&"matrixraft_public_api_contract".to_string()));
     assert!(surface
         .temporalstore_adapter_boundary
         .iter()
         .any(|item| item.contains("TemporalStore command codecs")));
-    let adapter_shape = rustraft_temporalstore_adapter_shape();
+    let adapter_shape = matrixraft_temporalstore_adapter_shape();
     assert_eq!(adapter_shape.node_field, "node");
     assert!(adapter_shape.node_runtime_type.contains("RaftNodeRuntime"));
     assert!(adapter_shape
@@ -329,7 +329,7 @@ fn debug_artifacts_example_exports_complete_support_envelope() {
     assert!(example.contains("snapshot.diagnostic_prometheus"));
     assert!(example.contains("snapshot.optimization_prometheus"));
     assert!(example.contains("snapshot.runbook_prometheus"));
-    assert!(example.contains("rustraft_operator_runbook_prometheus(&provisioning.runbook_steps"));
+    assert!(example.contains("matrixraft_operator_runbook_prometheus(&provisioning.runbook_steps"));
     assert!(example.contains("missing_debug_artifacts"));
     assert!(example.contains("extra_debug_artifacts"));
     assert!(example.contains("debug_artifact_unadvertised"));

--- a/tests/node_runtime.rs
+++ b/tests/node_runtime.rs
@@ -8,7 +8,7 @@ use matrixraft::{
     RustRaftNodeOptions, RustRaftPeer, RustRaftProposeOptions, RustRaftReplicaRole,
     RustRaftRequestTimer, RustRaftSnapshotChunk, RustRaftSnapshotMeta, RustRaftSnapshotState,
     RustRaftStepResult, RustRaftStorageApplyFence, RustRaftTickBackpressure, VoteRequest,
-    RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS,
+    MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -254,7 +254,7 @@ fn node_runtime_expires_and_renews_leader_lease() {
 }
 
 #[test]
-fn node_runtime_steps_down_leader_after_lost_quorum_like_matrixraft() {
+fn node_runtime_steps_down_leader_after_lost_quorum() {
     let mut options = node_options();
     options.config.heartbeat_interval_ms = 5;
     options.config.election_timeout_ms = 50;
@@ -295,7 +295,7 @@ fn node_runtime_steps_down_leader_after_lost_quorum_like_matrixraft() {
 }
 
 #[test]
-fn node_runtime_election_timeout_campaigns_after_stale_leader_like_matrixraft() {
+fn node_runtime_election_timeout_campaigns_after_stale_leader() {
     let mut options = node_options();
     options.node_id = 2;
     options.config.enable_lease_read = false;
@@ -328,7 +328,7 @@ fn node_runtime_election_timeout_campaigns_after_stale_leader_like_matrixraft() 
 }
 
 #[test]
-fn node_runtime_transfers_leader_on_fatal_event_like_matrixraft() {
+fn node_runtime_transfers_leader_on_fatal_event() {
     let mut runtime = RaftNodeRuntime::create(node_options()).expect("create runtime");
     runtime.start().expect("start runtime");
     runtime
@@ -528,7 +528,7 @@ fn node_runtime_step_down_transfers_to_selected_follower() {
 }
 
 #[test]
-fn node_runtime_resigns_leader_without_transfer_target_like_matrixraft() {
+fn node_runtime_resigns_leader_without_transfer_target() {
     let mut runtime = RaftNodeRuntime::create(node_options()).expect("create runtime");
     runtime.start().expect("start runtime");
     runtime.set_node_healthy(2, false).expect("stop follower 2");
@@ -987,7 +987,7 @@ fn node_runtime_reports_all_peer_pipeline_statuses() {
 }
 
 #[test]
-fn node_runtime_steps_batch_of_raft_messages_like_matrixraft() {
+fn node_runtime_steps_batch_of_raft_messages() {
     let mut runtime = RaftNodeRuntime::create(node_options()).expect("create runtime");
     runtime.start().expect("start runtime");
 
@@ -1266,7 +1266,7 @@ fn node_runtime_tracks_and_expires_reorder_queue() {
 }
 
 #[test]
-fn tick_backpressure_caps_pending_ticks_like_matrixraft() {
+fn tick_backpressure_caps_pending_ticks() {
     let mut ticks = RustRaftTickBackpressure::new(2);
 
     let first = ticks.admit_tick();
@@ -1313,11 +1313,11 @@ fn tick_backpressure_handles_empty_completion_and_reset() {
 }
 
 #[test]
-fn request_timer_watch_cancel_and_notify_like_matrixraft() {
+fn request_timer_watch_cancel_and_notify() {
     let mut timer = RustRaftRequestTimer::new();
     assert_eq!(
         timer.next_timeout_ms(100),
-        RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS
+        MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS
     );
 
     assert!(timer.watch(1, 1, 0, 100).is_none());
@@ -1325,7 +1325,7 @@ fn request_timer_watch_cancel_and_notify_like_matrixraft() {
     assert_eq!(timer.timed_len(), 0);
     assert_eq!(
         timer.next_timeout_ms(100),
-        RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS
+        MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS
     );
 
     assert!(timer.watch(1, 2, 110, 100).is_none());
@@ -1344,7 +1344,7 @@ fn request_timer_watch_cancel_and_notify_like_matrixraft() {
 }
 
 #[test]
-fn request_timer_lapses_with_limit_and_removes_node_tasks_like_matrixraft() {
+fn request_timer_lapses_with_limit_and_removes_node_tasks() {
     let mut timer = RustRaftRequestTimer::new();
     timer.watch(1, 1, 90, 80);
     timer.watch(1, 2, 95, 80);
@@ -1367,7 +1367,7 @@ fn request_timer_lapses_with_limit_and_removes_node_tasks_like_matrixraft() {
     assert!(timer.is_empty());
     assert_eq!(
         timer.next_timeout_ms(100),
-        RUSTRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS
+        MATRIXRAFT_REQUEST_TIMER_MAX_TIMEOUT_MS
     );
 }
 

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_wal_checksum_format, rustraft_wal_lifecycle_evidence, PersistentRaftWal,
+    matrixraft_wal_checksum_format, matrixraft_wal_lifecycle_evidence, PersistentRaftWal,
     PersistentRaftWalOptions, RaftWalRecord, RustRaftApplySnapshotFence, RustRaftHardState,
     RustRaftLogEntry, RustRaftLogId, RustRaftMembership, RustRaftStorageApplyFence,
 };
@@ -100,7 +100,7 @@ fn persistent_wal_writer_reports_checksum_segment_index_and_retained_range() {
     let first = wal.append_with_report(wal_record(1)).expect("append first");
     assert_eq!(first.segment_id, 0);
     assert_eq!(first.log_index, 1);
-    assert_eq!(first.checksum_format, rustraft_wal_checksum_format());
+    assert_eq!(first.checksum_format, matrixraft_wal_checksum_format());
     assert!(first.hard_state_persisted);
     assert!(first.fsync_on_append);
     assert_eq!(first.retained_range.first_log_index, 1);
@@ -144,7 +144,7 @@ fn persistent_wal_truncates_corrupt_tail_on_recovery() {
     assert_eq!(report.segments_scanned, 1);
     assert_eq!(
         report.checksum_format.expect("checksum format"),
-        rustraft_wal_checksum_format()
+        matrixraft_wal_checksum_format()
     );
     assert_eq!(
         report
@@ -174,7 +174,7 @@ fn persistent_wal_compacts_released_segments_and_reports_lifecycle_evidence() {
     assert_eq!(status.segment_count, 1);
     assert_eq!(status.first_log_index, 5);
     assert_eq!(status.released_segment_count, 2);
-    let evidence = rustraft_wal_lifecycle_evidence(&status);
+    let evidence = matrixraft_wal_lifecycle_evidence(&status);
     assert!(evidence.segment_lifecycle_present);
     assert!(evidence.compaction_observed);
 
@@ -253,7 +253,7 @@ fn persistent_wal_reports_slow_fsync_backpressure_through_lifecycle_status() {
     assert!(released.fence_valid);
     assert!(released.released_segments > 0);
 
-    let evidence = rustraft_wal_lifecycle_evidence(&wal.status());
+    let evidence = matrixraft_wal_lifecycle_evidence(&wal.status());
     assert!(evidence.compaction_observed);
     assert!(evidence.slow_fsync_backpressure_observed);
     assert!(evidence.compaction_after_slow_fsync_observed);

--- a/tests/process_rollout_readiness.rs
+++ b/tests/process_rollout_readiness.rs
@@ -3,8 +3,8 @@
 
 use matrixraft::{
     readiness::{
-        rustraft_data_node_process_rollout_readiness_report,
-        rustraft_meta_process_rollout_readiness_report,
+        matrixraft_data_node_process_rollout_readiness_report,
+        matrixraft_meta_process_rollout_readiness_report,
     },
     RustRaftDataNodeProcessRolloutReport, RustRaftMetaProcessRolloutReport,
     RustRaftProcessNodeEvidence, RustRaftProcessOperationalSemanticsEvidence,
@@ -172,7 +172,7 @@ fn data_node_process_rollout_report_fails_closed_on_missing_process_proof() {
     rollout.independent_wal_dirs = false;
     rollout.operational_semantics.stale_follower_write_rejected = false;
 
-    let report = rustraft_data_node_process_rollout_readiness_report(&rollout);
+    let report = matrixraft_data_node_process_rollout_readiness_report(&rollout);
     assert!(!report.ready);
     assert_eq!(report.production_status, RustRaftProductionStatus::Blocked);
     assert!(report
@@ -185,7 +185,7 @@ fn data_node_process_rollout_report_fails_closed_on_missing_process_proof() {
 
 #[test]
 fn data_node_process_rollout_report_accepts_complete_process_evidence() {
-    let report = rustraft_data_node_process_rollout_readiness_report(&ready_data_rollout());
+    let report = matrixraft_data_node_process_rollout_readiness_report(&ready_data_rollout());
     assert!(report.ready, "{report:#?}");
     assert_eq!(
         report.production_status,
@@ -203,7 +203,7 @@ fn metaserver_process_rollout_report_tracks_scheduler_and_membership_proof() {
     rollout.scheduler_task_replay_validated = false;
     rollout.data_node_raft_group_results_observed = false;
 
-    let report = rustraft_meta_process_rollout_readiness_report(&rollout);
+    let report = matrixraft_meta_process_rollout_readiness_report(&rollout);
     assert!(!report.ready);
     assert!(report
         .missing
@@ -215,7 +215,7 @@ fn metaserver_process_rollout_report_tracks_scheduler_and_membership_proof() {
 
 #[test]
 fn metaserver_process_rollout_report_accepts_complete_process_evidence() {
-    let report = rustraft_meta_process_rollout_readiness_report(&ready_meta_rollout());
+    let report = matrixraft_meta_process_rollout_readiness_report(&ready_meta_rollout());
     assert!(report.ready, "{report:#?}");
     assert_eq!(report.scope, "metaserver");
     assert!(report

--- a/tests/public_contract_examples.rs
+++ b/tests/public_contract_examples.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    readiness::rustraft_temporalstore_adapter_shape, rustraft_parity_report,
-    rustraft_read_safety_decision, rustraft_temporalstore_extraction_plan,
+    matrixraft_parity_report, matrixraft_read_safety_decision,
+    matrixraft_temporalstore_extraction_plan, readiness::matrixraft_temporalstore_adapter_shape,
     RustRaftExtractionStatus, RustRaftProductionStatus, RustRaftReadIndexRequest,
     RustRaftReadinessSnapshot, RustRaftRole, RustRaftStatusSnapshot,
 };
@@ -11,21 +11,21 @@ use matrixraft::{
 #[test]
 fn production_readiness_snapshot_reports_ready_when_all_evidence_is_present() {
     let readiness = RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     };
 
-    let report = rustraft_parity_report(&readiness);
+    let report = matrixraft_parity_report(&readiness);
     assert!(report.ready);
     assert!(report.missing.is_empty());
     assert_eq!(
@@ -49,7 +49,7 @@ fn read_safety_example_rejects_reads_ahead_of_applied_index() {
         peers: Vec::new(),
     };
 
-    let decision = rustraft_read_safety_decision(
+    let decision = matrixraft_read_safety_decision(
         &status,
         &RustRaftReadIndexRequest {
             group_id: 7,
@@ -65,7 +65,7 @@ fn read_safety_example_rejects_reads_ahead_of_applied_index() {
 
 #[test]
 fn extraction_plan_keeps_reusable_raft_logic_out_of_temporalstore() {
-    let plan = rustraft_temporalstore_extraction_plan();
+    let plan = matrixraft_temporalstore_extraction_plan();
     assert!(plan.policy.contains("RustRaft owns reusable consensus"));
     assert!(plan
         .slices
@@ -87,7 +87,7 @@ fn extraction_plan_keeps_reusable_raft_logic_out_of_temporalstore() {
 
 #[test]
 fn temporalstore_adapter_shape_keeps_consensus_inside_rustraft_runtime() {
-    let shape = rustraft_temporalstore_adapter_shape();
+    let shape = matrixraft_temporalstore_adapter_shape();
     assert_eq!(shape.backend_type, "TemporalRaftConsensusBackend");
     assert_eq!(shape.node_field, "node");
     assert_eq!(
@@ -97,7 +97,7 @@ fn temporalstore_adapter_shape_keeps_consensus_inside_rustraft_runtime() {
     assert_eq!(shape.codec_field, "codec: TemporalCommandCodec");
     assert_eq!(shape.engine_field, "engine: TemporalEngine");
     assert!(shape
-        .rustraft_owned
+        .matrixraft_owned
         .iter()
         .any(|item| item.contains("consensus node runtime")));
     for temporalstore_owned in [

--- a/tests/raft_cluster_engine.rs
+++ b/tests/raft_cluster_engine.rs
@@ -92,7 +92,7 @@ fn cluster_start_campaigns_and_tracks_leader_term() {
 }
 
 #[test]
-fn initial_campaign_appends_noop_like_matrixraft() {
+fn initial_campaign_appends_noop() {
     let mut cluster = three_node_cluster();
 
     cluster.start().expect("cluster starts");
@@ -114,7 +114,7 @@ fn initial_campaign_appends_noop_like_matrixraft() {
 }
 
 #[test]
-fn campaign_on_current_leader_is_noop_like_matrixraft_admin_election() {
+fn campaign_on_current_leader_is_noop_admin_election() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"base".to_vec()).expect("base append");
@@ -167,7 +167,7 @@ fn prohibits_election_blocks_normal_campaign_but_allows_forced_campaign() {
 }
 
 #[test]
-fn prohibits_election_does_not_reject_remote_votes_like_matrixraft() {
+fn prohibits_election_does_not_reject_remote_votes() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"base".to_vec()).expect("base append");
@@ -250,7 +250,7 @@ fn timeout_now_campaigns_only_followers_like_baseline_raft() {
 }
 
 #[test]
-fn added_peer_catches_up_immediately_like_matrixraft() {
+fn added_peer_catches_up_immediately() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"before-add".to_vec()).expect("propose");
@@ -285,7 +285,7 @@ fn added_peer_catches_up_immediately_like_matrixraft() {
 }
 
 #[test]
-fn commit_quorum_counts_stored_match_from_unhealthy_peer_like_matrixraft() {
+fn commit_quorum_counts_stored_match_from_unhealthy_peer() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     let leader = cluster.leader_id().expect("leader");
@@ -344,7 +344,7 @@ fn propose_replicates_to_quorum_and_advances_commit_and_apply() {
 }
 
 #[test]
-fn propose_preserves_command_entry_flag_like_matrixraft() {
+fn propose_preserves_command_entry_flag() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -389,7 +389,7 @@ fn propose_preserves_command_entry_flag_like_matrixraft() {
 }
 
 #[test]
-fn membership_proposal_downgrades_second_unapplied_change_like_matrixraft() {
+fn membership_proposal_downgrades_second_unapplied_change() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -510,7 +510,7 @@ fn witness_append_entries_store_command_entries_as_metadata_without_payload() {
 }
 
 #[test]
-fn membership_proposal_ignores_stale_expected_term_like_matrixraft_config_change() {
+fn membership_proposal_ignores_stale_expected_term_config_change() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -547,7 +547,7 @@ fn membership_proposal_ignores_stale_expected_term_like_matrixraft_config_change
 }
 
 #[test]
-fn rejected_apply_result_blocks_apply_until_snapshot_like_matrixraft() {
+fn rejected_apply_result_blocks_apply_until_snapshot() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -784,7 +784,7 @@ fn rejected_apply_result_blocks_apply_until_snapshot_like_matrixraft() {
 }
 
 #[test]
-fn snapshot_install_resets_membership_and_preserves_receiver_like_matrixraft() {
+fn snapshot_install_resets_membership_and_preserves_receiver() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -843,7 +843,7 @@ fn snapshot_install_resets_membership_and_preserves_receiver_like_matrixraft() {
 }
 
 #[test]
-fn stale_snapshot_rpc_is_acknowledged_without_install_like_matrixraft() {
+fn stale_snapshot_rpc_is_acknowledged_without_install() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"committed".to_vec()).expect("propose");
@@ -907,7 +907,7 @@ fn stale_snapshot_rpc_is_acknowledged_without_install_like_matrixraft() {
 }
 
 #[test]
-fn snapshot_rpc_waits_for_apply_drain_like_matrixraft() {
+fn snapshot_rpc_waits_for_apply_drain() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"first".to_vec()).expect("first propose");
@@ -963,7 +963,7 @@ fn snapshot_rpc_waits_for_apply_drain_like_matrixraft() {
 }
 
 #[test]
-fn compaction_waits_for_safe_apply_index_like_matrixraft() {
+fn compaction_waits_for_safe_apply_index() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"first".to_vec()).expect("first propose");
@@ -1081,7 +1081,7 @@ fn compaction_waits_for_safe_apply_index_like_matrixraft() {
 }
 
 #[test]
-fn busy_propose_releases_safe_memory_like_matrixraft() {
+fn busy_propose_releases_safe_memory() {
     let config = RaftConfig {
         max_log_buffer_bytes: 9,
         ..Default::default()
@@ -1126,7 +1126,7 @@ fn busy_propose_releases_safe_memory_like_matrixraft() {
 }
 
 #[test]
-fn high_watermark_propose_releases_safe_memory_before_hard_busy_like_matrixraft() {
+fn high_watermark_propose_releases_safe_memory_before_hard_busy() {
     let config = RaftConfig {
         max_log_buffer_bytes: 9,
         ..Default::default()
@@ -1168,7 +1168,7 @@ fn high_watermark_propose_releases_safe_memory_before_hard_busy_like_matrixraft(
 }
 
 #[test]
-fn local_stabled_result_does_not_commit_without_quorum_like_matrixraft() {
+fn local_stabled_result_does_not_commit_without_quorum() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.set_node_healthy(2, false).expect("isolate node 2");
@@ -1222,7 +1222,7 @@ fn local_stabled_result_does_not_commit_without_quorum_like_matrixraft() {
 }
 
 #[test]
-fn busy_follower_append_caps_batch_like_matrixraft() {
+fn busy_follower_append_caps_batch() {
     let config = RaftConfig {
         max_log_buffer_bytes: 1,
         ..Default::default()
@@ -1294,7 +1294,7 @@ fn busy_follower_append_caps_batch_like_matrixraft() {
 }
 
 #[test]
-fn leader_apply_rejection_transfers_to_closest_follower_like_matrixraft() {
+fn leader_apply_rejection_transfers_to_closest_follower() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -1565,7 +1565,7 @@ fn append_entries_updates_follower_commit_and_rejects_missing_prev_log() {
 }
 
 #[test]
-fn append_entries_caps_commit_to_matched_boundary_like_matrixraft() {
+fn append_entries_caps_commit_to_matched_boundary() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -1659,7 +1659,7 @@ fn append_entries_preserves_matching_suffix_like_baseline_raft() {
 }
 
 #[test]
-fn append_entries_reorder_queue_drains_adjacent_batches_like_matrixraft() {
+fn append_entries_reorder_queue_drains_adjacent_batches() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -1729,7 +1729,7 @@ fn append_entries_reorder_queue_drains_adjacent_batches_like_matrixraft() {
 }
 
 #[test]
-fn append_entries_reorder_queue_is_cleared_on_leader_change_like_matrixraft() {
+fn append_entries_reorder_queue_is_cleared_on_leader_change() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -1854,7 +1854,7 @@ fn append_entries_conflict_hint_skips_local_term_run_like_baseline_raft() {
 }
 
 #[test]
-fn duplicate_append_response_reports_packet_match_range_like_matrixraft() {
+fn duplicate_append_response_reports_packet_match_range() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -1914,7 +1914,7 @@ fn duplicate_append_response_reports_packet_match_range_like_matrixraft() {
 }
 
 #[test]
-fn conflict_truncation_clamps_read_index_current_term_floor_like_matrixraft() {
+fn conflict_truncation_clamps_read_index_current_term_floor() {
     let mut cluster = three_node_cluster();
     cluster
         .append_entries_to(
@@ -2059,7 +2059,7 @@ fn append_entries_conflict_truncation_resets_pending_membership_change_like_base
 }
 
 #[test]
-fn append_entries_conflict_truncation_restores_surviving_membership_change_like_matrixraft() {
+fn append_entries_conflict_truncation_restores_surviving_membership_change() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -2140,7 +2140,7 @@ fn append_entries_conflict_truncation_restores_surviving_membership_change_like_
 }
 
 #[test]
-fn append_entries_rejects_second_unapplied_membership_change_like_matrixraft() {
+fn append_entries_rejects_second_unapplied_membership_change() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -2264,7 +2264,7 @@ fn append_entries_rejects_second_unapplied_membership_change_like_matrixraft() {
 }
 
 #[test]
-fn witness_preserves_membership_change_payload_like_matrixraft() {
+fn witness_preserves_membership_change_payload() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -2594,7 +2594,7 @@ fn vote_and_pre_vote_require_higher_term_and_fresh_log() {
 }
 
 #[test]
-fn vote_requests_do_not_require_local_live_quorum_like_matrixraft() {
+fn vote_requests_do_not_require_local_live_quorum() {
     let mut cluster = five_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.set_leader_lease_valid(false);
@@ -2639,7 +2639,7 @@ fn vote_requests_do_not_require_local_live_quorum_like_matrixraft() {
 }
 
 #[test]
-fn startup_follower_lease_blocks_pre_vote_until_carried_duration_expires_like_matrixraft() {
+fn startup_follower_lease_blocks_pre_vote_until_carried_duration_expires() {
     let config = RaftConfig {
         last_follower_lease_ms: 25,
         ..Default::default()
@@ -2693,7 +2693,7 @@ fn startup_follower_lease_blocks_pre_vote_until_carried_duration_expires_like_ma
 }
 
 #[test]
-fn learners_do_not_vote_but_witnesses_do_like_matrixraft() {
+fn learners_do_not_vote_but_witnesses_do() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"base".to_vec()).expect("base append");
@@ -2755,7 +2755,7 @@ fn learners_do_not_vote_but_witnesses_do_like_matrixraft() {
 }
 
 #[test]
-fn removed_peer_cannot_collect_votes_or_step_down_leader_like_matrixraft() {
+fn removed_peer_cannot_collect_votes_or_step_down_leader() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"before-remove".to_vec()).expect("propose");
@@ -2846,7 +2846,7 @@ fn removed_peer_cannot_collect_votes_or_step_down_leader_like_matrixraft() {
 }
 
 #[test]
-fn removing_peer_drops_stale_vote_responses_like_matrixraft() {
+fn removing_peer_drops_stale_vote_responses() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -2922,7 +2922,7 @@ fn removing_peer_drops_stale_vote_responses_like_matrixraft() {
 }
 
 #[test]
-fn stopped_leader_cannot_drive_append_or_snapshot_like_matrixraft() {
+fn stopped_leader_cannot_drive_append_or_snapshot() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"before-stop".to_vec()).expect("propose");
@@ -2986,7 +2986,7 @@ fn stopped_leader_cannot_drive_append_or_snapshot_like_matrixraft() {
 }
 
 #[test]
-fn remove_and_readd_peer_drops_partial_snapshot_install_state_like_matrixraft() {
+fn remove_and_readd_peer_drops_partial_snapshot_install_state() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -3061,7 +3061,7 @@ fn remove_and_readd_peer_drops_partial_snapshot_install_state_like_matrixraft() 
 }
 
 #[test]
-fn remove_and_readd_peer_drops_pending_snapshot_install_state_like_matrixraft() {
+fn remove_and_readd_peer_drops_pending_snapshot_install_state() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -3128,7 +3128,7 @@ fn remove_and_readd_peer_drops_pending_snapshot_install_state_like_matrixraft() 
 }
 
 #[test]
-fn remove_and_readd_peer_drops_reordered_append_state_like_matrixraft() {
+fn remove_and_readd_peer_drops_reordered_append_state() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.propose(b"one".to_vec()).expect("base proposal");
@@ -3199,7 +3199,7 @@ fn remove_and_readd_peer_drops_reordered_append_state_like_matrixraft() {
 }
 
 #[test]
-fn snapshot_install_in_progress_ignores_new_snapshot_like_matrixraft() {
+fn snapshot_install_in_progress_ignores_new_snapshot() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     let first_meta = RustRaftSnapshotMeta {
@@ -3274,7 +3274,7 @@ fn snapshot_install_in_progress_ignores_new_snapshot_like_matrixraft() {
 }
 
 #[test]
-fn high_term_vote_responses_step_down_like_matrixraft() {
+fn high_term_vote_responses_step_down() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(2, true).expect("make node 2 leader");
@@ -3340,7 +3340,7 @@ fn high_term_vote_responses_step_down_like_matrixraft() {
 }
 
 #[test]
-fn vote_response_quorum_promotes_candidate_without_extra_term_like_matrixraft() {
+fn vote_response_quorum_promotes_candidate_without_extra_term() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -3383,7 +3383,7 @@ fn vote_response_quorum_promotes_candidate_without_extra_term_like_matrixraft() 
 }
 
 #[test]
-fn pre_vote_quorum_starts_real_vote_before_leader_like_matrixraft() {
+fn pre_vote_quorum_starts_real_vote_before_leader() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -3428,7 +3428,7 @@ fn pre_vote_quorum_starts_real_vote_before_leader_like_matrixraft() {
 }
 
 #[test]
-fn ignore_witness_drops_stale_witness_vote_responses_like_matrixraft() {
+fn ignore_witness_drops_stale_witness_vote_responses() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -3559,7 +3559,7 @@ fn ignore_witness_keeps_matrixraft_rejection_threshold() {
 }
 
 #[test]
-fn high_term_append_entries_responses_step_down_like_matrixraft() {
+fn high_term_append_entries_responses_step_down() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(2, true).expect("make node 2 leader");
@@ -3615,7 +3615,7 @@ fn high_term_append_entries_responses_step_down_like_matrixraft() {
 }
 
 #[test]
-fn heartbeat_append_response_carries_snapshot_progress_like_matrixraft() {
+fn heartbeat_append_response_carries_snapshot_progress() {
     let mut cluster = RaftCluster::new(
         7,
         RustRaftConfig::default(),
@@ -3704,7 +3704,7 @@ fn heartbeat_append_response_carries_snapshot_progress_like_matrixraft() {
 }
 
 #[test]
-fn leader_transition_resets_peer_pipelines_like_matrixraft() {
+fn leader_transition_resets_peer_pipelines() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -3741,7 +3741,7 @@ fn leader_transition_resets_peer_pipelines_like_matrixraft() {
 }
 
 #[test]
-fn high_term_snapshot_request_updates_leader_like_matrixraft() {
+fn high_term_snapshot_request_updates_leader() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(2, true).expect("make node 2 leader");
@@ -3786,7 +3786,7 @@ fn high_term_snapshot_request_updates_leader_like_matrixraft() {
 }
 
 #[test]
-fn stale_term_snapshot_request_is_rejected_like_matrixraft() {
+fn stale_term_snapshot_request_is_rejected() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(2, true).expect("make node 2 leader");
@@ -3830,7 +3830,7 @@ fn stale_term_snapshot_request_is_rejected_like_matrixraft() {
 }
 
 #[test]
-fn high_term_snapshot_responses_step_down_like_matrixraft() {
+fn high_term_snapshot_responses_step_down() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(2, true).expect("make node 2 leader");
@@ -3877,7 +3877,7 @@ fn high_term_snapshot_responses_step_down_like_matrixraft() {
 }
 
 #[test]
-fn rejected_snapshot_response_triggers_fresh_snapshot_like_matrixraft() {
+fn rejected_snapshot_response_triggers_fresh_snapshot() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -3907,7 +3907,7 @@ fn rejected_snapshot_response_triggers_fresh_snapshot_like_matrixraft() {
 }
 
 #[test]
-fn stale_snapshot_ready_does_not_clear_active_trigger_like_matrixraft() {
+fn stale_snapshot_ready_does_not_clear_active_trigger() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -3930,7 +3930,7 @@ fn stale_snapshot_ready_does_not_clear_active_trigger_like_matrixraft() {
 }
 
 #[test]
-fn same_term_snapshot_response_finishes_send_and_resumes_catchup_like_matrixraft() {
+fn same_term_snapshot_response_finishes_send_and_resumes_catchup() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -3964,7 +3964,7 @@ fn same_term_snapshot_response_finishes_send_and_resumes_catchup_like_matrixraft
 }
 
 #[test]
-fn stopped_peer_responses_do_not_step_down_leader_like_matrixraft() {
+fn stopped_peer_responses_do_not_step_down_leader() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     let leader = cluster.leader_id().expect("leader");
@@ -4115,7 +4115,7 @@ fn read_index_and_lease_read_follow_leader_lease_and_apply_floor() {
 }
 
 #[test]
-fn append_entries_piggybacks_lease_epoch_like_matrixraft() {
+fn append_entries_piggybacks_lease_epoch() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -4154,7 +4154,7 @@ fn append_entries_piggybacks_lease_epoch_like_matrixraft() {
 }
 
 #[test]
-fn leader_lease_confirmation_duration_bounds_quorum_like_matrixraft() {
+fn leader_lease_confirmation_duration_bounds_quorum() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -4197,7 +4197,7 @@ fn leader_lease_confirmation_duration_bounds_quorum_like_matrixraft() {
 }
 
 #[test]
-fn reduced_follower_lease_confirmation_does_not_rewind_lease_like_matrixraft() {
+fn reduced_follower_lease_confirmation_does_not_rewind_lease() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -4223,7 +4223,7 @@ fn reduced_follower_lease_confirmation_does_not_rewind_lease_like_matrixraft() {
 }
 
 #[test]
-fn legacy_append_entries_response_renews_leader_lease_like_matrixraft() {
+fn legacy_append_entries_response_renews_leader_lease() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -4257,7 +4257,7 @@ fn legacy_append_entries_response_renews_leader_lease_like_matrixraft() {
 }
 
 #[test]
-fn ignore_witness_preserves_voter_backed_leader_lease_like_matrixraft() {
+fn ignore_witness_preserves_voter_backed_leader_lease() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -4288,7 +4288,7 @@ fn ignore_witness_preserves_voter_backed_leader_lease_like_matrixraft() {
 }
 
 #[test]
-fn append_entries_response_marks_peer_healthy_like_matrixraft() {
+fn append_entries_response_marks_peer_healthy() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -4337,7 +4337,7 @@ fn append_entries_response_marks_peer_healthy_like_matrixraft() {
 }
 
 #[test]
-fn added_caught_up_auto_promote_learner_becomes_voter_like_matrixraft() {
+fn added_caught_up_auto_promote_learner_becomes_voter() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -4357,7 +4357,7 @@ fn added_caught_up_auto_promote_learner_becomes_voter_like_matrixraft() {
 }
 
 #[test]
-fn auto_promote_learner_waits_for_pending_membership_change_like_matrixraft() {
+fn auto_promote_learner_waits_for_pending_membership_change() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -4402,7 +4402,7 @@ fn auto_promote_learner_waits_for_pending_membership_change_like_matrixraft() {
 }
 
 #[test]
-fn auto_promote_learner_uses_leader_noop_as_first_matched_log_like_matrixraft() {
+fn auto_promote_learner_uses_leader_noop_as_first_matched_log() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -4438,7 +4438,7 @@ fn auto_promote_learner_uses_leader_noop_as_first_matched_log_like_matrixraft() 
 }
 
 #[test]
-fn auto_promote_learner_waits_one_check_turn_when_lagging_like_matrixraft() {
+fn auto_promote_learner_waits_one_check_turn_when_lagging() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -4661,7 +4661,7 @@ fn read_path_report_tracks_quorum_lease_fence_and_bounded_stale() {
 }
 
 #[test]
-fn lost_quorum_leader_steps_down_after_lease_expires_like_matrixraft() {
+fn lost_quorum_leader_steps_down_after_lease_expires() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -4704,7 +4704,7 @@ fn lost_quorum_leader_steps_down_after_lease_expires_like_matrixraft() {
 }
 
 #[test]
-fn liveness_timeout_preserves_confirmed_leader_lease_until_duration_like_matrixraft() {
+fn liveness_timeout_preserves_confirmed_leader_lease_until_duration() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -4867,7 +4867,7 @@ fn ignore_witness_recomputes_quorum_and_commit_index() {
 }
 
 #[test]
-fn removing_down_voter_recomputes_commit_like_matrixraft() {
+fn removing_down_voter_recomputes_commit() {
     let mut cluster = RaftCluster::new(
         7,
         RaftConfig::default(),
@@ -4899,7 +4899,7 @@ fn removing_down_voter_recomputes_commit_like_matrixraft() {
 }
 
 #[test]
-fn removing_current_leader_transfers_to_closest_follower_like_matrixraft() {
+fn removing_current_leader_transfers_to_closest_follower() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -4979,7 +4979,7 @@ fn leader_transfer_requires_a_caught_up_voter() {
 }
 
 #[test]
-fn promote_rejects_witness_like_matrixraft() {
+fn promote_rejects_witness() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -5135,7 +5135,7 @@ fn leader_transfer_waits_for_transferee_catchup_before_campaign() {
 }
 
 #[test]
-fn leader_transfer_to_stopped_follower_times_out_like_matrixraft() {
+fn leader_transfer_to_stopped_follower_times_out() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster
@@ -5166,7 +5166,7 @@ fn leader_transfer_to_stopped_follower_times_out_like_matrixraft() {
 }
 
 #[test]
-fn append_response_completes_caught_up_leader_transfer_like_matrixraft() {
+fn append_response_completes_caught_up_leader_transfer() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.set_node_healthy(2, false).expect("isolate node 2");
@@ -5210,7 +5210,7 @@ fn append_response_completes_caught_up_leader_transfer_like_matrixraft() {
 }
 
 #[test]
-fn heartbeat_skips_snapshot_transfer_peer_like_matrixraft() {
+fn heartbeat_skips_snapshot_transfer_peer() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -5237,7 +5237,7 @@ fn heartbeat_skips_snapshot_transfer_peer_like_matrixraft() {
 }
 
 #[test]
-fn heartbeat_refreshes_liveness_and_missing_heartbeats_timeout_like_matrixraft() {
+fn heartbeat_refreshes_liveness_and_missing_heartbeats_timeout() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
 
@@ -5292,7 +5292,7 @@ fn heartbeat_refreshes_liveness_and_missing_heartbeats_timeout_like_matrixraft()
 }
 
 #[test]
-fn heartbeat_response_resumes_paused_peer_like_matrixraft() {
+fn heartbeat_response_resumes_paused_peer() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -5337,7 +5337,7 @@ fn heartbeat_response_resumes_paused_peer_like_matrixraft() {
 }
 
 #[test]
-fn append_rejection_retries_catchup_immediately_like_matrixraft() {
+fn append_rejection_retries_catchup_immediately() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster.campaign(1, true).expect("make node 1 leader");
@@ -5385,7 +5385,7 @@ fn append_rejection_retries_catchup_immediately_like_matrixraft() {
 }
 
 #[test]
-fn required_snapshot_above_leader_snapshot_triggers_new_snapshot_like_matrixraft() {
+fn required_snapshot_above_leader_snapshot_triggers_new_snapshot() {
     let mut cluster = three_node_cluster();
     cluster.start().expect("cluster starts");
     cluster

--- a/tests/raft_integration_model.rs
+++ b/tests/raft_integration_model.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_learner_promotion_decision, rustraft_read_safety_runtime_decision,
-    rustraft_recover_latest_wal_record, rustraft_wal_checksum, RustRaftApplySnapshotFence,
+    matrixraft_learner_promotion_decision, matrixraft_read_safety_runtime_decision,
+    matrixraft_recover_latest_wal_record, matrixraft_wal_checksum, RustRaftApplySnapshotFence,
     RustRaftHardState, RustRaftLogEntry, RustRaftLogId, RustRaftMembership, RustRaftPeerStatus,
     RustRaftReadSafetyOperation, RustRaftReadSafetyRuntimeInput, RustRaftReplicaRole, RustRaftRole,
     RustRaftSnapshotMeta, RustRaftStatusSnapshot, RustRaftWalRecord,
@@ -136,7 +136,7 @@ fn wal_record(node: &ModelNode) -> RustRaftWalRecord {
         },
         checksum: String::new(),
     };
-    record.checksum = rustraft_wal_checksum(&record);
+    record.checksum = matrixraft_wal_checksum(&record);
     record
 }
 
@@ -146,7 +146,7 @@ fn three_node_replication_and_restart_recover_committed_state() {
     replicate(&mut nodes, 3);
     nodes[1].restarted = true;
 
-    let recovered = rustraft_recover_latest_wal_record(&[
+    let recovered = matrixraft_recover_latest_wal_record(&[
         wal_record(&nodes[0]),
         wal_record(&nodes[1]),
         wal_record(&nodes[2]),
@@ -172,7 +172,7 @@ fn learner_catchup_promotion_and_witness_quorum_are_modeled() {
     replicate(&mut nodes, 5);
 
     let leader_status = status_for(&nodes[0], &nodes);
-    assert!(rustraft_learner_promotion_decision(&leader_status, 4, 0).promotable);
+    assert!(matrixraft_learner_promotion_decision(&leader_status, 4, 0).promotable);
 
     nodes[3].replica_role = RustRaftReplicaRole::Witness;
     assert!(nodes[3].replica_role.participates_in_quorum());
@@ -186,7 +186,7 @@ fn leader_failover_and_transfer_preserve_read_safety() {
     nodes[0].role = RustRaftRole::Follower;
     nodes[1].role = RustRaftRole::Leader;
 
-    let decision = rustraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
+    let decision = matrixraft_read_safety_runtime_decision(RustRaftReadSafetyRuntimeInput {
         operation: RustRaftReadSafetyOperation::ReadIndex,
         node_id: 2,
         leader_id: 2,
@@ -209,7 +209,7 @@ fn snapshot_install_after_compaction_keeps_fence_and_recovery_valid() {
     replicate(&mut nodes, 9);
     nodes[2].last_snapshot_index = 9;
 
-    let recovered = rustraft_recover_latest_wal_record(&[wal_record(&nodes[2])]).unwrap();
+    let recovered = matrixraft_recover_latest_wal_record(&[wal_record(&nodes[2])]).unwrap();
     assert_eq!(
         recovered
             .installed_snapshot

--- a/tests/raft_unit_contract.rs
+++ b/tests/raft_unit_contract.rs
@@ -2,10 +2,10 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_append_safety_decision, rustraft_learner_promotion_decision,
-    rustraft_membership_readiness_report, rustraft_read_safety_decision,
-    rustraft_recover_latest_wal_record, rustraft_validate_apply_snapshot_fence,
-    rustraft_wal_checksum, RustRaftAppendEntriesRequest, RustRaftApplySnapshotFence,
+    matrixraft_append_safety_decision, matrixraft_learner_promotion_decision,
+    matrixraft_membership_readiness_report, matrixraft_read_safety_decision,
+    matrixraft_recover_latest_wal_record, matrixraft_validate_apply_snapshot_fence,
+    matrixraft_wal_checksum, RustRaftAppendEntriesRequest, RustRaftApplySnapshotFence,
     RustRaftHardState, RustRaftLogEntry, RustRaftLogId, RustRaftMembership,
     RustRaftMembershipScope, RustRaftMembershipTransitionEvidence,
     RustRaftMembershipTransitionKind, RustRaftPeerStatus, RustRaftPendingReadIndexQueue,
@@ -77,7 +77,7 @@ fn wal_record(commit_index: u64, snapshot_index: Option<u64>) -> RustRaftWalReco
         },
         checksum: String::new(),
     };
-    record.checksum = rustraft_wal_checksum(&record);
+    record.checksum = matrixraft_wal_checksum(&record);
     record
 }
 
@@ -149,7 +149,7 @@ fn transition(
 
 #[test]
 fn raft_safety_helpers_reject_non_leader_and_apply_lag() {
-    let follower_decision = rustraft_read_safety_decision(
+    let follower_decision = matrixraft_read_safety_decision(
         &status(RustRaftRole::Follower, 10),
         &RustRaftReadIndexRequest {
             group_id: 7,
@@ -161,7 +161,7 @@ fn raft_safety_helpers_reject_non_leader_and_apply_lag() {
     assert!(!follower_decision.safe);
     assert_eq!(follower_decision.reason, "not_leader");
 
-    let lag_decision = rustraft_read_safety_decision(
+    let lag_decision = matrixraft_read_safety_decision(
         &status(RustRaftRole::Leader, 9),
         &RustRaftReadIndexRequest {
             group_id: 7,
@@ -175,7 +175,7 @@ fn raft_safety_helpers_reject_non_leader_and_apply_lag() {
 }
 
 #[test]
-fn pending_read_index_queue_releases_only_after_apply_fence_like_matrixraft() {
+fn pending_read_index_queue_releases_only_after_apply_fence() {
     let mut queue = RustRaftPendingReadIndexQueue::new();
     queue.push(
         RustRaftReadIndexRequest {
@@ -218,7 +218,7 @@ fn pending_read_index_queue_releases_only_after_apply_fence_like_matrixraft() {
 }
 
 #[test]
-fn pending_read_index_queue_releases_waiters_on_node_removal_like_matrixraft() {
+fn pending_read_index_queue_releases_waiters_on_node_removal() {
     let mut queue = RustRaftPendingReadIndexQueue::new();
     queue.push(
         RustRaftReadIndexRequest {
@@ -271,7 +271,7 @@ fn membership_transitions_require_safe_failover_scale_up_and_scale_down() {
     })
     .collect::<Vec<_>>();
 
-    let report = rustraft_membership_readiness_report(&transitions);
+    let report = matrixraft_membership_readiness_report(&transitions);
     assert!(report.ready, "{report:#?}");
     assert_eq!(report.decisions.len(), 6);
 }
@@ -282,7 +282,7 @@ fn wal_recovery_uses_latest_record_with_valid_snapshot_fence() {
     let mut corrupt_new = wal_record(11, Some(9));
     corrupt_new.apply_snapshot_fence.applied_index = 12;
 
-    let recovered = rustraft_recover_latest_wal_record(&[old.clone(), corrupt_new]).unwrap();
+    let recovered = matrixraft_recover_latest_wal_record(&[old.clone(), corrupt_new]).unwrap();
     assert_eq!(recovered.hard_state.committed.unwrap().index, 10);
     assert_eq!(recovered.checksum, old.checksum);
 }
@@ -292,13 +292,13 @@ fn snapshot_fence_rejects_snapshot_floor_overlap() {
     let mut record = wal_record(10, Some(8));
     record.apply_snapshot_fence.first_retained_log_index = 8;
 
-    let err = rustraft_validate_apply_snapshot_fence(&record).unwrap_err();
+    let err = matrixraft_validate_apply_snapshot_fence(&record).unwrap_err();
     assert!(err.to_string().contains("overlaps installed snapshot"));
 }
 
 #[test]
 fn compacted_entry_rejection_blocks_prev_log_before_snapshot_floor() {
-    let decision = rustraft_append_safety_decision(
+    let decision = matrixraft_append_safety_decision(
         9,
         8,
         &RustRaftAppendEntriesRequest {
@@ -319,7 +319,7 @@ fn compacted_entry_rejection_blocks_prev_log_before_snapshot_floor() {
 #[test]
 fn read_safety_and_learner_promotion_accept_caught_up_learner() {
     let status = status(RustRaftRole::Leader, 10);
-    let read = rustraft_read_safety_decision(
+    let read = matrixraft_read_safety_decision(
         &status,
         &RustRaftReadIndexRequest {
             group_id: 7,
@@ -331,7 +331,7 @@ fn read_safety_and_learner_promotion_accept_caught_up_learner() {
     assert!(read.safe);
     assert!(read.lease_read);
 
-    let learner = rustraft_learner_promotion_decision(&status, 2, 0);
+    let learner = matrixraft_learner_promotion_decision(&status, 2, 0);
     assert!(learner.promotable);
     assert!(RustRaftReplicaRole::Witness.participates_in_quorum());
 }

--- a/tests/rate_limiter.rs
+++ b/tests/rate_limiter.rs
@@ -35,7 +35,7 @@ fn byte_quota_limiter_grants_rejects_and_refills_like_baseline_raft_quota_gate()
 }
 
 #[test]
-fn byte_quota_limiter_can_grant_partial_quota_like_matrixraft_streaming() {
+fn byte_quota_limiter_can_grant_partial_quota_streaming() {
     let mut limiter = RustRaftByteQuotaLimiter::with_available(10, 3);
 
     let partial = limiter.reserve_limited_bytes(8);

--- a/tests/real_baseline_raft_benchmark_contract.rs
+++ b/tests/real_baseline_raft_benchmark_contract.rs
@@ -2,17 +2,18 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::benchmark::{
-    rustraft_assert_production_baseline_raft_parity,
-    rustraft_assert_production_baseline_raft_summary, rustraft_baseline_raft_benchmark_evidence,
-    rustraft_baseline_raft_benchmark_failure_summary, rustraft_find_baseline_raft_harness,
-    rustraft_find_or_build_baseline_raft_harness, rustraft_probe_baseline_raft_native_benchmark,
-    rustraft_run_baseline_raft_parity_benchmark,
-    rustraft_validate_production_baseline_raft_benchmark_options, RustRaftBenchmarkEngine,
+    matrixraft_assert_production_baseline_raft_parity,
+    matrixraft_assert_production_baseline_raft_summary,
+    matrixraft_baseline_raft_benchmark_evidence,
+    matrixraft_baseline_raft_benchmark_failure_summary, matrixraft_find_baseline_raft_harness,
+    matrixraft_find_or_build_baseline_raft_harness,
+    matrixraft_probe_baseline_raft_native_benchmark, matrixraft_run_baseline_raft_parity_benchmark,
+    matrixraft_validate_production_baseline_raft_benchmark_options, RustRaftBenchmarkEngine,
     RustRaftBenchmarkEngineSource, RustRaftBenchmarkHarnessKind, RustRaftBenchmarkOptions,
     RustRaftBenchmarkRunner, RustRaftBenchmarkWorkload, RustRaftExternalBaselineRaftRunner,
-    RustRaftRuntimeBenchmarkRunner, RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT,
-    RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
-    RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES,
+    RustRaftRuntimeBenchmarkRunner, MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT,
+    MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+    MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -38,7 +39,7 @@ fn benchmark_artifact_verifier_rejects_debug_benchmark_environment() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -47,11 +48,11 @@ fn benchmark_artifact_verifier_rejects_debug_benchmark_environment() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     assert!(report
         .environment_fingerprint
         .contains("debug_assertions=true"));
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     let report_path = root.join("report.json");
     let summary_path = root.join("summary.json");
     fs::write(
@@ -616,10 +617,10 @@ fn production_benchmark_options_validator_rejects_non_release_scale_inputs() {
         iterations_per_workload: 0,
         batch_size: 1,
         payload_size_bytes: 1024,
-        pass_tolerance_percent: RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT + 0.1,
+        pass_tolerance_percent: MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT + 0.1,
     };
 
-    let error = rustraft_validate_production_baseline_raft_benchmark_options(&options)
+    let error = matrixraft_validate_production_baseline_raft_benchmark_options(&options)
         .expect_err("invalid production options must fail preflight");
     assert!(error.contains("benchmark:node_count_below_production_scale:3:5"));
     assert!(error.contains("benchmark:invalid_iterations_per_workload:0"));
@@ -638,7 +639,7 @@ fn direct_baseline_raft_benchmark_example_preflights_options_before_harness_look
     .expect("read benchmark example");
 
     let preflight = example
-        .find("rustraft_validate_production_baseline_raft_benchmark_options(&options)")
+        .find("matrixraft_validate_production_baseline_raft_benchmark_options(&options)")
         .expect("example should preflight production options");
     let harness_lookup = example
         .find("let baseline_raft_root =")
@@ -675,7 +676,7 @@ fn direct_baseline_raft_benchmark_example_writes_summary_atomically() {
         .env("BASELINE_RAFT_BENCHMARK_BIN", &fake_bin)
         .env(
             "RUSTRAFT_BENCHMARK_ITERATIONS",
-            RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD.to_string(),
+            MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD.to_string(),
         )
         .env("RUSTRAFT_BENCHMARK_BATCH_SIZE", "2")
         .env("RUSTRAFT_BENCHMARK_PAYLOAD_SIZE_BYTES", "4096")
@@ -1387,12 +1388,12 @@ fn real_baseline_raft_runner_uses_external_harness_and_production_sources() {
     let fake_bin = make_fake_baseline_raft_harness(&root);
     make_fake_git_checkout(&root);
     assert_eq!(
-        rustraft_find_baseline_raft_harness(&root).expect("find"),
+        matrixraft_find_baseline_raft_harness(&root).expect("find"),
         fake_bin
     );
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1401,24 +1402,24 @@ fn real_baseline_raft_runner_uses_external_harness_and_production_sources() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
-    let debug_error = rustraft_assert_production_baseline_raft_parity(&report)
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+    let debug_error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("debug-built test artifact is not production release parity");
     assert!(debug_error.contains("benchmark:report_environment_debug_assertions_enabled"));
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
-    rustraft_assert_production_baseline_raft_parity(&report).expect("production parity");
+    matrixraft_assert_production_baseline_raft_parity(&report).expect("production parity");
     assert!(report.generated_at_unix_ms > 0);
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     assert_eq!(summary.generated_at_unix_ms, report.generated_at_unix_ms);
-    rustraft_assert_production_baseline_raft_summary(&summary).expect("production summary");
+    matrixraft_assert_production_baseline_raft_summary(&summary).expect("production summary");
 
-    let evidence = rustraft_baseline_raft_benchmark_evidence(&report);
+    let evidence = matrixraft_baseline_raft_benchmark_evidence(&report);
     assert!(evidence.real_baseline_raft);
-    assert!(evidence.rustraft_runtime);
+    assert!(evidence.matrixraft_runtime);
     assert!(evidence.baseline_raft_reference);
-    assert!(evidence.rustraft_rust_candidate);
+    assert!(evidence.matrixraft_rust_candidate);
     assert!(evidence.correctness_passed);
     assert!(evidence.performance_within_threshold);
     assert!(evidence.blockers.is_empty());
@@ -1429,7 +1430,7 @@ fn real_baseline_raft_runner_uses_external_harness_and_production_sources() {
     let captured_args = fs::read_to_string(root.join("bin/last_args.txt")).expect("captured args");
     assert!(captured_args.contains("node_count=5"));
     assert!(captured_args.contains(&format!(
-        "iterations={RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD}"
+        "iterations={MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD}"
     )));
     assert!(captured_args.contains("batch_size=2"));
     assert!(captured_args.contains("payload_size_bytes=4096"));
@@ -1456,15 +1457,16 @@ fn production_benchmark_rejects_stale_report_and_summary_timestamps() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.generated_at_unix_ms = 1;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report).expect_err("stale report");
+    let error =
+        matrixraft_assert_production_baseline_raft_parity(&report).expect_err("stale report");
     assert!(error.contains("benchmark:report_generated_at_stale"));
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     let summary_error =
-        rustraft_assert_production_baseline_raft_summary(&summary).expect_err("stale summary");
+        matrixraft_assert_production_baseline_raft_summary(&summary).expect_err("stale summary");
     assert!(summary_error.contains("benchmark:summary_generated_at_stale"));
 
     let _ = fs::remove_dir_all(root);
@@ -1478,7 +1480,7 @@ fn benchmark_reports_use_unique_process_scoped_run_ids() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1487,9 +1489,9 @@ fn benchmark_reports_use_unique_process_scoped_run_ids() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let first =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     let second =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
     assert_ne!(first.benchmark_run_id, second.benchmark_run_id);
     for report in [&first, &second] {
@@ -1536,10 +1538,10 @@ fn production_benchmark_rejects_non_finite_pass_tolerance() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
     let error =
-        rustraft_assert_production_baseline_raft_parity(&report).expect_err("invalid tolerance");
+        matrixraft_assert_production_baseline_raft_parity(&report).expect_err("invalid tolerance");
     assert!(error.contains("benchmark:invalid_pass_tolerance_percent:NaN"));
 
     let _ = fs::remove_dir_all(root);
@@ -1553,25 +1555,25 @@ fn production_benchmark_rejects_loose_pass_tolerance() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
-        pass_tolerance_percent: RUSTRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT + 0.1,
+        pass_tolerance_percent: MATRIXRAFT_BENCHMARK_MAX_PRODUCTION_PASS_TOLERANCE_PERCENT + 0.1,
         ..Default::default()
     };
     let mut baseline_raft =
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
     let error =
-        rustraft_assert_production_baseline_raft_parity(&report).expect_err("loose tolerance");
+        matrixraft_assert_production_baseline_raft_parity(&report).expect_err("loose tolerance");
     assert!(error.contains("benchmark:invalid_pass_tolerance_percent:10.100"));
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     let summary_error =
-        rustraft_assert_production_baseline_raft_summary(&summary).expect_err("loose tolerance");
+        matrixraft_assert_production_baseline_raft_summary(&summary).expect_err("loose tolerance");
     assert!(summary_error.contains("benchmark:invalid_pass_tolerance_percent:10.100"));
 
     let _ = fs::remove_dir_all(root);
@@ -1594,15 +1596,15 @@ fn production_benchmark_rejects_tiny_iteration_count() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
     let error =
-        rustraft_assert_production_baseline_raft_parity(&report).expect_err("tiny iterations");
+        matrixraft_assert_production_baseline_raft_parity(&report).expect_err("tiny iterations");
     assert!(error.contains("benchmark:iterations_per_workload_below_production_min:2:128"));
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     let summary_error =
-        rustraft_assert_production_baseline_raft_summary(&summary).expect_err("tiny iterations");
+        matrixraft_assert_production_baseline_raft_summary(&summary).expect_err("tiny iterations");
     assert!(summary_error.contains("benchmark:iterations_per_workload_below_production_min:2:128"));
 
     let _ = fs::remove_dir_all(root);
@@ -1616,7 +1618,7 @@ fn production_benchmark_rejects_unbatched_batch_size() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 1,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1625,14 +1627,14 @@ fn production_benchmark_rejects_unbatched_batch_size() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("unbatched batch size must not satisfy production parity");
     assert!(error.contains("benchmark:batch_size_below_production_min:1:2"));
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject unbatched batch size");
     assert!(summary_error.contains("benchmark:batch_size_below_production_min:1:2"));
 
@@ -1647,23 +1649,23 @@ fn production_benchmark_rejects_tiny_payload_size() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
-        payload_size_bytes: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES - 1,
+        payload_size_bytes: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_PAYLOAD_SIZE_BYTES - 1,
         ..Default::default()
     };
     let mut baseline_raft =
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("tiny payload size must not satisfy production parity");
     assert!(error.contains("benchmark:payload_size_below_production_min:4095:4096"));
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject tiny payload size");
     assert!(summary_error.contains("benchmark:payload_size_below_production_min:4095:4096"));
 
@@ -1688,14 +1690,15 @@ fn production_benchmark_rejects_below_scale_node_count() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report).expect_err("below scale");
+    let error =
+        matrixraft_assert_production_baseline_raft_parity(&report).expect_err("below scale");
     assert!(error.contains("benchmark:node_count_below_production_scale:3:5"));
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     let summary_error =
-        rustraft_assert_production_baseline_raft_summary(&summary).expect_err("below scale");
+        matrixraft_assert_production_baseline_raft_summary(&summary).expect_err("below scale");
     assert!(summary_error.contains("benchmark:node_count_below_production_scale:3:5"));
 
     let _ = fs::remove_dir_all(root);
@@ -1709,7 +1712,7 @@ fn production_benchmark_rejects_non_runtime_rustraft_harness() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1718,12 +1721,12 @@ fn production_benchmark_rejects_non_runtime_rustraft_harness() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.harness_kind = RustRaftBenchmarkHarnessKind::Model;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("non-runtime rustraft harness must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_runtime_harness_missing:model"),
@@ -1741,7 +1744,7 @@ fn production_benchmark_rejects_sample_engine_mismatch() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1750,12 +1753,12 @@ fn production_benchmark_rejects_sample_engine_mismatch() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.engine = RustRaftBenchmarkEngine::BaselineRaft;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("sample engine mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_sample_engine_mismatch"),
@@ -1773,7 +1776,7 @@ fn production_benchmark_rejects_sample_engine_source_mismatch() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1782,12 +1785,12 @@ fn production_benchmark_rejects_sample_engine_source_mismatch() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.engine_source = RustRaftBenchmarkEngineSource::Model;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("sample engine source mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_sample_engine_source_mismatch"),
@@ -1805,7 +1808,7 @@ fn production_benchmark_rejects_nonexistent_binary_provenance() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1814,7 +1817,7 @@ fn production_benchmark_rejects_nonexistent_binary_provenance() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.binary_path = Some(
@@ -1823,15 +1826,15 @@ fn production_benchmark_rejects_nonexistent_binary_provenance() {
             .to_string(),
     );
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("nonexistent binary provenance must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_provenance_binary_path_not_file"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject nonexistent binary provenance");
     assert!(
         summary_error.contains("benchmark:summary_rustraft_provenance_binary_path_not_file"),
@@ -1851,7 +1854,7 @@ fn production_benchmark_rejects_non_executable_binary_provenance() {
     fs::write(&non_executable, b"not executable").expect("write non-executable binary fixture");
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1860,20 +1863,20 @@ fn production_benchmark_rejects_non_executable_binary_provenance() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.binary_path = Some(non_executable.display().to_string());
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("non-executable binary provenance must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_provenance_binary_path_not_executable"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject non-executable binary provenance");
     assert!(
         summary_error.contains("benchmark:summary_rustraft_provenance_binary_path_not_executable"),
@@ -1903,7 +1906,7 @@ fn production_benchmark_rejects_relative_binary_provenance() {
     write_executable(&relative_binary, "#!/usr/bin/env bash\nexit 0\n");
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1912,20 +1915,20 @@ fn production_benchmark_rejects_relative_binary_provenance() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.binary_path = Some(relative_binary.display().to_string());
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("relative binary provenance must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_provenance_binary_path_not_absolute"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject relative binary provenance");
     assert!(
         summary_error.contains("benchmark:summary_rustraft_provenance_binary_path_not_absolute"),
@@ -1944,7 +1947,7 @@ fn production_benchmark_rejects_binary_path_collision() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1953,7 +1956,7 @@ fn production_benchmark_rejects_binary_path_collision() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     let reference_binary = report.comparisons[0]
@@ -1963,12 +1966,12 @@ fn production_benchmark_rejects_binary_path_collision() {
         .expect("reference binary path");
     report.comparisons[0].rustraft.binary_path = Some(reference_binary);
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("binary path collision must not satisfy production parity");
     assert!(error.contains("benchmark:binary_path_collision"), "{error}");
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject binary path collision");
     assert!(
         summary_error.contains("benchmark:summary_binary_path_collision:single_key_writes"),
@@ -1986,7 +1989,7 @@ fn benchmark_evidence_classifies_operation_count_pair_mismatch_as_correctness() 
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -1995,12 +1998,12 @@ fn benchmark_evidence_classifies_operation_count_pair_mismatch_as_correctness() 
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.comparisons[0]
         .blockers
         .push("operation_count_mismatch_baseline_raft_128_rustraft_64".to_string());
 
-    let evidence = rustraft_baseline_raft_benchmark_evidence(&report);
+    let evidence = matrixraft_baseline_raft_benchmark_evidence(&report);
     assert!(
         evidence.correctness_blockers.iter().any(|blocker| blocker
             .contains("benchmark:operation_count_mismatch_baseline_raft_128_rustraft_64")),
@@ -2019,7 +2022,7 @@ fn benchmark_evidence_classifies_inconsistent_comparison_status_as_correctness()
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2028,13 +2031,13 @@ fn benchmark_evidence_classifies_inconsistent_comparison_status_as_correctness()
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.comparisons[0].passed = true;
     report.comparisons[0]
         .blockers
         .push("stale_imported_blocker".to_string());
 
-    let evidence = rustraft_baseline_raft_benchmark_evidence(&report);
+    let evidence = matrixraft_baseline_raft_benchmark_evidence(&report);
     assert!(
         evidence
             .correctness_blockers
@@ -2044,7 +2047,7 @@ fn benchmark_evidence_classifies_inconsistent_comparison_status_as_correctness()
         evidence.correctness_blockers
     );
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("passed row with blockers must not satisfy production parity");
     assert!(
         error.contains("benchmark:comparison_passed_with_blockers"),
@@ -2062,7 +2065,7 @@ fn production_summary_rejects_inconsistent_workload_status() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2071,16 +2074,16 @@ fn production_summary_rejects_inconsistent_workload_status() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
-    let mut summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let mut summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     summary.workloads[0].passed = true;
     summary.workloads[0]
         .blockers
         .push("stale_summary_blocker".to_string());
 
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary workload status must be internally consistent");
     assert!(
         summary_error.contains("benchmark:summary_workload_passed_with_blockers"),
@@ -2089,7 +2092,7 @@ fn production_summary_rejects_inconsistent_workload_status() {
 
     summary.workloads[0].blockers.clear();
     summary.workloads[0].p99_ratio = 2.0;
-    let regression_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let regression_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary workload must not pass with a measured regression");
     assert!(
         regression_error.contains("benchmark:summary_workload_passed_despite_regression"),
@@ -2107,7 +2110,7 @@ fn production_benchmark_rejects_mismatched_timed_iteration_count() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2116,20 +2119,20 @@ fn production_benchmark_rejects_mismatched_timed_iteration_count() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.timed_iteration_count = 1;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("timed iteration mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_sample_timed_iteration_count_mismatch:1:128"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject timed iteration mismatch");
     assert!(
         summary_error.contains(
@@ -2149,7 +2152,7 @@ fn production_benchmark_rejects_mismatched_operations_per_timed_iteration() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2158,7 +2161,7 @@ fn production_benchmark_rejects_mismatched_operations_per_timed_iteration() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     let batched = report
@@ -2168,15 +2171,15 @@ fn production_benchmark_rejects_mismatched_operations_per_timed_iteration() {
         .expect("batched writes comparison");
     batched.rustraft.operations_per_timed_iteration = 1;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("operation/sample mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_sample_operations_per_timed_iteration_mismatch:1:2"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject operation/sample mismatch");
     assert!(
         summary_error.contains(
@@ -2196,7 +2199,7 @@ fn production_benchmark_rejects_required_workload_manifest_mismatch() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2205,20 +2208,20 @@ fn production_benchmark_rejects_required_workload_manifest_mismatch() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.required_workloads.pop();
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("required workload manifest mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:report_required_workloads_mismatch"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject required workload manifest mismatch");
     assert!(
         summary_error.contains("benchmark:summary_required_workloads_mismatch"),
@@ -2236,7 +2239,7 @@ fn production_benchmark_rejects_required_workload_order_mismatch() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2245,20 +2248,20 @@ fn production_benchmark_rejects_required_workload_order_mismatch() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons.swap(0, 1);
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("workload row order mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:report_workload_order_mismatch"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject workload row order mismatch");
     assert!(
         summary_error.contains("benchmark:summary_workload_order_mismatch"),
@@ -2276,7 +2279,7 @@ fn production_benchmark_rejects_nonfinite_comparison_ratios() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2285,12 +2288,12 @@ fn production_benchmark_rejects_nonfinite_comparison_ratios() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].p99_ratio = f64::NAN;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("nonfinite comparison ratio must not satisfy production parity");
     assert!(
         error.contains("benchmark:comparison_p99_ratio_not_finite"),
@@ -2308,7 +2311,7 @@ fn production_summary_rejects_nonfinite_workload_ratios() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2317,13 +2320,13 @@ fn production_summary_rejects_nonfinite_workload_ratios() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
-    let mut summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
+    let mut summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
     summary.workloads[0].p99_ratio = f64::NAN;
 
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("nonfinite summary workload ratio must not satisfy production parity");
     assert!(
         summary_error.contains("benchmark:summary_workload_p99_ratio_not_finite"),
@@ -2341,7 +2344,7 @@ fn production_benchmark_rejects_sample_run_id_pair_mismatch() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2350,20 +2353,20 @@ fn production_benchmark_rejects_sample_run_id_pair_mismatch() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.benchmark_run_id = "rustraft-other-run".to_string();
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("sample run id pair mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:report_sample_run_id_pair_mismatch"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject sample run id pair mismatch");
     assert!(
         summary_error.contains("benchmark:summary_sample_run_id_pair_mismatch"),
@@ -2381,7 +2384,7 @@ fn production_benchmark_rejects_throughput_duration_mismatch() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2390,20 +2393,20 @@ fn production_benchmark_rejects_throughput_duration_mismatch() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].baseline_raft.total_duration_micros = 1;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("throughput/duration mismatch must not satisfy production parity");
     assert!(
         error.contains("benchmark:baseline_raft_sample_throughput_duration_mismatch"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject throughput/duration mismatch");
     assert!(
         summary_error.contains(
@@ -2423,7 +2426,7 @@ fn production_benchmark_rejects_latency_exceeding_total_duration() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2432,21 +2435,21 @@ fn production_benchmark_rejects_latency_exceeding_total_duration() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     let total_duration = report.comparisons[0].rustraft.total_duration_micros;
     report.comparisons[0].rustraft.p99_latency_micros = total_duration + 1;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("latency over total duration must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_sample_p99_exceeds_total_duration"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject latency over total duration");
     assert!(
         summary_error
@@ -2465,7 +2468,7 @@ fn production_benchmark_reports_missing_regression_blocker_from_ratios() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2474,7 +2477,7 @@ fn production_benchmark_reports_missing_regression_blocker_from_ratios() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
 
@@ -2489,14 +2492,14 @@ fn production_benchmark_reports_missing_regression_blocker_from_ratios() {
     comparison.blockers.clear();
     report.passed = false;
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("missing regression blocker must not satisfy production parity");
     assert!(
         error.contains("benchmark:comparison_missing_p99_regression_blocker"),
         "{error}"
     );
 
-    let evidence = rustraft_baseline_raft_benchmark_evidence(&report);
+    let evidence = matrixraft_baseline_raft_benchmark_evidence(&report);
     assert!(
         evidence
             .performance_blockers
@@ -2517,7 +2520,7 @@ fn production_benchmark_rejects_invalid_git_revision_provenance() {
     make_fake_git_checkout(&root);
 
     let options = RustRaftBenchmarkOptions {
-        iterations_per_workload: RUSTRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
+        iterations_per_workload: MATRIXRAFT_BENCHMARK_MIN_PRODUCTION_ITERATIONS_PER_WORKLOAD,
         batch_size: 2,
         payload_size_bytes: 4096,
         ..Default::default()
@@ -2526,20 +2529,20 @@ fn production_benchmark_rejects_invalid_git_revision_provenance() {
         RustRaftExternalBaselineRaftRunner::from_root(&root, "release").expect("runner");
     let mut rustraft = RustRaftRuntimeBenchmarkRunner::new("release");
     let mut report =
-        rustraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
+        matrixraft_run_baseline_raft_parity_benchmark(&mut baseline_raft, &mut rustraft, &options);
     report.environment_fingerprint =
         "os=linux;arch=x86_64;target=x86_64-unknown-linux-gnu;debug_assertions=false".to_string();
     report.comparisons[0].rustraft.git_revision = Some("rustraft-test-rev".to_string());
 
-    let error = rustraft_assert_production_baseline_raft_parity(&report)
+    let error = matrixraft_assert_production_baseline_raft_parity(&report)
         .expect_err("invalid git revision provenance must not satisfy production parity");
     assert!(
         error.contains("benchmark:rustraft_provenance_git_revision_invalid:rustraft-test-rev"),
         "{error}"
     );
 
-    let summary = rustraft_baseline_raft_benchmark_failure_summary(&report);
-    let summary_error = rustraft_assert_production_baseline_raft_summary(&summary)
+    let summary = matrixraft_baseline_raft_benchmark_failure_summary(&report);
+    let summary_error = matrixraft_assert_production_baseline_raft_summary(&summary)
         .expect_err("summary must also reject invalid git revision provenance");
     assert!(
         summary_error.contains(
@@ -2611,9 +2614,9 @@ fn baseline_raft_harness_discovery_rejects_non_executable_candidate() {
     let harness = bin_dir.join("baseline_raft_parity_benchmark");
     fs::write(&harness, "#!/usr/bin/env bash\necho should-not-run\n").expect("write harness");
 
-    let error = rustraft_find_baseline_raft_harness(&root).expect_err("non-executable harness");
+    let error = matrixraft_find_baseline_raft_harness(&root).expect_err("non-executable harness");
     assert!(error.contains("benchmark:real_baseline_raft_harness_not_executable"));
-    let error = rustraft_find_or_build_baseline_raft_harness(&root, "debug")
+    let error = matrixraft_find_or_build_baseline_raft_harness(&root, "debug")
         .expect_err("non-executable build");
     assert!(error.contains("benchmark:real_baseline_raft_harness_not_executable"));
     let _ = fs::remove_dir_all(root);
@@ -2907,7 +2910,7 @@ chmod +x bin/baseline_raft_parity_benchmark
     fs::set_permissions(&build_script, perms).expect("chmod");
 
     let built =
-        rustraft_find_or_build_baseline_raft_harness(&root, "debug").expect("build fake harness");
+        matrixraft_find_or_build_baseline_raft_harness(&root, "debug").expect("build fake harness");
 
     assert_eq!(built, root.join("bin/baseline_raft_parity_benchmark"));
     assert!(built.is_file());
@@ -2918,9 +2921,9 @@ chmod +x bin/baseline_raft_parity_benchmark
 fn missing_baseline_raft_harness_fails_closed_with_real_baseline_raft_blocker() {
     let root = temp_dir("missing");
     fs::create_dir_all(&root).expect("root");
-    let err = rustraft_find_baseline_raft_harness(&root).expect_err("missing harness");
+    let err = matrixraft_find_baseline_raft_harness(&root).expect_err("missing harness");
     assert!(err.contains("benchmark:real_baseline_raft_missing"));
-    let err = rustraft_find_or_build_baseline_raft_harness(&root, "debug")
+    let err = matrixraft_find_or_build_baseline_raft_harness(&root, "debug")
         .expect_err("missing build target");
     assert!(err.contains("benchmark:real_baseline_raft_missing"));
     let _ = fs::remove_dir_all(root);
@@ -2948,7 +2951,7 @@ fn native_baseline_raft_kvbench_is_reported_as_partial_not_production_parity() {
     .expect("cmake source");
     fs::write(root.join("script/bench.sh"), "#!/usr/bin/env bash\n").expect("bench script");
 
-    let capability = rustraft_probe_baseline_raft_native_benchmark(&root);
+    let capability = matrixraft_probe_baseline_raft_native_benchmark(&root);
 
     assert_eq!(
         capability.kvbench_source_path,
@@ -2987,8 +2990,8 @@ fn native_baseline_raft_kvbench_is_reported_as_partial_not_production_parity() {
         .blockers
         .contains(&"benchmark:baseline_raft_native_kvbench_partial".to_string()));
 
-    let err =
-        rustraft_find_or_build_baseline_raft_harness(&root, "debug").expect_err("partial kvbench");
+    let err = matrixraft_find_or_build_baseline_raft_harness(&root, "debug")
+        .expect_err("partial kvbench");
     assert!(err.contains("benchmark:real_baseline_raft_missing"));
 
     let _ = fs::remove_dir_all(root);
@@ -3009,7 +3012,7 @@ fn native_baseline_raft_probe_reports_runnable_partial_workloads_when_kv_binarie
     )
     .expect("bench");
 
-    let capability = rustraft_probe_baseline_raft_native_benchmark(&root);
+    let capability = matrixraft_probe_baseline_raft_native_benchmark(&root);
 
     assert_eq!(
         capability.kvserver_binary_path,

--- a/tests/replication_pipeline.rs
+++ b/tests/replication_pipeline.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_apply_batch_outcome_like_matrixraft, rustraft_peer_pipeline_status_from_observed,
-    RaftCluster, RaftReplicationPipeline, RustRaftAppendEntriesResponse, RustRaftApplyBatchStatus,
+    matrixraft_apply_batch_outcome, matrixraft_peer_pipeline_status_from_observed, RaftCluster,
+    RaftReplicationPipeline, RustRaftAppendEntriesResponse, RustRaftApplyBatchStatus,
     RustRaftLogEntry, RustRaftLogId, RustRaftObservedPeerPipeline, RustRaftPeer,
     RustRaftPeerProgressState, RustRaftPipelineLimits, RustRaftReplicaRole, RustRaftRole,
     RustRaftSnapshotState,
@@ -94,7 +94,7 @@ fn observed_peer_pipeline_converts_into_full_status_surface() {
         witness_quorum_acked: 3,
     };
 
-    let status = rustraft_peer_pipeline_status_from_observed(&observed);
+    let status = matrixraft_peer_pipeline_status_from_observed(&observed);
 
     assert_eq!(status.peer_id, 7);
     assert_eq!(status.progress_state, RustRaftPeerProgressState::Replicate);
@@ -112,18 +112,15 @@ fn observed_peer_pipeline_converts_into_full_status_surface() {
 }
 
 #[test]
-fn apply_batch_outcome_splits_pending_suffix_like_matrixraft() {
+fn apply_batch_outcome_splits_pending_suffix() {
     let entries = vec![
         entry(10, b"ten"),
         entry(11, b"eleven"),
         entry(12, b"twelve"),
     ];
 
-    let full = rustraft_apply_batch_outcome_like_matrixraft(
-        &entries,
-        entries.len(),
-        RustRaftApplyBatchStatus::Applied,
-    );
+    let full =
+        matrixraft_apply_batch_outcome(&entries, entries.len(), RustRaftApplyBatchStatus::Applied);
     assert_eq!(full.status, RustRaftApplyBatchStatus::Applied);
     assert_eq!(full.first_log_id.as_ref().map(|id| id.index), Some(10));
     assert_eq!(full.last_log_id.as_ref().map(|id| id.index), Some(12));
@@ -132,11 +129,7 @@ fn apply_batch_outcome_splits_pending_suffix_like_matrixraft() {
     assert_eq!(full.applied_entries.len(), 3);
     assert!(full.pending_entries.is_empty());
 
-    let partial = rustraft_apply_batch_outcome_like_matrixraft(
-        &entries,
-        2,
-        RustRaftApplyBatchStatus::NotReady,
-    );
+    let partial = matrixraft_apply_batch_outcome(&entries, 2, RustRaftApplyBatchStatus::NotReady);
     assert_eq!(partial.status, RustRaftApplyBatchStatus::NotReady);
     assert_eq!(partial.applied_through, 11);
     assert_eq!(partial.next_index, 12);
@@ -157,19 +150,14 @@ fn apply_batch_outcome_splits_pending_suffix_like_matrixraft() {
         vec![12]
     );
 
-    let rejected = rustraft_apply_batch_outcome_like_matrixraft(
-        &entries,
-        0,
-        RustRaftApplyBatchStatus::Rejected,
-    );
+    let rejected = matrixraft_apply_batch_outcome(&entries, 0, RustRaftApplyBatchStatus::Rejected);
     assert_eq!(rejected.status, RustRaftApplyBatchStatus::Rejected);
     assert_eq!(rejected.applied_through, 0);
     assert_eq!(rejected.next_index, 10);
     assert!(rejected.applied_entries.is_empty());
     assert_eq!(rejected.pending_entries, entries);
 
-    let empty =
-        rustraft_apply_batch_outcome_like_matrixraft(&[], 4, RustRaftApplyBatchStatus::Applied);
+    let empty = matrixraft_apply_batch_outcome(&[], 4, RustRaftApplyBatchStatus::Applied);
     assert_eq!(empty.status, RustRaftApplyBatchStatus::Applied);
     assert_eq!(empty.first_log_id, None);
     assert_eq!(empty.last_log_id, None);
@@ -304,7 +292,7 @@ fn replication_pipeline_batches_retries_backoff_and_lag() {
 }
 
 #[test]
-fn replication_pipeline_pauses_and_resumes_progress_like_matrixraft() {
+fn replication_pipeline_pauses_and_resumes_progress() {
     let mut probe = RaftReplicationPipeline::new(
         2,
         1,
@@ -376,7 +364,7 @@ fn replication_pipeline_pauses_and_resumes_progress_like_matrixraft() {
 }
 
 #[test]
-fn heartbeat_response_resumes_paused_peer_like_matrixraft() {
+fn heartbeat_response_resumes_paused_peer() {
     let mut probe = RaftReplicationPipeline::new(2, 1, small_limits());
     probe.queue_append(&entry(1, b"a")).expect("queue append");
     assert_eq!(probe.flush_append_batch(1, 1024).len(), 1);
@@ -390,7 +378,7 @@ fn heartbeat_response_resumes_paused_peer_like_matrixraft() {
 }
 
 #[test]
-fn stale_success_does_not_unpause_or_free_inflight_like_matrixraft() {
+fn stale_success_does_not_unpause_or_free_inflight() {
     let mut probe = RaftReplicationPipeline::new(2, 5, RustRaftPipelineLimits::default());
     probe.queue_append(&entry(5, b"five")).expect("queue probe");
     assert_eq!(probe.flush_append_batch(1, 1024).len(), 1);
@@ -486,7 +474,7 @@ fn append_rejection_can_require_snapshot_transfer() {
 }
 
 #[test]
-fn replicate_rejection_falls_back_to_matched_boundary_like_matrixraft() {
+fn replicate_rejection_falls_back_to_matched_boundary() {
     let mut pipeline = RaftReplicationPipeline::new(2, 8, RustRaftPipelineLimits::default());
     pipeline
         .handle_append_response(&RustRaftAppendEntriesResponse {
@@ -530,7 +518,7 @@ fn replicate_rejection_falls_back_to_matched_boundary_like_matrixraft() {
 }
 
 #[test]
-fn probe_rejection_ignores_stale_index_and_pauses_same_index_like_matrixraft() {
+fn probe_rejection_ignores_stale_index_and_pauses_same_index() {
     let mut pipeline = RaftReplicationPipeline::new(2, 5, RustRaftPipelineLimits::default());
 
     pipeline
@@ -690,7 +678,7 @@ fn replication_pipeline_tracks_snapshot_sender_and_receiver_state() {
 }
 
 #[test]
-fn snapshot_finish_advances_or_retries_like_matrixraft() {
+fn snapshot_finish_advances_or_retries() {
     let mut accepted = RaftReplicationPipeline::new(2, 10, RustRaftPipelineLimits::default());
     accepted
         .begin_snapshot_send("snap-20", 20, 2)
@@ -716,7 +704,7 @@ fn snapshot_finish_advances_or_retries_like_matrixraft() {
 }
 
 #[test]
-fn snapshot_require_is_tracked_and_acked_like_matrixraft() {
+fn snapshot_require_is_tracked_and_acked() {
     let mut pipeline = RaftReplicationPipeline::new(2, 10, RustRaftPipelineLimits::default());
 
     assert!(pipeline.maybe_require_snapshot(8));
@@ -742,7 +730,7 @@ fn snapshot_require_is_tracked_and_acked_like_matrixraft() {
 }
 
 #[test]
-fn snapshot_progress_times_out_non_receiving_peer_like_matrixraft() {
+fn snapshot_progress_times_out_non_receiving_peer() {
     let mut pipeline = RaftReplicationPipeline::new(2, 10, RustRaftPipelineLimits::default());
     pipeline
         .begin_snapshot_send("snap-20", 20, 2)
@@ -801,7 +789,7 @@ fn raft_cluster_updates_live_peer_pipelines_during_replication() {
 }
 
 #[test]
-fn raft_cluster_network_error_immediately_probes_replicating_peer_like_matrixraft() {
+fn raft_cluster_network_error_immediately_probes_replicating_peer() {
     let mut cluster = RaftCluster::new(188, Default::default(), vec![peer(1), peer(2), peer(3)])
         .expect("cluster");
     cluster.start().expect("start");

--- a/tests/runtime_reports.rs
+++ b/tests/runtime_reports.rs
@@ -2,14 +2,14 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_admin_diagnostic_json_lines, rustraft_admin_diagnostic_log_entries,
-    rustraft_admin_status_surface_evidence, rustraft_capability_evidence,
-    rustraft_debug_bundle_validation_prometheus, rustraft_debug_snapshot,
-    rustraft_debug_snapshot_json, rustraft_debug_snapshot_metadata_prometheus,
-    rustraft_diagnostic_log_prometheus, rustraft_operator_runbook_prometheus,
-    rustraft_optimization_report, rustraft_optimization_report_prometheus,
-    rustraft_runtime_admin_report, rustraft_runtime_local_status_report,
-    rustraft_validate_debug_snapshot, rustraft_validate_debug_snapshot_json, RaftCluster,
+    matrixraft_admin_diagnostic_json_lines, matrixraft_admin_diagnostic_log_entries,
+    matrixraft_admin_status_surface_evidence, matrixraft_capability_evidence,
+    matrixraft_debug_bundle_validation_prometheus, matrixraft_debug_snapshot,
+    matrixraft_debug_snapshot_json, matrixraft_debug_snapshot_metadata_prometheus,
+    matrixraft_diagnostic_log_prometheus, matrixraft_operator_runbook_prometheus,
+    matrixraft_optimization_report, matrixraft_optimization_report_prometheus,
+    matrixraft_runtime_admin_report, matrixraft_runtime_local_status_report,
+    matrixraft_validate_debug_snapshot, matrixraft_validate_debug_snapshot_json, RaftCluster,
     RaftHealthStatus, RaftPeerPipelineState, RustRaftAdminStatusSurfaceInput,
     RustRaftDiagnosticLogEntry, RustRaftDiagnosticSeverity, RustRaftOperatorRunbookStep,
     RustRaftOptimizationHint, RustRaftOptimizationHintSeverity, RustRaftPeer,
@@ -29,16 +29,16 @@ fn peer(node_id: u64) -> RustRaftPeer {
 
 fn ready_snapshot() -> matrixraft::RustRaftReadinessSnapshot {
     matrixraft::RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     }
@@ -194,7 +194,7 @@ fn local_status_report_tracks_replication_apply_and_pipeline_health() {
         witness_quorum_reached: false,
     }];
 
-    let report = rustraft_runtime_local_status_report(status, pipeline, ready_snapshot());
+    let report = matrixraft_runtime_local_status_report(status, pipeline, ready_snapshot());
     assert_eq!(report.replication_health.status, RaftHealthStatus::Degraded);
     assert_eq!(report.apply_health.status, RaftHealthStatus::Degraded);
     assert!(report.blockers.contains(&"replication_lagging".to_string()));
@@ -216,7 +216,7 @@ fn admin_status_surface_evidence_accepts_quorum_progress_with_lagging_peer() {
         wal_last_log_index: 10,
         wal_segment_lifecycle_present: true,
     };
-    let evidence = rustraft_admin_status_surface_evidence(&input);
+    let evidence = matrixraft_admin_status_surface_evidence(&input);
     assert!(evidence.complete, "{evidence:?}");
     assert!(evidence.quorum_peer_progress_observed);
     assert!(evidence.peer_pipeline_runtime_activity_observed);
@@ -235,7 +235,7 @@ fn admin_status_surface_evidence_fails_closed_on_missing_wal_or_quorum() {
         wal_last_log_index: 9,
         wal_segment_lifecycle_present: false,
     };
-    let evidence = rustraft_admin_status_surface_evidence(&input);
+    let evidence = matrixraft_admin_status_surface_evidence(&input);
     assert!(!evidence.complete);
     assert!(evidence
         .blockers
@@ -260,7 +260,7 @@ fn optimization_report_surfaces_pipeline_wal_and_commit_pressure() {
     apply_saturated.apply_inflight_tasks = apply_saturated.apply_inflight_limit;
     apply_saturated.inflight_bytes = apply_saturated.inflight_bytes_limit;
 
-    let report = rustraft_optimization_report(&RustRaftAdminStatusSurfaceInput {
+    let report = matrixraft_optimization_report(&RustRaftAdminStatusSurfaceInput {
         commit_index: 10,
         max_observed_node_commit_index: 11,
         quorum_size: 2,
@@ -301,7 +301,7 @@ fn optimization_report_surfaces_pipeline_wal_and_commit_pressure() {
 
 #[test]
 fn optimization_report_is_ready_for_clean_admin_status_surface() {
-    let report = rustraft_optimization_report(&RustRaftAdminStatusSurfaceInput {
+    let report = matrixraft_optimization_report(&RustRaftAdminStatusSurfaceInput {
         commit_index: 10,
         max_observed_node_commit_index: 10,
         quorum_size: 2,
@@ -337,8 +337,8 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     cluster.start().expect("start");
     cluster.propose(b"x".to_vec()).expect("write");
     let readiness = ready_snapshot();
-    let capability_evidence = rustraft_capability_evidence(&readiness);
-    let report = rustraft_runtime_admin_report(
+    let capability_evidence = matrixraft_capability_evidence(&readiness);
+    let report = matrixraft_runtime_admin_report(
         cluster.cluster_status_report().expect("cluster status"),
         readiness,
         capability_evidence,
@@ -357,7 +357,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .feature_reference
         .contains("BaselineRaft"));
 
-    let entries = rustraft_admin_diagnostic_log_entries(&report);
+    let entries = matrixraft_admin_diagnostic_log_entries(&report);
     assert_eq!(entries.len(), 3);
     assert_eq!(entries[0].target, "rustraft.admin");
     assert_eq!(entries[0].severity, RustRaftDiagnosticSeverity::Info);
@@ -371,7 +371,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .iter()
         .any(|entry| entry.target == "rustraft.apply" && entry.message == "apply_healthy"));
 
-    let json_lines = rustraft_admin_diagnostic_json_lines(&report);
+    let json_lines = matrixraft_admin_diagnostic_json_lines(&report);
     let parsed = json_lines
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).expect("diagnostic json line"))
@@ -393,8 +393,8 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         wal_last_log_index: 10,
         wal_segment_lifecycle_present: true,
     };
-    let snapshot = rustraft_debug_snapshot(&report, &status_surface, &[("service", "raft-a")]);
-    assert_eq!(snapshot.contract.name, "rustraft_debug_snapshot");
+    let snapshot = matrixraft_debug_snapshot(&report, &status_surface, &[("service", "raft-a")]);
+    assert_eq!(snapshot.contract.name, "matrixraft_debug_snapshot");
     assert_eq!(snapshot.contract.version, 1);
     assert_eq!(snapshot.contract.schema, "rustraft.debug_snapshot.v1");
     assert!(snapshot.generated_at_unix_ms > 0);
@@ -426,11 +426,11 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     assert!(snapshot.runbook_prometheus.text.contains(
         "rustraft_operator_runbook_step_present{service=\"raft-a\",step=\"continue_normal_observation\",severity=\"info\",target=\"observability\"} 1"
     ));
-    let validation = rustraft_validate_debug_snapshot(&snapshot);
+    let validation = matrixraft_validate_debug_snapshot(&snapshot);
     assert!(validation.ready);
     assert_eq!(validation.issue_count, 0);
     let metadata_prometheus =
-        rustraft_debug_snapshot_metadata_prometheus(&snapshot, &[("service", "raft\"a")]);
+        matrixraft_debug_snapshot_metadata_prometheus(&snapshot, &[("service", "raft\"a")]);
     assert_eq!(metadata_prometheus.metric_count, 8);
     assert!(metadata_prometheus
         .text
@@ -462,14 +462,16 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut invalid_snapshot = snapshot.clone();
     invalid_snapshot.contract.schema = "rustraft.debug_snapshot.v0".to_string();
-    let invalid_validation = rustraft_validate_debug_snapshot(&invalid_snapshot);
+    let invalid_validation = matrixraft_validate_debug_snapshot(&invalid_snapshot);
     assert!(!invalid_validation.ready);
     assert_eq!(
         invalid_validation.issues,
         vec!["contract_mismatch".to_string()]
     );
-    let invalid_validation_metrics =
-        rustraft_debug_bundle_validation_prometheus(&invalid_validation, &[("service", "raft\"a")]);
+    let invalid_validation_metrics = matrixraft_debug_bundle_validation_prometheus(
+        &invalid_validation,
+        &[("service", "raft\"a")],
+    );
     assert_eq!(invalid_validation_metrics.format, "prometheus_text_v0.0.4");
     assert_eq!(invalid_validation_metrics.metric_count, 4);
     assert!(invalid_validation_metrics
@@ -488,7 +490,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut missing_timestamp_snapshot = snapshot.clone();
     missing_timestamp_snapshot.generated_at_unix_ms = 0;
     let missing_timestamp_validation =
-        rustraft_validate_debug_snapshot(&missing_timestamp_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_timestamp_snapshot);
     assert!(!missing_timestamp_validation.ready);
     assert!(missing_timestamp_validation
         .issues
@@ -496,7 +498,8 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut future_timestamp_snapshot = snapshot.clone();
     future_timestamp_snapshot.generated_at_unix_ms = u64::MAX;
-    let future_timestamp_validation = rustraft_validate_debug_snapshot(&future_timestamp_snapshot);
+    let future_timestamp_validation =
+        matrixraft_validate_debug_snapshot(&future_timestamp_snapshot);
     assert!(!future_timestamp_validation.ready);
     assert!(future_timestamp_validation
         .issues
@@ -504,12 +507,12 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_timestamp_snapshot = snapshot.clone();
     stale_timestamp_snapshot.generated_at_unix_ms = 1;
-    let stale_timestamp_validation = rustraft_validate_debug_snapshot(&stale_timestamp_snapshot);
+    let stale_timestamp_validation = matrixraft_validate_debug_snapshot(&stale_timestamp_snapshot);
     assert!(!stale_timestamp_validation.ready);
     assert!(stale_timestamp_validation
         .issues
         .contains(&"generated_at_stale".to_string()));
-    let stale_timestamp_validation_metrics = rustraft_debug_bundle_validation_prometheus(
+    let stale_timestamp_validation_metrics = matrixraft_debug_bundle_validation_prometheus(
         &stale_timestamp_validation,
         &[("service", "raft-a")],
     );
@@ -522,7 +525,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_snapshot = snapshot.clone();
     stale_snapshot.triage.critical_optimization_count = 7;
-    let stale_validation = rustraft_validate_debug_snapshot(&stale_snapshot);
+    let stale_validation = matrixraft_validate_debug_snapshot(&stale_snapshot);
     assert!(!stale_validation.ready);
     assert!(stale_validation
         .issues
@@ -530,7 +533,8 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_diagnostic_snapshot = snapshot.clone();
     stale_diagnostic_snapshot.triage.diagnostic_warning_count = 13;
-    let stale_diagnostic_validation = rustraft_validate_debug_snapshot(&stale_diagnostic_snapshot);
+    let stale_diagnostic_validation =
+        matrixraft_validate_debug_snapshot(&stale_diagnostic_snapshot);
     assert!(!stale_diagnostic_validation.ready);
     assert!(stale_diagnostic_validation
         .issues
@@ -538,7 +542,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_triage_snapshot = snapshot.clone();
     stale_triage_snapshot.triage.first_action = "stale action".to_string();
-    let stale_triage_validation = rustraft_validate_debug_snapshot(&stale_triage_snapshot);
+    let stale_triage_validation = matrixraft_validate_debug_snapshot(&stale_triage_snapshot);
     assert!(!stale_triage_validation.ready);
     assert!(stale_triage_validation
         .issues
@@ -547,7 +551,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut stale_diagnostic_log_snapshot = snapshot.clone();
     stale_diagnostic_log_snapshot.diagnostics[0].message = "stale diagnostic".to_string();
     let stale_diagnostic_log_validation =
-        rustraft_validate_debug_snapshot(&stale_diagnostic_log_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_diagnostic_log_snapshot);
     assert!(!stale_diagnostic_log_validation.ready);
     assert!(stale_diagnostic_log_validation
         .issues
@@ -566,7 +570,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .map(|line| format!("{}\n", line))
         .collect();
     let missing_diagnostic_severity_validation =
-        rustraft_validate_debug_snapshot(&missing_diagnostic_severity_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_diagnostic_severity_snapshot);
     assert!(!missing_diagnostic_severity_validation.ready);
     assert!(missing_diagnostic_severity_validation
         .issues
@@ -582,7 +586,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
             .map(|line| format!("{}\n", line))
             .collect();
     let missing_diagnostic_entry_validation =
-        rustraft_validate_debug_snapshot(&missing_diagnostic_entry_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_diagnostic_entry_snapshot);
     assert!(!missing_diagnostic_entry_validation.ready);
     assert!(missing_diagnostic_entry_validation
         .issues
@@ -601,9 +605,9 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
             )],
         });
     escaped_diagnostic_snapshot.diagnostic_prometheus =
-        rustraft_diagnostic_log_prometheus(&escaped_diagnostic_snapshot.diagnostics, &[]);
+        matrixraft_diagnostic_log_prometheus(&escaped_diagnostic_snapshot.diagnostics, &[]);
     let escaped_diagnostic_validation =
-        rustraft_validate_debug_snapshot(&escaped_diagnostic_snapshot);
+        matrixraft_validate_debug_snapshot(&escaped_diagnostic_snapshot);
     assert!(
         !escaped_diagnostic_validation
             .issues
@@ -624,7 +628,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .optimization
         .hint_count = 99;
     let stale_optimization_hint_count_validation =
-        rustraft_validate_debug_snapshot(&stale_optimization_hint_count_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_optimization_hint_count_snapshot);
     assert!(!stale_optimization_hint_count_validation.ready);
     assert!(stale_optimization_hint_count_validation
         .issues
@@ -635,7 +639,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .optimization
         .warning_count = 99;
     let stale_optimization_warning_count_validation =
-        rustraft_validate_debug_snapshot(&stale_optimization_warning_count_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_optimization_warning_count_snapshot);
     assert!(!stale_optimization_warning_count_validation.ready);
     assert!(stale_optimization_warning_count_validation
         .issues
@@ -658,7 +662,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .optimization
         .critical_count += 1;
     let stale_optimization_ready_validation =
-        rustraft_validate_debug_snapshot(&stale_optimization_ready_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_optimization_ready_snapshot);
     assert!(!stale_optimization_ready_validation.ready);
     assert!(stale_optimization_ready_validation
         .issues
@@ -669,7 +673,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .optimization_prometheus
         .metric_count = 99;
     let stale_prometheus_count_validation =
-        rustraft_validate_debug_snapshot(&stale_prometheus_count_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_prometheus_count_snapshot);
     assert!(!stale_prometheus_count_validation.ready);
     assert!(stale_prometheus_count_validation
         .issues
@@ -680,7 +684,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .optimization_prometheus
         .text = "rustraft_optimization_ready 1\n".to_string();
     let missing_prometheus_metric_validation =
-        rustraft_validate_debug_snapshot(&missing_prometheus_metric_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_prometheus_metric_snapshot);
     assert!(!missing_prometheus_metric_validation.ready);
     assert!(missing_prometheus_metric_validation
         .issues
@@ -700,7 +704,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         });
     missing_prometheus_hint_snapshot.optimization.hint_count += 1;
     let missing_prometheus_hint_validation =
-        rustraft_validate_debug_snapshot(&missing_prometheus_hint_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_prometheus_hint_snapshot);
     assert!(!missing_prometheus_hint_validation.ready);
     assert!(missing_prometheus_hint_validation
         .issues
@@ -724,8 +728,8 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     escaped_hint_snapshot.optimization.hint_count += 1;
     escaped_hint_snapshot.optimization.warning_count += 1;
     escaped_hint_snapshot.optimization_prometheus =
-        rustraft_optimization_report_prometheus(&escaped_hint_snapshot.optimization, &[]);
-    let escaped_hint_validation = rustraft_validate_debug_snapshot(&escaped_hint_snapshot);
+        matrixraft_optimization_report_prometheus(&escaped_hint_snapshot.optimization, &[]);
+    let escaped_hint_validation = matrixraft_validate_debug_snapshot(&escaped_hint_snapshot);
     assert!(
         !escaped_hint_validation
             .issues
@@ -740,7 +744,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut stale_grafana_contract_snapshot = snapshot.clone();
     stale_grafana_contract_snapshot.grafana.uid = "old-dashboard".to_string();
     let stale_grafana_contract_validation =
-        rustraft_validate_debug_snapshot(&stale_grafana_contract_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_grafana_contract_snapshot);
     assert!(!stale_grafana_contract_validation.ready);
     assert!(stale_grafana_contract_validation
         .issues
@@ -749,7 +753,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut stale_grafana_panel_snapshot = snapshot.clone();
     stale_grafana_panel_snapshot.grafana.panels[0].expr = "rustraft_ready == 0".to_string();
     let stale_grafana_panel_validation =
-        rustraft_validate_debug_snapshot(&stale_grafana_panel_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_grafana_panel_snapshot);
     assert!(!stale_grafana_panel_validation.ready);
     assert!(stale_grafana_panel_validation
         .issues
@@ -761,7 +765,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .panels
         .retain(|panel| panel.id != 17);
     let missing_grafana_panel_validation =
-        rustraft_validate_debug_snapshot(&missing_grafana_panel_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_grafana_panel_snapshot);
     assert!(!missing_grafana_panel_validation.ready);
     assert!(missing_grafana_panel_validation
         .issues
@@ -769,7 +773,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_runbook_snapshot = snapshot.clone();
     stale_runbook_snapshot.runbook_steps[0].action = "do something else".to_string();
-    let stale_runbook_validation = rustraft_validate_debug_snapshot(&stale_runbook_snapshot);
+    let stale_runbook_validation = matrixraft_validate_debug_snapshot(&stale_runbook_snapshot);
     assert!(!stale_runbook_validation.ready);
     assert!(stale_runbook_validation
         .issues
@@ -779,7 +783,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     missing_runbook_prometheus_snapshot.runbook_prometheus.text =
         "rustraft_operator_runbook_step_total 1\n".to_string();
     let missing_runbook_prometheus_validation =
-        rustraft_validate_debug_snapshot(&missing_runbook_prometheus_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_runbook_prometheus_snapshot);
     assert!(!missing_runbook_prometheus_validation.ready);
     assert!(missing_runbook_prometheus_validation
         .issues
@@ -801,7 +805,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .runbook_prometheus
         .metric_count -= 1;
     let missing_runbook_first_step_validation =
-        rustraft_validate_debug_snapshot(&missing_runbook_first_step_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_runbook_first_step_snapshot);
     assert!(!missing_runbook_first_step_validation.ready);
     assert!(missing_runbook_first_step_validation
         .issues
@@ -821,8 +825,8 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
             validation: "validator still recognizes escaped runbook metrics".to_string(),
         });
     escaped_runbook_snapshot.runbook_prometheus =
-        rustraft_operator_runbook_prometheus(&escaped_runbook_snapshot.runbook_steps, &[]);
-    let escaped_runbook_validation = rustraft_validate_debug_snapshot(&escaped_runbook_snapshot);
+        matrixraft_operator_runbook_prometheus(&escaped_runbook_snapshot.runbook_steps, &[]);
+    let escaped_runbook_validation = matrixraft_validate_debug_snapshot(&escaped_runbook_snapshot);
     assert!(
         !escaped_runbook_validation
             .issues
@@ -843,7 +847,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .runbook_steps
         .push(snapshot.runbook_steps[0].clone());
     extra_runbook_snapshot.runbook_steps[1].id = "unexpected_extra_step".to_string();
-    let extra_runbook_validation = rustraft_validate_debug_snapshot(&extra_runbook_snapshot);
+    let extra_runbook_validation = matrixraft_validate_debug_snapshot(&extra_runbook_snapshot);
     assert!(!extra_runbook_validation.ready);
     assert!(extra_runbook_validation
         .issues
@@ -852,7 +856,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut stale_alert_contract_snapshot = snapshot.clone();
     stale_alert_contract_snapshot.alerts[0].expr = "rustraft_optimization_ready < 0".to_string();
     let stale_alert_contract_validation =
-        rustraft_validate_debug_snapshot(&stale_alert_contract_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_alert_contract_snapshot);
     assert!(!stale_alert_contract_validation.ready);
     assert!(stale_alert_contract_validation
         .issues
@@ -865,7 +869,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     missing_alert_contract_snapshot.triage.alert_rule_count =
         missing_alert_contract_snapshot.alerts.len();
     let missing_alert_contract_validation =
-        rustraft_validate_debug_snapshot(&missing_alert_contract_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_alert_contract_snapshot);
     assert!(!missing_alert_contract_validation.ready);
     assert!(missing_alert_contract_validation
         .issues
@@ -873,7 +877,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_top_alert_snapshot = snapshot.clone();
     stale_top_alert_snapshot.triage.top_alert = Some("MissingRustRaftAlert".to_string());
-    let stale_top_alert_validation = rustraft_validate_debug_snapshot(&stale_top_alert_snapshot);
+    let stale_top_alert_validation = matrixraft_validate_debug_snapshot(&stale_top_alert_snapshot);
     assert!(!stale_top_alert_validation.ready);
     assert!(stale_top_alert_validation
         .issues
@@ -885,7 +889,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     stale_top_diagnostic_snapshot.triage.top_diagnostic_message =
         Some("missing_diagnostic".to_string());
     let stale_top_diagnostic_validation =
-        rustraft_validate_debug_snapshot(&stale_top_diagnostic_snapshot);
+        matrixraft_validate_debug_snapshot(&stale_top_diagnostic_snapshot);
     assert!(!stale_top_diagnostic_validation.ready);
     assert!(stale_top_diagnostic_validation
         .issues
@@ -896,7 +900,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         .triage
         .top_diagnostic_message = None;
     let incomplete_top_diagnostic_validation =
-        rustraft_validate_debug_snapshot(&incomplete_top_diagnostic_snapshot);
+        matrixraft_validate_debug_snapshot(&incomplete_top_diagnostic_snapshot);
     assert!(!incomplete_top_diagnostic_validation.ready);
     assert!(incomplete_top_diagnostic_validation
         .issues
@@ -905,7 +909,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut stale_top_hint_snapshot = snapshot.clone();
     stale_top_hint_snapshot.triage.top_optimization_hint =
         Some("missing_optimization_hint".to_string());
-    let stale_top_hint_validation = rustraft_validate_debug_snapshot(&stale_top_hint_snapshot);
+    let stale_top_hint_validation = matrixraft_validate_debug_snapshot(&stale_top_hint_snapshot);
     assert!(!stale_top_hint_validation.ready);
     assert!(stale_top_hint_validation
         .issues
@@ -913,7 +917,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
 
     let mut stale_severity_snapshot = snapshot.clone();
     stale_severity_snapshot.triage.severity = "warning".to_string();
-    let stale_severity_validation = rustraft_validate_debug_snapshot(&stale_severity_snapshot);
+    let stale_severity_validation = matrixraft_validate_debug_snapshot(&stale_severity_snapshot);
     assert!(!stale_severity_validation.ready);
     assert!(stale_severity_validation
         .issues
@@ -922,18 +926,18 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
     let mut missing_ready_runbook_snapshot = snapshot.clone();
     missing_ready_runbook_snapshot.runbook_steps.clear();
     let missing_ready_runbook_validation =
-        rustraft_validate_debug_snapshot(&missing_ready_runbook_snapshot);
+        matrixraft_validate_debug_snapshot(&missing_ready_runbook_snapshot);
     assert!(!missing_ready_runbook_validation.ready);
     assert!(missing_ready_runbook_validation
         .issues
         .contains(&"runbook_ready_step_missing".to_string()));
 
     let snapshot_json =
-        rustraft_debug_snapshot_json(&report, &status_surface, &[("service", "raft-a")]);
-    let json_validation = rustraft_validate_debug_snapshot_json(&snapshot_json);
+        matrixraft_debug_snapshot_json(&report, &status_surface, &[("service", "raft-a")]);
+    let json_validation = matrixraft_validate_debug_snapshot_json(&snapshot_json);
     assert!(json_validation.ready);
     assert_eq!(json_validation.issue_count, 0);
-    let invalid_json_validation = rustraft_validate_debug_snapshot_json("{not-json");
+    let invalid_json_validation = matrixraft_validate_debug_snapshot_json("{not-json");
     assert!(!invalid_json_validation.ready);
     assert_eq!(
         invalid_json_validation.issues,
@@ -943,7 +947,7 @@ fn admin_report_genericizes_baseline_raft_parity_evidence_for_rustraft() {
         serde_json::from_str(&snapshot_json).expect("debug snapshot json for mutation");
     stale_contract_json["contract"]["schema"] = Value::String("rustraft.debug_snapshot.old".into());
     let stale_contract_validation =
-        rustraft_validate_debug_snapshot_json(&stale_contract_json.to_string());
+        matrixraft_validate_debug_snapshot_json(&stale_contract_json.to_string());
     assert!(!stale_contract_validation.ready);
     assert!(stale_contract_validation
         .issues

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -17,7 +17,7 @@ fn entry(index: u64) -> RustRaftLogEntry {
 }
 
 #[test]
-fn scheduler_fetch_preserves_priority_and_fifo_order_like_matrixraft_mailbox() {
+fn scheduler_fetch_preserves_priority_and_fifo_order_mailbox() {
     let scheduler = RustRaftScheduler::new(8);
     scheduler.schedule(
         RustRaftMailPriority::Slowly,

--- a/tests/snapshot_lifecycle.rs
+++ b/tests/snapshot_lifecycle.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_snapshot_lifecycle_evidence, PersistentRaftSnapshotStore,
+    matrixraft_snapshot_lifecycle_evidence, PersistentRaftSnapshotStore,
     PersistentRaftSnapshotStoreOptions, RaftAdminCommand, RaftCluster, RaftSnapshot,
     RaftSnapshotLifecycle, RaftSnapshotLifecycleConfig, RustRaftApplySnapshotFence,
     RustRaftByteQuotaLimiter, RustRaftInstallSnapshotResponse, RustRaftLogEntry, RustRaftLogId,
@@ -131,7 +131,7 @@ fn snapshot_lifecycle_uses_baseline_raft_style_transfer_quota_without_advancing_
 }
 
 #[test]
-fn snapshot_lifecycle_splits_chunks_on_partial_rate_quota_like_matrixraft() {
+fn snapshot_lifecycle_splits_chunks_on_partial_rate_quota() {
     let snap = snapshot(12, b"abcdefghijkl");
     let mut lifecycle = RaftSnapshotLifecycle::new(RaftSnapshotLifecycleConfig {
         chunk_size: 6,
@@ -315,14 +315,14 @@ fn cluster_installs_snapshot_with_lifecycle_then_catches_up_tail_after_compactio
     assert_eq!(cluster.status(3).expect("status").last_log_index, 6);
 
     let peer_three = cluster.peer_pipeline_status(3).expect("pipeline");
-    let evidence = rustraft_snapshot_lifecycle_evidence(&[peer_three], 1_000, 1);
+    let evidence = matrixraft_snapshot_lifecycle_evidence(&[peer_three], 1_000, 1);
     assert!(evidence.sender_lifecycle_present || evidence.downloader_lifecycle_present);
     assert!(evidence.install_progress_present);
     assert!(evidence.rejoin_after_compacted_log_present);
 }
 
 #[test]
-fn snapshot_finish_catches_up_tail_like_matrixraft() {
+fn snapshot_finish_catches_up_tail() {
     let mut cluster =
         RaftCluster::new(55, Default::default(), vec![peer(1), peer(2), peer(3)]).expect("cluster");
     cluster.start().expect("start");
@@ -376,7 +376,7 @@ fn snapshot_finish_catches_up_tail_like_matrixraft() {
 }
 
 #[test]
-fn rejected_snapshot_finish_triggers_fresh_snapshot_like_matrixraft() {
+fn rejected_snapshot_finish_triggers_fresh_snapshot() {
     let mut cluster =
         RaftCluster::new(56, Default::default(), vec![peer(1), peer(2), peer(3)]).expect("cluster");
     cluster.start().expect("start");
@@ -408,7 +408,7 @@ fn rejected_snapshot_finish_triggers_fresh_snapshot_like_matrixraft() {
 }
 
 #[test]
-fn failed_replication_task_sends_snapshot_or_triggers_one_like_matrixraft() {
+fn failed_replication_task_sends_snapshot_or_triggers_one() {
     let mut direct =
         RaftCluster::new(57, Default::default(), vec![peer(1), peer(2), peer(3)]).expect("cluster");
     direct.start().expect("start");

--- a/tests/standalone_embedding_contract.rs
+++ b/tests/standalone_embedding_contract.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    metrics::rustraft_metric_names, readiness::rustraft_standalone_readiness_report,
+    metrics::matrixraft_metric_names, readiness::matrixraft_standalone_readiness_report,
     snapshot::PersistentRaftSnapshotStore, AppendEntriesRequest, InstallSnapshotRequest,
     PersistentRaftSnapshotStoreOptions, PersistentRaftWal, PersistentRaftWalOptions, RaftCluster,
     RaftConfig, RaftMembershipExecutor, RaftMembershipOperation, RaftNodeRuntime,
@@ -358,7 +358,7 @@ fn pass_4_non_temporalstore_app_gets_wal_snapshot_recovery_and_fences() {
 
 #[test]
 fn pass_5_standalone_status_api_covers_all_embedding_capabilities() {
-    let report = rustraft_standalone_readiness_report();
+    let report = matrixraft_standalone_readiness_report();
     let capability_ids = report
         .capabilities
         .iter()
@@ -380,7 +380,7 @@ fn pass_5_standalone_status_api_covers_all_embedding_capabilities() {
     assert!(report.standalone);
     assert!(report.evidence.len() >= capability_ids.len());
     assert!(report.missing.is_empty());
-    assert!(rustraft_metric_names()
+    assert!(matrixraft_metric_names()
         .append_latency_ms
         .starts_with("rustraft_"));
 

--- a/tests/state_machine_apply.rs
+++ b/tests/state_machine_apply.rs
@@ -2,12 +2,12 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    matrixraft_flexible_apply_with_store, matrixraft_flexible_apply_with_store_report,
-    rustraft_apply_entry, EntryPayload, MatrixRaftCheckpoint, MatrixRaftConfigurationApplied,
-    MatrixRaftFsm, MatrixRaftFsmEntry, MatrixRaftFsmEntryKind, MatrixRaftStoreFsm, RaftApply,
-    RaftApplyRequest, RaftApplyResponse, RaftLogEntry, RaftStateMachine, RustRaftApplyRequest,
-    RustRaftApplyResponse, RustRaftLogId, RustRaftNodeId, RustRaftSnapshotChunk,
-    RustRaftSnapshotMeta, RustRaftStateMachine,
+    matrixraft_apply_entry, matrixraft_flexible_apply_with_store,
+    matrixraft_flexible_apply_with_store_report, EntryPayload, MatrixRaftCheckpoint,
+    MatrixRaftConfigurationApplied, MatrixRaftFsm, MatrixRaftFsmEntry, MatrixRaftFsmEntryKind,
+    MatrixRaftStoreFsm, RaftApply, RaftApplyRequest, RaftApplyResponse, RaftLogEntry,
+    RaftStateMachine, RustRaftApplyRequest, RustRaftApplyResponse, RustRaftLogId, RustRaftNodeId,
+    RustRaftSnapshotChunk, RustRaftSnapshotMeta, RustRaftStateMachine,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -222,7 +222,7 @@ impl RustRaftStateMachine for OpaqueBytesStateMachine {
 #[test]
 fn generic_apply_trait_accepts_temporalstore_data_shard_payloads() {
     let mut state_machine = DataShardStateMachine::default();
-    let response = rustraft_apply_entry(
+    let response = matrixraft_apply_entry(
         &mut state_machine,
         "tenant-a/shard-7".to_string(),
         RaftLogEntry {
@@ -250,7 +250,7 @@ fn generic_apply_trait_accepts_temporalstore_data_shard_payloads() {
 #[test]
 fn generic_apply_trait_accepts_temporalstore_meta_payloads() {
     let mut state_machine = MetaStateMachine::default();
-    let response = rustraft_apply_entry(
+    let response = matrixraft_apply_entry(
         &mut state_machine,
         42,
         RaftLogEntry {
@@ -271,7 +271,7 @@ fn generic_apply_trait_accepts_temporalstore_meta_payloads() {
 #[test]
 fn opaque_bytes_state_machine_still_uses_compatibility_trait() {
     let mut state_machine = OpaqueBytesStateMachine::default();
-    let response = rustraft_apply_entry(
+    let response = matrixraft_apply_entry(
         &mut state_machine,
         7,
         RaftLogEntry {

--- a/tests/transport_contract.rs
+++ b/tests/transport_contract.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    rustraft_validate_read_index_response, rustraft_validate_tcp_transport_request,
-    rustraft_validate_vote_request, AppendEntriesRequest, AppendEntriesResponse,
+    matrixraft_validate_read_index_response, matrixraft_validate_tcp_transport_request,
+    matrixraft_validate_vote_request, AppendEntriesRequest, AppendEntriesResponse,
     AuthenticatedRaftTransport, ClusterRaftTransport, InMemoryRaftTransport,
     InstallSnapshotRequest, InstallSnapshotResponse, RaftCluster, RaftError, RaftTransport,
     ReadIndexRequest, ReadIndexResponse, RustRaftAppendEntriesRequest, RustRaftHeartbeatMerger,
@@ -179,7 +179,7 @@ fn transport_validation_reports_bad_requests_and_responses() {
         pre_vote: true,
         force: false,
     };
-    let vote_report = rustraft_validate_vote_request(&bad_vote);
+    let vote_report = matrixraft_validate_vote_request(&bad_vote);
     assert!(!vote_report.valid);
     assert!(vote_report
         .blockers
@@ -196,7 +196,7 @@ fn transport_validation_reports_bad_requests_and_responses() {
         lease_read: true,
         reason: "".to_string(),
     };
-    let read_report = rustraft_validate_read_index_response(&bad_read_response);
+    let read_report = matrixraft_validate_read_index_response(&bad_read_response);
     assert!(!read_report.valid);
     assert!(read_report
         .blockers
@@ -207,7 +207,7 @@ fn transport_validation_reports_bad_requests_and_responses() {
         target: 0,
         request: bad_vote,
     };
-    let tcp_report = rustraft_validate_tcp_transport_request(&bad_tcp);
+    let tcp_report = matrixraft_validate_tcp_transport_request(&bad_tcp);
     assert!(!tcp_report.valid);
     assert!(tcp_report
         .blockers
@@ -217,7 +217,7 @@ fn transport_validation_reports_bad_requests_and_responses() {
     let empty_batch = TcpRaftTransportRequest::Batch {
         requests: Vec::new(),
     };
-    let empty_batch_report = rustraft_validate_tcp_transport_request(&empty_batch);
+    let empty_batch_report = matrixraft_validate_tcp_transport_request(&empty_batch);
     assert!(!empty_batch_report.valid);
     assert!(empty_batch_report
         .blockers
@@ -229,7 +229,7 @@ fn transport_validation_reports_bad_requests_and_responses() {
             requests: Vec::new(),
         }],
     };
-    let nested_batch_report = rustraft_validate_tcp_transport_request(&nested_batch);
+    let nested_batch_report = matrixraft_validate_tcp_transport_request(&nested_batch);
     assert!(!nested_batch_report.valid);
     assert!(nested_batch_report
         .blockers
@@ -328,7 +328,7 @@ fn in_memory_transport_forwards_and_validates_all_rpc_messages() {
 }
 
 #[test]
-fn heartbeat_merger_queues_empty_append_heartbeats_like_matrixraft() {
+fn heartbeat_merger_queues_empty_append_heartbeats() {
     let mut resolver = HashMap::new();
     resolver.insert((1, 2), "127.0.0.1:7002".to_string());
     resolver.insert((3, 2), "127.0.0.1:7002".to_string());
@@ -533,7 +533,7 @@ fn cluster_installs_snapshot_from_chunked_snapshot_rpc() {
 }
 
 #[test]
-fn cluster_reassembles_multi_chunk_snapshot_rpc_like_matrixraft() {
+fn cluster_reassembles_multi_chunk_snapshot_rpc() {
     let mut cluster = RaftCluster::new(
         3,
         Default::default(),
@@ -703,7 +703,7 @@ fn tcp_transport_round_trips_append_snapshot_vote_and_read_index() {
 }
 
 #[test]
-fn tcp_transport_batches_mixed_rpc_requests_like_matrixraft() {
+fn tcp_transport_batches_mixed_rpc_requests() {
     let cluster = Arc::new(Mutex::new(
         RaftCluster::new(
             3,

--- a/tests/transport_observability.rs
+++ b/tests/transport_observability.rs
@@ -3,22 +3,22 @@
 
 use matrixraft::{
     metrics::{
-        rustraft_alert_rules, rustraft_alert_rules_json, rustraft_diagnostic_log_prometheus,
-        rustraft_grafana_dashboard, rustraft_grafana_dashboard_json, rustraft_metric_names,
-        rustraft_observability_provisioning, rustraft_observability_provisioning_json,
-        rustraft_observability_provisioning_runbook_steps,
-        rustraft_observability_provisioning_validation_prometheus,
-        rustraft_operator_runbook_prometheus, rustraft_operator_runbook_steps,
-        rustraft_operator_triage_prometheus, rustraft_operator_triage_summary,
-        rustraft_optimization_report_prometheus, rustraft_validate_observability_provisioning,
-        rustraft_validate_observability_provisioning_json,
+        matrixraft_alert_rules, matrixraft_alert_rules_json, matrixraft_diagnostic_log_prometheus,
+        matrixraft_grafana_dashboard, matrixraft_grafana_dashboard_json, matrixraft_metric_names,
+        matrixraft_observability_provisioning, matrixraft_observability_provisioning_json,
+        matrixraft_observability_provisioning_runbook_steps,
+        matrixraft_observability_provisioning_validation_prometheus,
+        matrixraft_operator_runbook_prometheus, matrixraft_operator_runbook_steps,
+        matrixraft_operator_triage_prometheus, matrixraft_operator_triage_summary,
+        matrixraft_optimization_report_prometheus, matrixraft_validate_observability_provisioning,
+        matrixraft_validate_observability_provisioning_json,
     },
     readiness::{
-        rustraft_baseline_raft_parity_surface, rustraft_parity_report,
-        rustraft_public_api_contract, RustRaftReadinessSnapshot,
+        matrixraft_baseline_raft_parity_surface, matrixraft_parity_report,
+        matrixraft_public_api_contract, RustRaftReadinessSnapshot,
     },
     status::{
-        rustraft_fatal_blocker_report, RustRaftBlockerSeverity, RustRaftDiagnosticLogEntry,
+        matrixraft_fatal_blocker_report, RustRaftBlockerSeverity, RustRaftDiagnosticLogEntry,
         RustRaftDiagnosticSeverity, RustRaftOptimizationHint, RustRaftOptimizationHintSeverity,
         RustRaftOptimizationReport,
     },
@@ -33,16 +33,16 @@ use serde_json::Value;
 
 fn ready_snapshot() -> RustRaftReadinessSnapshot {
     RustRaftReadinessSnapshot {
-        rustraft_leader_write_authority_present: true,
-        rustraft_operator_observability_present: true,
-        rustraft_rpc_transport_contract_present: true,
-        rustraft_log_retention_snapshot_trigger_present: true,
-        rustraft_apply_snapshot_fence_present: true,
+        matrixraft_leader_write_authority_present: true,
+        matrixraft_operator_observability_present: true,
+        matrixraft_rpc_transport_contract_present: true,
+        matrixraft_log_retention_snapshot_trigger_present: true,
+        matrixraft_apply_snapshot_fence_present: true,
         raft_storage_apply_fence_present: true,
-        rustraft_snapshot_floor_log_matching_present: true,
-        rustraft_snapshot_tail_catchup_present: true,
-        rustraft_compacted_entry_rejection_present: true,
-        rustraft_metaserver_snapshot_floor_election_present: true,
+        matrixraft_snapshot_floor_log_matching_present: true,
+        matrixraft_snapshot_tail_catchup_present: true,
+        matrixraft_compacted_entry_rejection_present: true,
+        matrixraft_metaserver_snapshot_floor_election_present: true,
         learner_catchup_promotion_present: true,
         metaserver_membership_workflow_present: true,
     }
@@ -122,7 +122,7 @@ fn transport_contract_names_owned_rpc_types_including_prevote_and_snapshot_chunk
 
 #[test]
 fn observability_contract_exports_metrics_parity_readiness_and_blocker_reports() {
-    let metrics = rustraft_metric_names();
+    let metrics = matrixraft_metric_names();
     assert_eq!(metrics.pre_vote_latency_ms, "rustraft_pre_vote_latency_ms");
     assert_eq!(metrics.blocker_total, "rustraft_blocker_total");
     assert_eq!(metrics.fatal_total, "rustraft_fatal_total");
@@ -232,7 +232,7 @@ fn observability_contract_exports_metrics_parity_readiness_and_blocker_reports()
         "rustraft_debug_snapshot_fresh"
     );
 
-    let api = rustraft_public_api_contract();
+    let api = matrixraft_public_api_contract();
     assert!(api.rpc_messages.contains(&"PreVoteRequest".to_string()));
     assert!(api.rpc_messages.contains(&"PreVoteResponse".to_string()));
     assert!(api
@@ -246,9 +246,9 @@ fn observability_contract_exports_metrics_parity_readiness_and_blocker_reports()
         .contains(&"InMemoryRaftTransport".to_string()));
     assert!(api
         .safety_helpers
-        .contains(&"rustraft_fatal_blocker_report".to_string()));
+        .contains(&"matrixraft_fatal_blocker_report".to_string()));
 
-    let surface = rustraft_baseline_raft_parity_surface();
+    let surface = matrixraft_baseline_raft_parity_surface();
     assert!(surface.transport_api.contains(&"pre_vote_rpc".to_string()));
     assert!(surface
         .transport_api
@@ -269,10 +269,10 @@ fn observability_contract_exports_metrics_parity_readiness_and_blocker_reports()
         .observability_api
         .contains(&"readiness_report".to_string()));
 
-    let readiness = rustraft_parity_report(&ready_snapshot());
+    let readiness = matrixraft_parity_report(&ready_snapshot());
     assert!(readiness.ready);
 
-    let blockers = rustraft_fatal_blocker_report(
+    let blockers = matrixraft_fatal_blocker_report(
         "rustraft_transport_observability",
         vec!["leader_unavailable".to_string(), "wal_corrupt".to_string()],
         vec!["wal_corrupt".to_string()],
@@ -294,8 +294,8 @@ fn observability_contract_exports_metrics_parity_readiness_and_blocker_reports()
 
 #[test]
 fn grafana_dashboard_exports_runtime_metric_panels() {
-    let metrics = rustraft_metric_names();
-    let dashboard = rustraft_grafana_dashboard();
+    let metrics = matrixraft_metric_names();
+    let dashboard = matrixraft_grafana_dashboard();
     assert_eq!(dashboard.uid, "rustraft-runtime-overview");
     assert_eq!(dashboard.refresh, "10s");
     // The count is pinned so a panel cannot appear or vanish unnoticed. It went 53 -> 55 when
@@ -386,7 +386,7 @@ fn grafana_dashboard_exports_runtime_metric_panels() {
     assert!(expressions
         .contains(&"sum by (issue) (rustraft_observability_provisioning_validation_issue)"));
 
-    let json = rustraft_grafana_dashboard_json();
+    let json = matrixraft_grafana_dashboard_json();
     let parsed: Value = serde_json::from_str(&json).expect("dashboard json");
     assert_eq!(parsed["title"], "RustRaft Runtime Overview");
     // Same pin, checked through the serialized JSON: the struct and the exported document
@@ -458,7 +458,7 @@ fn grafana_dashboard_exports_runtime_metric_panels() {
 
 #[test]
 fn alert_rules_export_operator_contract_for_readiness_and_blockers() {
-    let rules = rustraft_alert_rules();
+    let rules = matrixraft_alert_rules();
     // Pinned for the same reason as the panel count: 15 -> 16 with the provisioning
     // validation alert.
     assert_eq!(rules.len(), 16);
@@ -657,7 +657,7 @@ fn alert_rules_export_operator_contract_for_readiness_and_blockers() {
     assert_eq!(provisioning_validation.duration, "5m");
     assert_eq!(provisioning_validation.severity, "warning");
 
-    let json = rustraft_alert_rules_json();
+    let json = matrixraft_alert_rules_json();
     let parsed: Value = serde_json::from_str(&json).expect("alert rule json");
     assert_eq!(parsed.as_array().expect("alert rules").len(), 16);
     assert!(json.contains("RustRaftOptimizationWarningHints"));
@@ -696,14 +696,14 @@ fn alert_rules_export_operator_contract_for_readiness_and_blockers() {
 
 #[test]
 fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contract() {
-    let provisioning = rustraft_observability_provisioning();
+    let provisioning = matrixraft_observability_provisioning();
     assert_eq!(provisioning.service, "rustraft");
     assert_eq!(provisioning.prometheus_format, "prometheus_text_v0.0.4");
     assert_eq!(provisioning.dashboard.uid, "rustraft-runtime-overview");
-    assert_eq!(provisioning.alert_rules, rustraft_alert_rules());
+    assert_eq!(provisioning.alert_rules, matrixraft_alert_rules());
     assert_eq!(
         provisioning.runbook_steps,
-        rustraft_observability_provisioning_runbook_steps()
+        matrixraft_observability_provisioning_runbook_steps()
     );
     assert!(provisioning
         .runbook_steps
@@ -781,8 +781,10 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     assert!(validate_support_envelope
         .validation
         .contains("support_envelope_severity is ok"));
-    let provisioning_runbook_metrics =
-        rustraft_operator_runbook_prometheus(&provisioning.runbook_steps, &[("service", "raft-a")]);
+    let provisioning_runbook_metrics = matrixraft_operator_runbook_prometheus(
+        &provisioning.runbook_steps,
+        &[("service", "raft-a")],
+    );
     assert!(provisioning_runbook_metrics.text.contains(
         "rustraft_operator_runbook_step_present{service=\"raft-a\",step=\"refresh_debug_snapshot\",severity=\"warning\",target=\"debug_bundle\"} 1"
     ));
@@ -912,7 +914,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
             "Prometheus artifact {artifact_name} missing from debug artifact envelope list"
         );
     }
-    let dashboard_json = rustraft_grafana_dashboard_json();
+    let dashboard_json = matrixraft_grafana_dashboard_json();
     for metric_name in &provisioning.required_metric_names {
         assert!(
             dashboard_json.contains(metric_name),
@@ -958,7 +960,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
         "cargo run --example debug_artifacts"
     );
 
-    let json = rustraft_observability_provisioning_json();
+    let json = matrixraft_observability_provisioning_json();
     assert!(json.contains("rustraft-runtime-overview"));
     assert!(json.contains("RustRaftDebugBundleValidationFailed"));
     assert!(json.contains("RustRaftSupportEnvelopeValidationFailed"));
@@ -1000,10 +1002,10 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     assert!(json.contains("debug_snapshot_low_fresh is true"));
     assert!(json.contains("debug_snapshot_fresh is true"));
 
-    let validation = rustraft_validate_observability_provisioning(&provisioning);
+    let validation = matrixraft_validate_observability_provisioning(&provisioning);
     assert!(validation.ready);
     assert_eq!(validation.issue_count, 0);
-    let validation_metrics = rustraft_observability_provisioning_validation_prometheus(
+    let validation_metrics = matrixraft_observability_provisioning_validation_prometheus(
         &validation,
         &[("service", "raft\"a")],
     );
@@ -1012,13 +1014,13 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     assert!(validation_metrics
         .text
         .contains("rustraft_observability_provisioning_validation_ready{service=\"raft\\\"a\"} 1"));
-    let json_validation = rustraft_validate_observability_provisioning_json(&json);
+    let json_validation = matrixraft_validate_observability_provisioning_json(&json);
     assert!(json_validation.ready);
 
     let mut stale_provisioning = provisioning.clone();
     stale_provisioning.dashboard.uid = "old-runtime-dashboard".to_string();
     let stale_dashboard_validation =
-        rustraft_validate_observability_provisioning(&stale_provisioning);
+        matrixraft_validate_observability_provisioning(&stale_provisioning);
     assert!(!stale_dashboard_validation.ready);
     assert!(stale_dashboard_validation
         .issues
@@ -1029,7 +1031,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     assert!(!stale_dashboard_validation
         .issues
         .contains(&"observability_dashboard_metric_not_advertised".to_string()));
-    let stale_dashboard_metrics = rustraft_observability_provisioning_validation_prometheus(
+    let stale_dashboard_metrics = matrixraft_observability_provisioning_validation_prometheus(
         &stale_dashboard_validation,
         &[("service", "raft\"a")],
     );
@@ -1044,7 +1046,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     stale_dashboard_metric.dashboard.panels[0].expr =
         "rustraft_dashboard_unadvertised_metric".to_string();
     let stale_dashboard_metric_validation =
-        rustraft_validate_observability_provisioning(&stale_dashboard_metric);
+        matrixraft_validate_observability_provisioning(&stale_dashboard_metric);
     assert!(!stale_dashboard_metric_validation.ready);
     assert!(stale_dashboard_metric_validation
         .issues
@@ -1058,7 +1060,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
         issue_count: 1,
         issues: vec!["issue\"with\\escape".to_string()],
     };
-    let escaped_issue_metrics = rustraft_observability_provisioning_validation_prometheus(
+    let escaped_issue_metrics = matrixraft_observability_provisioning_validation_prometheus(
         &escaped_issue_validation,
         &[("service", "raft\\b")],
     );
@@ -1071,7 +1073,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     stale_metrics
         .required_metric_names
         .retain(|name| name != "rustraft_optimization_ready");
-    let stale_metrics_validation = rustraft_validate_observability_provisioning(&stale_metrics);
+    let stale_metrics_validation = matrixraft_validate_observability_provisioning(&stale_metrics);
     assert!(!stale_metrics_validation.ready);
     assert!(stale_metrics_validation
         .issues
@@ -1080,7 +1082,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     let mut stale_alert_metric = provisioning.clone();
     stale_alert_metric.alert_rules[0].expr = "rustraft_unadvertised_metric > 0".to_string();
     let stale_alert_metric_validation =
-        rustraft_validate_observability_provisioning(&stale_alert_metric);
+        matrixraft_validate_observability_provisioning(&stale_alert_metric);
     assert!(!stale_alert_metric_validation.ready);
     assert!(stale_alert_metric_validation
         .issues
@@ -1094,7 +1096,7 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
         .debug_artifact_names
         .retain(|name| name != "debug_snapshot_json");
     let stale_debug_artifacts_validation =
-        rustraft_validate_observability_provisioning(&stale_debug_artifacts);
+        matrixraft_validate_observability_provisioning(&stale_debug_artifacts);
     assert!(!stale_debug_artifacts_validation.ready);
     assert!(stale_debug_artifacts_validation
         .issues
@@ -1104,7 +1106,8 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
     stale_artifacts
         .prometheus_artifact_names
         .retain(|name| name != "provisioning_runbook_prometheus");
-    let stale_artifacts_validation = rustraft_validate_observability_provisioning(&stale_artifacts);
+    let stale_artifacts_validation =
+        matrixraft_validate_observability_provisioning(&stale_artifacts);
     assert!(!stale_artifacts_validation.ready);
     assert!(stale_artifacts_validation
         .issues
@@ -1112,13 +1115,13 @@ fn observability_provisioning_exports_dashboard_alerts_metrics_and_bundle_contra
 
     let mut stale_runbook = provisioning.clone();
     stale_runbook.runbook_steps.clear();
-    let stale_runbook_validation = rustraft_validate_observability_provisioning(&stale_runbook);
+    let stale_runbook_validation = matrixraft_validate_observability_provisioning(&stale_runbook);
     assert!(!stale_runbook_validation.ready);
     assert!(stale_runbook_validation
         .issues
         .contains(&"observability_runbook_steps_mismatch".to_string()));
 
-    let invalid_json_validation = rustraft_validate_observability_provisioning_json("{not-json");
+    let invalid_json_validation = matrixraft_validate_observability_provisioning_json("{not-json");
     assert!(!invalid_json_validation.ready);
     assert!(invalid_json_validation
         .issues
@@ -1152,7 +1155,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         ],
     };
 
-    let metrics = rustraft_optimization_report_prometheus(&report, &[("service", "raft\"a")]);
+    let metrics = matrixraft_optimization_report_prometheus(&report, &[("service", "raft\"a")]);
     assert_eq!(metrics.format, "prometheus_text_v0.0.4");
     assert_eq!(metrics.metric_count, 7);
     assert!(metrics
@@ -1177,7 +1180,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         "rustraft_optimization_component_hint_total{service=\"raft\\\"a\",component=\"replication_pipeline\",severity=\"warning\"} 1"
     ));
 
-    let triage = rustraft_operator_triage_summary(&[], &report, &rustraft_alert_rules());
+    let triage = matrixraft_operator_triage_summary(&[], &report, &matrixraft_alert_rules());
     assert_eq!(triage.status, "needs_attention");
     assert_eq!(triage.severity, "critical");
     assert_eq!(triage.critical_optimization_count, 1);
@@ -1185,7 +1188,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         triage.top_optimization_hint,
         Some("wal_commit_range_missing".to_string())
     );
-    let triage_metrics = rustraft_operator_triage_prometheus(&triage, &[("service", "raft\"a")]);
+    let triage_metrics = matrixraft_operator_triage_prometheus(&triage, &[("service", "raft\"a")]);
     assert_eq!(triage_metrics.format, "prometheus_text_v0.0.4");
     assert_eq!(triage_metrics.metric_count, 9);
     assert!(triage_metrics.text.contains(
@@ -1213,7 +1216,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
     escaped_triage.top_alert = Some("RustRaftAlert\"With\\Escape".to_string());
     escaped_triage.top_optimization_hint = Some("hint\"with\\escape".to_string());
     let escaped_triage_metrics =
-        rustraft_operator_triage_prometheus(&escaped_triage, &[("service", "raft\\b")]);
+        matrixraft_operator_triage_prometheus(&escaped_triage, &[("service", "raft\\b")]);
     assert!(escaped_triage_metrics
         .text
         .contains("service=\"raft\\\\b\""));
@@ -1230,12 +1233,13 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         .text
         .contains("hint=\"hint\\\"with\\\\escape\""));
 
-    let runbook = rustraft_operator_runbook_steps(&triage, &report, &rustraft_alert_rules());
+    let runbook = matrixraft_operator_runbook_steps(&triage, &report, &matrixraft_alert_rules());
     assert!(runbook
         .iter()
         .any(|step| step.id == "resolve_critical_optimization_hints"));
     assert!(runbook.iter().any(|step| step.id == "wire_critical_alerts"));
-    let runbook_metrics = rustraft_operator_runbook_prometheus(&runbook, &[("service", "raft\"a")]);
+    let runbook_metrics =
+        matrixraft_operator_runbook_prometheus(&runbook, &[("service", "raft\"a")]);
     assert_eq!(runbook_metrics.format, "prometheus_text_v0.0.4");
     assert!(runbook_metrics.text.contains(
         "rustraft_operator_runbook_step_total{service=\"raft\\\"a\",severity=\"critical\",target=\"optimization\"}"
@@ -1262,7 +1266,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         },
     ];
     let diagnostic_metrics =
-        rustraft_diagnostic_log_prometheus(&diagnostics, &[("service", "raft\"a")]);
+        matrixraft_diagnostic_log_prometheus(&diagnostics, &[("service", "raft\"a")]);
     assert_eq!(diagnostic_metrics.format, "prometheus_text_v0.0.4");
     assert_eq!(diagnostic_metrics.metric_count, 5);
     assert!(diagnostic_metrics
@@ -1272,7 +1276,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         "rustraft_diagnostic_log_entry_total{service=\"raft\\\"a\",target=\"rustraft.quorum\",severity=\"error\",message=\"quorum_not_observed\"} 1"
     ));
     let diagnostic_triage =
-        rustraft_operator_triage_summary(&diagnostics, &report, &rustraft_alert_rules());
+        matrixraft_operator_triage_summary(&diagnostics, &report, &matrixraft_alert_rules());
     assert_eq!(
         diagnostic_triage.top_diagnostic_target.as_deref(),
         Some("rustraft.quorum")
@@ -1282,7 +1286,7 @@ fn optimization_report_prometheus_exports_hint_metrics() {
         Some("quorum_not_observed")
     );
     let diagnostic_triage_metrics =
-        rustraft_operator_triage_prometheus(&diagnostic_triage, &[("service", "raft\"a")]);
+        matrixraft_operator_triage_prometheus(&diagnostic_triage, &[("service", "raft\"a")]);
     assert_eq!(diagnostic_triage_metrics.metric_count, 10);
     assert!(diagnostic_triage_metrics.text.contains(
         "rustraft_operator_triage_top_diagnostic{service=\"raft\\\"a\",target=\"rustraft.quorum\",message=\"quorum_not_observed\",severity=\"critical\"} 1"

--- a/tests/unique_id.rs
+++ b/tests/unique_id.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::thread;
 
-use matrixraft::{RustRaftUniqueIdGenerator, RUSTRAFT_UNIQUE_ID_COUNTER_MASK};
+use matrixraft::{RustRaftUniqueIdGenerator, MATRIXRAFT_UNIQUE_ID_COUNTER_MASK};
 
 #[test]
 fn unique_id_generator_matches_matrixraft_packing() {
@@ -24,7 +24,7 @@ fn unique_id_generator_matches_matrixraft_packing() {
 }
 
 #[test]
-fn unique_id_generator_masks_member_and_timestamp_like_matrixraft() {
+fn unique_id_generator_masks_member_and_timestamp() {
     let generator = RustRaftUniqueIdGenerator::new(0x1_0001, 0x1_0000_0000_0002);
     let decoded = RustRaftUniqueIdGenerator::decode(generator.next());
 
@@ -34,11 +34,11 @@ fn unique_id_generator_masks_member_and_timestamp_like_matrixraft() {
 }
 
 #[test]
-fn unique_id_counter_rolls_into_timestamp_bits_like_matrixraft() {
+fn unique_id_counter_rolls_into_timestamp_bits() {
     let generator = RustRaftUniqueIdGenerator::new(7, 8);
 
     let first = generator.next();
-    for _ in 0..RUSTRAFT_UNIQUE_ID_COUNTER_MASK {
+    for _ in 0..MATRIXRAFT_UNIQUE_ID_COUNTER_MASK {
         generator.next();
     }
     let rolled = RustRaftUniqueIdGenerator::decode(generator.next());


### PR DESCRIPTION
The crate is `matrixraft`, but 293 of its functions and constants were prefixed `rustraft_` / `RUSTRAFT_` from an earlier name for it, and its own opening doc line introduced it as "RustRaft". Reading the source, it was not obvious what the thing is called.

## What changed

**Function and constant names.** `rustraft_*` → `matrixraft_*`, `RUSTRAFT_*` → `MATRIXRAFT_*`. 1484 identifier occurrences across 59 files. Zero collisions -- checked before writing.

**A suffix that compares the crate to itself.** 128 identifiers, nearly all test names, ended in `_like_matrixraft`. That dates from when these behaviours were described by comparison with another engine; inside MatrixRaft it reads as "behaves like itself", which says nothing, and after the prefix rename it read as `matrixraft_apply_batch_outcome_like_matrixraft`. Dropping it leaves the name describing the behaviour: `initial_campaign_appends_noop_like_matrixraft` is now `initial_campaign_appends_noop`. Two were public API -- `MatrixRaftFsm::apply_batch_like_matrixraft` is now `apply_batch`, and `matrixraft_apply_batch_outcome_like_matrixraft` is now `matrixraft_apply_batch_outcome`. No two names collapsed onto one; that was checked before anything was written.

**The crate's own doc header**, which now introduces it by its own name.

## What deliberately did not change

String literals, unless they name an item this crate declares.

That distinction is the careful part of this change. The same spellings appear in emitted Prometheus metric names (`rustraft_ready`, `rustraft_append_latency_ms`, …), alert-rule names, evidence field keys, and the `RUSTRAFT_BENCHMARK_*` environment variables that `scripts/` sets. Those are published interfaces -- renaming them silently breaks dashboards, alert rules and operator scripts, which is a separate and breaking decision, not a tidy-up.

So the rewrite ran **outside string literals**, scanning each file character by character and skipping normal and raw strings. A second pass then rewrote a name *inside* a string only when the renamed form is an item the crate actually declares. That caught 39 names -- API surface listings, and tests that assert on example source text -- and left 511 occurrences of the published spellings untouched. The discriminator is checkable: `matrixraft_operator_runbook_prometheus` is a declared function so it moved; `rustraft_ready` is not, so it stayed.

The compiler and the tests both caught cases the first pass got wrong, which is worth recording: one constant was read through an inline format argument (`"iterations={RUSTRAFT_…}"`, an identifier living inside a string), and two tests assert on the text of `examples/`, so their expected strings had to follow. Both are fixed.

## Public types are untouched, on purpose

247 public types still carry the `RustRaft` prefix. That rename is not mechanical: seven of them -- `MatrixRaftNodeId`, `MatrixRaftHardState`, `MatrixRaftMessage`, `MatrixRaftAdminCommand`, `MatrixRaftProposeOptions`, `MatrixRaftAppendEntriesRequest`, `MatrixRaftAppendEntriesResponse` -- would collide with **distinct** types of the same name already declared in the compatibility facade. `RustRaftNodeId` is a `u64` alias while `MatrixRaftNodeId` is a struct of peer id plus two addresses; they are different concepts sharing a name. Each clash needs a decision about what the facade type should be called, so it belongs in its own change. This is now stated in the crate docs rather than left as a silent inconsistency.

## Checks

517 tests pass, unchanged. `cargo clippy --all-targets -- -D warnings` clean, `cargo doc` clean under `-D warnings`, `cargo +1.82.0 check --all-targets` (MSRV) clean, `cargo fmt --check` clean.

The diff is large but mechanical, and the interesting part is the 511 strings that were left alone.
