### PR TITLE
Stop writing the whole log to the WAL on every proposal

### DIFF
--- a/examples/wal_amplification.rs
+++ b/examples/wal_amplification.rs
@@ -63,7 +63,7 @@ fn run(entries: usize, payload_bytes: usize) -> (u64, f64) {
     let started = Instant::now();
     for _ in 0..entries {
         cluster.propose(payload.clone()).expect("propose");
-        wal.append(cluster.wal_record_for(1).expect("record"))
+        wal.append_built(|coverage| cluster.wal_record_for_coverage(1, coverage))
             .expect("append");
     }
     let seconds = started.elapsed().as_secs_f64();

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -3969,6 +3969,7 @@ fn benchmark_peer(node_id: u64) -> RustRaftPeer {
 
 fn benchmark_wal_record(index: u64, payload: Vec<u8>) -> RustRaftWalRecord {
     RustRaftWalRecord {
+        entries_are_delta: false,
         group_id: 10,
         node_id: 1,
         hard_state: RustRaftHardState {

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -2605,6 +2605,7 @@ impl RaftCluster {
             .map(|snapshot| snapshot.last_log_id.index)
             .unwrap_or_default();
         let mut record = RaftWalRecord {
+            entries_are_delta: false,
             group_id: self.group_id,
             node_id,
             hard_state: node.hard_state.clone(),

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -2631,6 +2631,82 @@ impl RaftCluster {
         Ok(record)
     }
 
+    /// Builds a WAL record carrying only the entries a WAL does not already
+    /// hold.
+    ///
+    /// `coverage` is what the WAL's active segment already describes, as
+    /// (first index, last index, term at the last index). When the node's log
+    /// still extends that, only the tail past it is copied; otherwise -- a log
+    /// truncated and rewritten, a tail rewritten under a newer term, or a log
+    /// compacted past where the segment starts -- the whole log is copied, and
+    /// the record says so. Passing `None` always copies the whole log.
+    ///
+    /// This is what keeps the per-proposal cost off the length of the log: the
+    /// whole log is only materialised when a whole record is actually needed.
+    pub fn wal_record_for_coverage(
+        &self,
+        node_id: RustRaftNodeId,
+        coverage: Option<(RustRaftLogIndex, RustRaftLogIndex, RustRaftTerm)>,
+    ) -> Result<RaftWalRecord, RaftError> {
+        let node = self
+            .nodes
+            .get(&node_id)
+            .ok_or(RaftError::NodeNotFound(node_id))?;
+        let extends = coverage.and_then(|(first_index, last_index, last_term)| {
+            let log_first = node.log.first()?.log_id.index;
+            if log_first > first_index {
+                return None;
+            }
+            let position = node.log_position(last_index)?;
+            if node.log[position].log_id.term != last_term {
+                return None;
+            }
+            Some(position + 1)
+        });
+        let mut record = self.wal_record_shell(node_id, node);
+        match extends {
+            Some(from) => {
+                record.entries = node.log[from..].to_vec();
+                record.entries_are_delta = true;
+            }
+            None => record.entries = node.log.clone(),
+        }
+        record.checksum = rustraft_wal_checksum(&record);
+        Ok(record)
+    }
+
+    /// Everything in a WAL record except the entries and the checksum.
+    fn wal_record_shell(&self, node_id: RustRaftNodeId, node: &RaftNode) -> RaftWalRecord {
+        let installed_snapshot = node.installed_snapshot.clone();
+        let snapshot_index = installed_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.last_log_id.index)
+            .unwrap_or_default();
+        RaftWalRecord {
+            entries_are_delta: false,
+            group_id: self.group_id,
+            node_id,
+            hard_state: node.hard_state.clone(),
+            membership: self.membership(),
+            entries: Vec::new(),
+            installed_snapshot,
+            apply_snapshot_fence: RustRaftApplySnapshotFence {
+                applied_index: node.applied_index,
+                commit_index: node.commit_index,
+                installed_snapshot_index: snapshot_index,
+                first_retained_log_index: if snapshot_index > 0 {
+                    snapshot_index + 1
+                } else {
+                    node.log
+                        .first()
+                        .map(|entry| entry.log_id.index)
+                        .unwrap_or_default()
+                },
+            },
+            checksum: String::new(),
+        }
+    }
+
     pub fn restore_wal_record(&mut self, record: RaftWalRecord) -> Result<(), RaftError> {
         if record.group_id != self.group_id {
             return Err(RaftError::InvalidRequest(

--- a/src/facade/node_runtime.rs
+++ b/src/facade/node_runtime.rs
@@ -1101,7 +1101,9 @@ fn runtime_step_message(
             }
             let log_id = cluster.propose_with_options(payload, options)?;
             if let Some(wal) = wal.as_mut() {
-                wal.append(cluster.wal_record_for(node_id)?)?;
+                // Built against what the WAL already holds, so a proposal does
+                // not copy and hash the whole log to write one entry.
+                wal.append_built(|coverage| cluster.wal_record_for_coverage(node_id, coverage))?;
             }
             Ok(RustRaftStepResult::Proposed(log_id))
         }

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -234,6 +234,10 @@ pub struct PersistentRaftWal {
     max_fsync_elapsed_ms: u64,
     compacted_after_slow_fsync_count: u64,
     inject_next_fsync_delay_ms: Option<u64>,
+    /// What the active segment's records already describe, as
+    /// (first index, last index, term at the last index). `None` means the
+    /// segment is empty, so the next record has to be stored whole.
+    active_covered: Option<(RustRaftLogIndex, RustRaftLogIndex, RustRaftTerm)>,
 }
 
 impl PersistentRaftWal {
@@ -265,7 +269,7 @@ impl PersistentRaftWal {
         }
         let active_segment = open_segment_for_append(&options.dir, active_id)?;
         let next_segment_id = active_id + 1;
-        Ok(Self {
+        let mut wal = Self {
             options,
             segments,
             active_segment,
@@ -278,7 +282,63 @@ impl PersistentRaftWal {
             max_fsync_elapsed_ms: 0,
             compacted_after_slow_fsync_count: 0,
             inject_next_fsync_delay_ms: None,
-        })
+            active_covered: None,
+        };
+        wal.active_covered = wal.covered_from_active_segment();
+        Ok(wal)
+    }
+
+    /// Advances coverage using the record just appended. The whole-log case
+    /// resets it; a delta only moves the far end.
+    fn advance_active_covered(&mut self) {
+        let Some(record) = self.segments.last().and_then(|s| s.records.last()) else {
+            self.active_covered = None;
+            return;
+        };
+        let last = record.entries.last();
+        if record.entries_are_delta {
+            if let (Some((first_index, _, _)), Some(last)) = (self.active_covered, last) {
+                self.active_covered = Some((first_index, last.log_id.index, last.log_id.term));
+            }
+            return;
+        }
+        self.active_covered = match (record.entries.first(), last) {
+            (Some(first), Some(last)) => {
+                Some((first.log_id.index, last.log_id.index, last.log_id.term))
+            }
+            _ => None,
+        };
+    }
+
+    /// Turns a whole-log record into the delta this segment can store, or
+    /// returns it whole when a delta would not be sound.
+    fn delta_record(&self, record: &RaftWalRecord) -> RaftWalRecord {
+        let Some((first_index, last_index, last_term)) = self.active_covered else {
+            return whole_record(record);
+        };
+        let Some(base) =
+            rustraft_wal_delta_base(&record.entries, first_index, last_index, last_term)
+        else {
+            return whole_record(record);
+        };
+        let mut delta = record.clone();
+        delta.entries = record.entries[base..].to_vec();
+        delta.entries_are_delta = true;
+        delta.checksum = rustraft_wal_checksum(&delta);
+        delta
+    }
+
+    /// Rebuilds the active segment's coverage by folding what is already on
+    /// disk, so an appended-to WAL keeps writing deltas after a reopen.
+    fn covered_from_active_segment(
+        &self,
+    ) -> Option<(RustRaftLogIndex, RustRaftLogIndex, RustRaftTerm)> {
+        let segment = self.segments.last()?;
+        let folded = rustraft_fold_wal_records(&segment.records);
+        let entries = &folded.last()?.entries;
+        let first = entries.first()?;
+        let last = entries.last()?;
+        Some((first.log_id.index, last.log_id.index, last.log_id.term))
     }
 
     pub fn set_slow_fsync_threshold_ms(&mut self, threshold_ms: u64) {
@@ -295,13 +355,9 @@ impl PersistentRaftWal {
 
     pub fn append_with_report(
         &mut self,
-        mut record: RaftWalRecord,
+        record: RaftWalRecord,
     ) -> Result<RaftWalWriteReport, RaftError> {
-        record.checksum = rustraft_wal_checksum(&record);
         let hard_state_persisted = rustraft_validate_hard_state_persistence(&record).is_ok();
-        let encoded = serde_json::to_string(&record)
-            .map_err(|err| RaftError::Storage(format!("failed to encode WAL record: {err}")))?;
-        let record_bytes = encoded.len() as u64 + 1;
         let active_len = self
             .active_segment
             .metadata()
@@ -314,13 +370,34 @@ impl PersistentRaftWal {
             .last()
             .map(|segment| segment.records.len())
             .unwrap_or_default();
+        let rolling_by_count = active_records >= self.options.max_records_per_segment;
+
+        // A record only becomes a delta when it stays in a segment that already
+        // describes a log it extends. Anything else -- a fresh segment, a log
+        // truncated by a conflict, a log compacted past this segment's start --
+        // is stored whole.
+        let mut stored = if rolling_by_count {
+            whole_record(&record)
+        } else {
+            self.delta_record(&record)
+        };
+        let mut encoded = encode_wal_record(&stored)?;
+        let mut record_bytes = encoded.len() as u64 + 1;
+
         let mut segment_rolled = false;
-        if active_records >= self.options.max_records_per_segment
+        if rolling_by_count
             || (active_records > 0 && active_len + record_bytes > self.options.max_segment_bytes)
         {
             self.roll_segment()?;
             segment_rolled = true;
+            if stored.entries_are_delta {
+                // The segment it was a delta against is now sealed.
+                stored = whole_record(&record);
+                encoded = encode_wal_record(&stored)?;
+                record_bytes = encoded.len() as u64 + 1;
+            }
         }
+        let record = stored;
 
         self.active_segment
             .write_all(encoded.as_bytes())
@@ -363,6 +440,7 @@ impl PersistentRaftWal {
         segment.last_index = record_index;
         segment.records.push(record);
         let segment_id = segment.segment_id;
+        self.advance_active_covered();
         Ok(RaftWalWriteReport {
             segment_id,
             log_index: record_index,
@@ -382,10 +460,11 @@ impl PersistentRaftWal {
     pub fn recover(&mut self) -> Result<RaftWalRecoveryReport, RaftError> {
         let (segments, truncated_corrupt_tail) = read_wal_segments_from_dir(&self.options.dir)?;
         let original_len = self.records().len();
-        let records: Vec<_> = segments
+        let stored: Vec<_> = segments
             .iter()
             .flat_map(|segment| segment.records.iter().cloned())
             .collect();
+        let records = rustraft_fold_wal_records(&stored);
         self.segments = if segments.is_empty() {
             vec![RaftWalSegment {
                 segment_id: 0,
@@ -407,6 +486,7 @@ impl PersistentRaftWal {
         }
         self.active_segment = open_segment_for_append(&self.options.dir, active_id)?;
         self.next_segment_id = active_id + 1;
+        self.active_covered = self.covered_from_active_segment();
         let observed_corrupt_tail = self.truncated_corrupt_tail || truncated_corrupt_tail;
         self.truncated_corrupt_tail = observed_corrupt_tail;
         Ok(RaftWalRecoveryReport {
@@ -578,10 +658,12 @@ impl PersistentRaftWal {
     }
 
     pub fn records(&self) -> Vec<RaftWalRecord> {
-        self.segments
+        let stored: Vec<_> = self
+            .segments
             .iter()
             .flat_map(|segment| segment.records.iter().cloned())
-            .collect()
+            .collect();
+        rustraft_fold_wal_records(&stored)
     }
 
     pub fn corrupt_tail_for_test(&mut self) -> Result<(), RaftError> {
@@ -615,6 +697,18 @@ impl PersistentRaftWal {
 }
 
 pub type FileRaftWal = PersistentRaftWal;
+
+fn whole_record(record: &RaftWalRecord) -> RaftWalRecord {
+    let mut whole = record.clone();
+    whole.entries_are_delta = false;
+    whole.checksum = rustraft_wal_checksum(&whole);
+    whole
+}
+
+fn encode_wal_record(record: &RaftWalRecord) -> Result<String, RaftError> {
+    serde_json::to_string(record)
+        .map_err(|err| RaftError::Storage(format!("failed to encode WAL record: {err}")))
+}
 
 fn wal_segment_path(dir: &Path, segment_id: u64) -> PathBuf {
     dir.join(format!("{segment_id:020}.wal"))

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -349,6 +349,40 @@ impl PersistentRaftWal {
         self.inject_next_fsync_delay_ms = Some(delay_ms);
     }
 
+    /// What the active segment already describes, for a caller that wants to
+    /// build the delta itself rather than hand over the whole log.
+    pub fn active_coverage(&self) -> Option<(RustRaftLogIndex, RustRaftLogIndex, RustRaftTerm)> {
+        self.active_covered
+    }
+
+    /// Appends a record the caller builds on demand.
+    ///
+    /// `build` is handed the coverage the record should be written against, or
+    /// `None` when a whole-log record is required -- at the start of a segment,
+    /// and again if rolling turns out to be necessary after the record was
+    /// built. Callers that can produce a delta cheaply should use this instead
+    /// of [`Self::append`], which has to be given the whole log every time.
+    pub fn append_built<F>(&mut self, mut build: F) -> Result<RaftWalWriteReport, RaftError>
+    where
+        F: FnMut(
+            Option<(RustRaftLogIndex, RustRaftLogIndex, RustRaftTerm)>,
+        ) -> Result<RaftWalRecord, RaftError>,
+    {
+        let active_records = self
+            .segments
+            .last()
+            .map(|segment| segment.records.len())
+            .unwrap_or_default();
+        let rolling_by_count = active_records >= self.options.max_records_per_segment;
+        let coverage = if rolling_by_count {
+            None
+        } else {
+            self.active_covered
+        };
+        let record = build(coverage)?;
+        self.write_record(record, active_records, rolling_by_count, || build(None))
+    }
+
     pub fn append(&mut self, record: RaftWalRecord) -> Result<String, RaftError> {
         Ok(self.append_with_report(record)?.checksum)
     }
@@ -357,6 +391,37 @@ impl PersistentRaftWal {
         &mut self,
         record: RaftWalRecord,
     ) -> Result<RaftWalWriteReport, RaftError> {
+        let active_records = self
+            .segments
+            .last()
+            .map(|segment| segment.records.len())
+            .unwrap_or_default();
+        let rolling_by_count = active_records >= self.options.max_records_per_segment;
+        let stored = if rolling_by_count {
+            whole_record(&record)
+        } else {
+            self.delta_record(&record)
+        };
+        self.write_record(stored, active_records, rolling_by_count, || {
+            Ok(whole_record(&record))
+        })
+    }
+
+    /// Writes a record that has already been reduced to what will be stored.
+    ///
+    /// `whole` is only called when rolling turns out to be necessary after the
+    /// record was built, since the segment it was a delta against is then
+    /// sealed and the new segment has to open with a whole-log record.
+    fn write_record<W>(
+        &mut self,
+        mut record: RaftWalRecord,
+        active_records: usize,
+        rolling_by_count: bool,
+        whole: W,
+    ) -> Result<RaftWalWriteReport, RaftError>
+    where
+        W: FnOnce() -> Result<RaftWalRecord, RaftError>,
+    {
         let hard_state_persisted = rustraft_validate_hard_state_persistence(&record).is_ok();
         let active_len = self
             .active_segment
@@ -365,23 +430,7 @@ impl PersistentRaftWal {
                 RaftError::Storage(format!("failed to read WAL active segment metadata: {err}"))
             })?
             .len();
-        let active_records = self
-            .segments
-            .last()
-            .map(|segment| segment.records.len())
-            .unwrap_or_default();
-        let rolling_by_count = active_records >= self.options.max_records_per_segment;
-
-        // A record only becomes a delta when it stays in a segment that already
-        // describes a log it extends. Anything else -- a fresh segment, a log
-        // truncated by a conflict, a log compacted past this segment's start --
-        // is stored whole.
-        let mut stored = if rolling_by_count {
-            whole_record(&record)
-        } else {
-            self.delta_record(&record)
-        };
-        let mut encoded = encode_wal_record(&stored)?;
+        let mut encoded = encode_wal_record(&record)?;
         let mut record_bytes = encoded.len() as u64 + 1;
 
         let mut segment_rolled = false;
@@ -390,14 +439,14 @@ impl PersistentRaftWal {
         {
             self.roll_segment()?;
             segment_rolled = true;
-            if stored.entries_are_delta {
-                // The segment it was a delta against is now sealed.
-                stored = whole_record(&record);
-                encoded = encode_wal_record(&stored)?;
+            if record.entries_are_delta {
+                record = whole()?;
+                record.entries_are_delta = false;
+                record.checksum = rustraft_wal_checksum(&record);
+                encoded = encode_wal_record(&record)?;
                 record_bytes = encoded.len() as u64 + 1;
             }
         }
-        let record = stored;
 
         self.active_segment
             .write_all(encoded.as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,10 @@ pub use unique_id::{
     RUSTRAFT_UNIQUE_ID_TIMESTAMP_MASK,
 };
 pub use wal::{
-    rustraft_recover_latest_wal_record, rustraft_validate_apply_snapshot_fence,
-    rustraft_validate_hard_state_persistence, rustraft_validate_wal_lifecycle_evidence_artifact,
-    rustraft_wal_checksum, rustraft_wal_checksum_format, rustraft_wal_checksum_valid,
+    rustraft_fold_wal_records, rustraft_recover_latest_wal_record,
+    rustraft_validate_apply_snapshot_fence, rustraft_validate_hard_state_persistence,
+    rustraft_validate_wal_lifecycle_evidence_artifact, rustraft_wal_checksum,
+    rustraft_wal_checksum_format, rustraft_wal_checksum_valid, rustraft_wal_delta_base,
     rustraft_wal_lifecycle_evidence, rustraft_wal_lifecycle_evidence_artifact,
     RaftLogRetainedRange, RaftWalChecksumFormat, RaftWalCompactionReport, RaftWalRecord,
     RaftWalRecoveryReport, RaftWalSegment, RaftWalSegmentIndex, RaftWalWriteReport,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub use crate::{
     rustraft_durability_parity_report, FileRaftWal, LocalRaftWal, PersistentRaftWal,
     PersistentRaftWalOptions, RaftHardState, RustRaftDurabilityParityReport, RustRaftHardState,
+    RustRaftTerm,
 };
 
 use crate::{
@@ -77,6 +78,13 @@ pub struct RustRaftWalRecord {
     pub membership: RustRaftMembership,
     #[serde(default)]
     pub entries: Vec<RustRaftLogEntry>,
+    /// When true, `entries` carries only what was appended since the previous
+    /// record in the same segment rather than the whole retained log. The first
+    /// record of every segment is always a full one, so a segment can be read
+    /// without reading any other -- which is what lets whole-segment compaction
+    /// stay as simple as it was.
+    #[serde(default)]
+    pub entries_are_delta: bool,
     #[serde(default)]
     pub installed_snapshot: Option<RustRaftSnapshotMeta>,
     pub apply_snapshot_fence: RustRaftApplySnapshotFence,
@@ -191,6 +199,11 @@ pub fn rustraft_wal_checksum(record: &RaftWalRecord) -> String {
         mix(entry.log_id.index);
         mix(entry.payload.len() as u64);
     }
+    if record.entries_are_delta {
+        // Mixed only when set: a full record hashes exactly as it did before
+        // this field existed, so WAL files written earlier still validate.
+        mix(1);
+    }
     if let Some(snapshot) = &record.installed_snapshot {
         mix(snapshot.last_log_id.term);
         mix(snapshot.last_log_id.index);
@@ -214,6 +227,7 @@ pub fn rustraft_wal_checksum_format() -> RaftWalChecksumFormat {
             "hard_state.committed".to_string(),
             "entries.log_id".to_string(),
             "entries.payload_len".to_string(),
+            "entries_are_delta".to_string(),
             "installed_snapshot.last_log_id".to_string(),
             "apply_snapshot_fence".to_string(),
         ],
@@ -287,6 +301,71 @@ pub fn rustraft_validate_apply_snapshot_fence(
         }
     }
     Ok(())
+}
+
+/// Folds stored records back into whole-log records.
+///
+/// Records are stored so that the first one in a segment carries the whole
+/// retained log and the rest carry only what was appended after it. Every
+/// reader upstream of this function expects whole-log records, so folding
+/// happens here, once, on the way out.
+///
+/// Checksums are verified against the bytes as stored, before folding, and the
+/// fold stops at the first record that fails -- the same place a reader
+/// scanning for a valid prefix would have stopped. The folded records are then
+/// re-checksummed so they validate as the whole-log records they now are.
+pub fn rustraft_fold_wal_records(stored: &[RustRaftWalRecord]) -> Vec<RustRaftWalRecord> {
+    let mut folded_entries: Vec<RustRaftLogEntry> = Vec::new();
+    let mut out = Vec::with_capacity(stored.len());
+    for record in stored {
+        if !rustraft_wal_checksum_valid(record) {
+            break;
+        }
+        if record.entries_are_delta {
+            if let Some(first) = record.entries.first() {
+                let cut =
+                    folded_entries.partition_point(|entry| entry.log_id.index < first.log_id.index);
+                folded_entries.truncate(cut);
+            }
+            folded_entries.extend(record.entries.iter().cloned());
+        } else {
+            folded_entries.clone_from(&record.entries);
+        }
+        let mut whole = record.clone();
+        whole.entries.clone_from(&folded_entries);
+        whole.entries_are_delta = false;
+        whole.checksum = rustraft_wal_checksum(&whole);
+        out.push(whole);
+    }
+    out
+}
+
+/// Whether `entries` extends `covered` rather than diverging from it.
+///
+/// A delta is only sound when the record continues the log the segment already
+/// describes. If the log was truncated by a conflict and rewritten, or compacted
+/// so it now starts later than the segment does, the overlap no longer matches
+/// and the record has to be stored whole.
+pub fn rustraft_wal_delta_base(
+    entries: &[RustRaftLogEntry],
+    covered_first_index: RustRaftLogIndex,
+    covered_last_index: RustRaftLogIndex,
+    covered_last_term: RustRaftTerm,
+) -> Option<usize> {
+    let first = entries.first()?;
+    if first.log_id.index > covered_first_index {
+        // The log was compacted past where this segment starts; folding would
+        // resurrect entries the node no longer holds.
+        return None;
+    }
+    let position = entries
+        .binary_search_by(|entry| entry.log_id.index.cmp(&covered_last_index))
+        .ok()?;
+    if entries[position].log_id.term != covered_last_term {
+        // Same index, different term: the log diverged here.
+        return None;
+    }
+    Some(position + 1)
 }
 
 pub fn rustraft_recover_latest_wal_record(

--- a/tests/durability_parity.rs
+++ b/tests/durability_parity.rs
@@ -31,6 +31,7 @@ fn tail_entry(index: u64) -> RustRaftLogEntry {
 fn wal_record(committed_index: u64) -> RaftWalRecord {
     let meta = snapshot_meta();
     let mut record = RaftWalRecord {
+        entries_are_delta: false,
         group_id: 404,
         node_id: 1,
         hard_state: RustRaftHardState {

--- a/tests/membership_wal_snapshot.rs
+++ b/tests/membership_wal_snapshot.rs
@@ -21,6 +21,7 @@ fn peer(node_id: u64, role: RustRaftReplicaRole) -> RustRaftPeer {
 
 fn wal_record(index: u64) -> RaftWalRecord {
     let mut record = RaftWalRecord {
+        entries_are_delta: false,
         group_id: 9,
         node_id: 1,
         hard_state: RaftHardState {

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -30,6 +30,7 @@ fn wal_options(dir: PathBuf) -> PersistentRaftWalOptions {
 
 fn wal_record(index: u64) -> RaftWalRecord {
     RaftWalRecord {
+        entries_are_delta: false,
         group_id: 9,
         node_id: 1,
         hard_state: RustRaftHardState {
@@ -314,4 +315,211 @@ fn persistent_wal_compaction_fence_blocks_unsafe_release_and_reports_range() {
     assert_eq!(released.retained_range.last_log_index, 5);
 
     let _ = fs::remove_dir_all(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Records are stored as deltas against the segment they land in. These pin the
+// two things that has to be true: what comes back out is the whole log, and a
+// log that stops being an extension of the segment is stored whole instead.
+// ---------------------------------------------------------------------------
+
+/// A record whose log is every index from 1 to `last`, at `term`.
+fn growing_wal_record(last: u64, term: u64) -> RaftWalRecord {
+    let mut record = wal_record(last);
+    record.hard_state.current_term = term;
+    record.hard_state.committed = Some(RustRaftLogId { term, index: last });
+    record.entries = (1..=last)
+        .map(|index| RustRaftLogEntry {
+            log_id: RustRaftLogId {
+                // The tail carries the newer term; the prefix keeps term 3.
+                term: if index == last { term } else { 3 },
+                index,
+            },
+            payload: format!("entry-{index}").into_bytes(),
+            is_command: true,
+        })
+        .collect();
+    record.apply_snapshot_fence.applied_index = last;
+    record.apply_snapshot_fence.commit_index = last;
+    record
+}
+
+fn wide_segment_options(dir: PathBuf) -> PersistentRaftWalOptions {
+    PersistentRaftWalOptions {
+        dir,
+        max_records_per_segment: 1_000,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        fsync_on_append: false,
+    }
+}
+
+fn stored_bytes(dir: &PathBuf) -> u64 {
+    fs::read_dir(dir)
+        .expect("read wal dir")
+        .flatten()
+        .filter_map(|entry| entry.metadata().ok())
+        .map(|meta| meta.len())
+        .sum()
+}
+
+fn stored_delta_count(dir: &PathBuf) -> usize {
+    fs::read_dir(dir)
+        .expect("read wal dir")
+        .flatten()
+        .filter_map(|entry| fs::read_to_string(entry.path()).ok())
+        .map(|text| text.matches("\"entries_are_delta\":true").count())
+        .sum()
+}
+
+#[test]
+fn a_growing_log_is_stored_as_deltas_and_recovers_whole() {
+    let dir = temp_wal_dir("delta-growing");
+    let last = 200_u64;
+    {
+        let mut wal = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("open");
+        for index in 1..=last {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        // The optimisation has to have engaged, or the rest of this test is
+        // just re-testing whole-log records.
+        assert_eq!(
+            stored_delta_count(&dir),
+            (last - 1) as usize,
+            "every record after the first in the segment should be a delta"
+        );
+    }
+
+    let mut reopened = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("reopen");
+    let report = reopened.recover().expect("recover");
+    let recovered = report.recovered.expect("a record survives recovery");
+    assert_eq!(
+        recovered.entries.len(),
+        last as usize,
+        "recovery must fold the deltas back into the whole log"
+    );
+    assert!(!recovered.entries_are_delta);
+    for (offset, entry) in recovered.entries.iter().enumerate() {
+        assert_eq!(entry.log_id.index, offset as u64 + 1);
+        assert_eq!(entry.payload, format!("entry-{}", offset + 1).into_bytes());
+    }
+
+    // The point of the change is that a record's cost stops growing with the
+    // log. Stored whole, the average record here would carry ~100 entries; as
+    // deltas it carries one.
+    let bytes = stored_bytes(&dir);
+    let bytes_per_record = bytes / last;
+    assert!(
+        bytes_per_record < 1_000,
+        "expected a roughly constant per-record cost, got {bytes_per_record} bytes          across {bytes} total"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_log_truncated_by_a_conflict_is_stored_whole() {
+    let dir = temp_wal_dir("delta-conflict");
+    {
+        let mut wal = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("open");
+        for index in 1..=5 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        assert_eq!(stored_delta_count(&dir), 4);
+
+        // A conflict truncates the log back to 3 and rewrites index 3 under a
+        // newer term. That is not an extension of what the segment describes,
+        // so it must be stored whole -- a delta here would leave recovery
+        // rebuilding the entries that were thrown away.
+        wal.append(growing_wal_record(3, 7))
+            .expect("append conflict");
+        assert_eq!(
+            stored_delta_count(&dir),
+            4,
+            "the diverging record must not be stored as a delta"
+        );
+    }
+
+    let reopened = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("reopen");
+    // Read the folded records rather than going through recovery, which picks
+    // by highest committed index and would hand back the pre-conflict record.
+    let folded = reopened.records();
+    let last = folded.last().expect("a record was stored");
+    assert_eq!(
+        last.entries.len(),
+        3,
+        "folding must not resurrect the truncated tail"
+    );
+    assert_eq!(last.entries[2].log_id.term, 7);
+    assert!(!last.entries_are_delta);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn each_segment_can_be_read_without_the_ones_compaction_removed() {
+    let dir = temp_wal_dir("delta-compaction");
+    let options = PersistentRaftWalOptions {
+        dir: dir.clone(),
+        max_records_per_segment: 10,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        fsync_on_append: false,
+    };
+    {
+        let mut wal = PersistentRaftWal::open(options.clone()).expect("open");
+        for index in 1..=50 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        assert!(wal.segments().len() >= 4);
+        // Drop the early segments. Every segment opens with a whole-log record,
+        // so the survivors stay readable on their own.
+        wal.compact_through(20).expect("compact");
+    }
+
+    let mut reopened = PersistentRaftWal::open(options).expect("reopen");
+    let recovered = reopened
+        .recover()
+        .expect("recover")
+        .recovered
+        .expect("a record survives recovery");
+    assert_eq!(recovered.entries.len(), 50);
+    assert_eq!(recovered.entries.last().expect("tail").log_id.index, 50);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_tail_rewritten_at_the_same_index_is_stored_whole() {
+    // The nastiest divergence: the log keeps the same last index but that entry
+    // now carries a newer term. Nothing about the shape of the log changed, so
+    // only comparing the term catches it. Storing a delta here would write an
+    // empty delta and leave folding handing back the entry that was replaced.
+    let dir = temp_wal_dir("delta-rewritten-tail");
+    {
+        let mut wal = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("open");
+        for index in 1..=5 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        assert_eq!(stored_delta_count(&dir), 4);
+
+        wal.append(growing_wal_record(5, 7))
+            .expect("append rewritten tail");
+        assert_eq!(
+            stored_delta_count(&dir),
+            4,
+            "a tail rewritten under a newer term must not be stored as a delta"
+        );
+    }
+
+    let reopened = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("reopen");
+    let folded = reopened.records();
+    let last = folded.last().expect("a record was stored");
+    assert_eq!(last.entries.len(), 5);
+    assert_eq!(
+        last.entries[4].log_id.term, 7,
+        "folding handed back the replaced entry instead of the rewritten one"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
 }

--- a/tests/raft_cluster_engine.rs
+++ b/tests/raft_cluster_engine.rs
@@ -5443,3 +5443,48 @@ fn raft_cluster_implements_consensus_trait_surface() {
     assert!(read.safe);
     assert_eq!(read.read_index, 2);
 }
+
+#[test]
+fn wal_record_for_coverage_copies_only_the_tail_the_wal_lacks() {
+    let mut cluster = three_node_cluster();
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+    for index in 0..5 {
+        cluster
+            .propose(format!("entry-{index}").into_bytes())
+            .expect("propose");
+    }
+
+    let whole = cluster
+        .wal_record_for_coverage(1, None)
+        .expect("whole record");
+    assert!(!whole.entries_are_delta);
+    let entry_count = whole.entries.len();
+    let first = whole.entries.first().expect("a log").log_id.index;
+    let last = whole.entries.last().expect("a log").log_id.clone();
+
+    // Coverage that matches the log exactly: nothing left to carry.
+    let caught_up = cluster
+        .wal_record_for_coverage(1, Some((first, last.index, last.term)))
+        .expect("delta record");
+    assert!(caught_up.entries_are_delta);
+    assert!(caught_up.entries.is_empty());
+
+    // Two more proposals: the delta carries exactly those two, not the log.
+    cluster.propose(b"six".to_vec()).expect("propose");
+    cluster.propose(b"seven".to_vec()).expect("propose");
+    let delta = cluster
+        .wal_record_for_coverage(1, Some((first, last.index, last.term)))
+        .expect("delta record");
+    assert!(delta.entries_are_delta);
+    assert_eq!(delta.entries.len(), 2);
+    assert_eq!(delta.entries[0].log_id.index, last.index + 1);
+
+    // A different term at the overlap means the log diverged, so the whole log
+    // has to be carried instead.
+    let diverged = cluster
+        .wal_record_for_coverage(1, Some((first, last.index, last.term + 1)))
+        .expect("whole record");
+    assert!(!diverged.entries_are_delta);
+    assert_eq!(diverged.entries.len(), entry_count + 2);
+}

--- a/tests/raft_integration_model.rs
+++ b/tests/raft_integration_model.rs
@@ -90,6 +90,7 @@ fn status_for(node: &ModelNode, nodes: &[ModelNode]) -> RustRaftStatusSnapshot {
 
 fn wal_record(node: &ModelNode) -> RustRaftWalRecord {
     let mut record = RustRaftWalRecord {
+        entries_are_delta: false,
         group_id: 7,
         node_id: node.id,
         hard_state: RustRaftHardState {

--- a/tests/raft_unit_contract.rs
+++ b/tests/raft_unit_contract.rs
@@ -43,6 +43,7 @@ fn wal_record(commit_index: u64, snapshot_index: Option<u64>) -> RustRaftWalReco
         members: Vec::new(),
     });
     let mut record = RustRaftWalRecord {
+        entries_are_delta: false,
         group_id: 7,
         node_id: 1,
         hard_state: RustRaftHardState {

--- a/tests/standalone_embedding_contract.rs
+++ b/tests/standalone_embedding_contract.rs
@@ -73,6 +73,7 @@ fn tail_entry(index: u64) -> RustRaftLogEntry {
 
 fn wal_record(index: u64) -> RustRaftWalRecord {
     RustRaftWalRecord {
+        entries_are_delta: false,
         group_id: 909,
         node_id: 1,
         hard_state: RustRaftHardState {


### PR DESCRIPTION
Every WAL record carried the node's whole retained log, and the node runtime appends a record after every proposal. So proposal *k* wrote and fsynced *k* entries, and the bytes on disk grew with the square of the number of proposals.

Measured with `examples/wal_amplification.rs`, which mirrors what the node runtime does per proposal:

| proposals | before | after |
|---:|---:|---:|
| 250 | 24,471 B/proposal | 598 |
| 500 | 48,462 | 598 |
| 1000 | 96,457 | 599 |
| 2000 | 192,708 | 601 |

The per-proposal cost is now flat instead of climbing. The 2000-proposal run writes **1.2 MB instead of 385 MB** — 321x fewer bytes for 128 KB of actual payload — and write amplification goes from 3011x and growing to 9.4x and constant.

Two commits, because storing deltas fixed the bytes but not the work. A proposal still cloned the whole log into a record and hashed all of it before the WAL diffed it, so the bytes stopped growing while the time per proposal kept growing. The second commit lets the WAL ask for the record instead of being handed one: it passes back what its active segment already describes, and the cluster copies only the tail past that — an O(1) lookup, since the log is addressed by index. A whole-log record is built only when one is actually needed.

Wall time for the same run, fsync off: **1.327 s → 0.229 s (deltas) → 0.016 s (built on demand)**. Doubling the proposals now doubles the time rather than quadrupling it, so both the bytes and the work are flat in the length of the log.

 still takes a whole record and still works;  is for callers that can produce a delta cheaply, which the node runtime now does.

## The shape, and why this one

Records now store only what was appended since the previous record in the same segment. **The first record of a segment is still written whole**, so a segment can be read without reading any other.

That property is the whole reason for choosing this shape. `compact_through` drops entire segments; with a running delta across the WAL, dropping a segment could remove the record a later delta was built on, and losing committed entries at recovery is not a trade worth any number of bytes. Because each segment opens with a whole-log record, compaction keeps working exactly as it did, with no new rules about which records something else still depends on.

## When a delta is not sound

A delta only makes sense when the record extends the log its segment already describes. Three cases do not, and are stored whole:

- a log truncated by a conflict and rewritten,
- a log compacted past where the segment starts (folding would resurrect entries the node no longer holds),
- **a tail rewritten under a newer term at the same index.**

The third is the one worth naming. The last index and the shape of the log are unchanged, so nothing about the log's size reveals the divergence — only comparing the *term* at the overlap does. Storing a delta there would write an empty delta and leave folding handing back the entry that had been replaced. There is a test for exactly this, and it is the one that fails if the term comparison is removed.

## Compatibility

Reading folds the deltas back, so everything upstream still sees whole-log records: recovery, `records()`, `status()` and retained-range reporting are untouched, and `rustraft_recover_latest_wal_record` did not change at all.

Checksums are verified against the bytes **as stored**, before folding, and folding stops at the first record that fails — the same place a reader scanning for a valid prefix stopped before, so corrupt-tail detection is unaffected. The new `entries_are_delta` field is mixed into the checksum **only when set**, which means a whole-log record hashes exactly as it did before the field existed and a WAL written by an older build still validates and recovers unchanged.

`RustRaftWalRecord` gains a field, so struct literals that construct one need `entries_are_delta: false`. That is source-breaking for outside constructors.

## Tests

Four new tests, and each was checked against a deliberately broken implementation rather than assumed to be meaningful:

- breaking the fold fails `a_growing_log_is_stored_as_deltas_and_recovers_whole` and `each_segment_can_be_read_without_the_ones_compaction_removed`;
- dropping the term comparison fails `a_tail_rewritten_at_the_same_index_is_stored_whole`.

That check was worth running: an earlier version of the conflict test passed against the broken build, because the truncation it used was caught by a length check and never reached the term comparison at all.

521 tests pass. `cargo clippy --all-targets -- -D warnings` clean, `cargo doc` clean under `-D warnings`, `cargo +1.82.0 check --all-targets` (MSRV) clean, `cargo fmt --check` clean.

## Merge order

This branches from `main`, so it does not include the function renaming in the other open PR. Whichever lands first, the other needs a rebase; the overlap is mechanical (renamed identifiers in the same files).
