### PR TITLE
Say which halves of the evidence bundle are built in

### DIFF
--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -3455,17 +3455,27 @@ impl RaftCluster {
     }
 
     pub fn transfer_leader(&mut self, target: NodeId) -> Result<(), RaftError> {
+        self.transfer_leader_outcome(target).map(|_| ())
+    }
+
+    /// Transfer leadership, reporting which of the three things happened.
+    ///
+    /// `transfer_leader` collapses all three into `Ok(())`, which is why a
+    /// report built from its return value cannot tell "leadership moved" from
+    /// "the request was ignored".
+    pub fn transfer_leader_outcome(
+        &mut self,
+        target: NodeId,
+    ) -> Result<LeaderTransferOutcome, RaftError> {
         if self.begin_leader_transfer(target)?.is_none() {
-            return Ok(());
+            return Ok(LeaderTransferOutcome::Ignored);
         }
         if !self.leader_transfer_target_caught_up(target)? {
-            return Ok(());
+            return Ok(LeaderTransferOutcome::Pending);
         }
-        let result = self.campaign(target, true);
-        if result.is_ok() {
-            self.leader_transfer = None;
-        }
-        result
+        self.campaign(target, true)?;
+        self.leader_transfer = None;
+        Ok(LeaderTransferOutcome::Transferred)
     }
 
     pub fn try_complete_leader_transfer(&mut self) -> Result<bool, RaftError> {

--- a/src/facade/matrixraft_compat.rs
+++ b/src/facade/matrixraft_compat.rs
@@ -191,7 +191,21 @@ pub struct MatrixRaftTransferLeaderReport {
     pub transferee_node: Option<MatrixRaftNodeId>,
     #[serde(default)]
     pub state: Option<LeaderTransferState>,
+    /// True only when leadership actually moved. `state` cannot substitute for
+    /// this: it is `None` both for an ignored request and for a completed one.
     pub transferred: bool,
+    /// Which of the three things the request did. `transferred` is
+    /// `outcome == Transferred`; this says which of the two non-transfers it
+    /// was when it is false.
+    #[serde(default = "default_leader_transfer_outcome")]
+    pub outcome: crate::LeaderTransferOutcome,
+}
+
+/// Older payloads predate `outcome` and only ever carried `transferred: true`,
+/// which by then meant "the call returned Ok". `Ignored` is the honest default
+/// for a field that was not recorded.
+fn default_leader_transfer_outcome() -> crate::LeaderTransferOutcome {
+    crate::LeaderTransferOutcome::Ignored
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3615,12 +3629,27 @@ impl MatrixRaftNode {
         transferee: NodeId,
     ) -> Result<MatrixRaftTransferLeaderReport, RaftError> {
         let transferee_node = self.peers.get(&transferee).map(MatrixRaftNodeId::from);
-        self.transfer_leader(transferee)?;
+        if let Some(peer) = self.peers.get(&transferee) {
+            if !peer.role.can_be_leader() {
+                return Err(RaftError::InvalidRequest(format!(
+                    "matrixraft leader transfer target must be voter, got {:?}",
+                    peer.role
+                )));
+            }
+        }
+        // `transferred` reports whether leadership moved, not whether the call
+        // returned Ok. An unknown or ineligible transferee is ignored and a
+        // lagging one is queued; both of those are Ok and neither is a
+        // transfer. The runtime classifies the outcome in the same step that
+        // performs it, so this cannot be invalidated by anything happening in
+        // between.
+        let outcome = self.runtime.transfer_leader_outcome(transferee)?;
         Ok(MatrixRaftTransferLeaderReport {
             transferee_id: transferee,
             transferee_node,
             state: self.runtime.leader_transfer_state()?,
-            transferred: true,
+            transferred: outcome.is_transferred(),
+            outcome,
         })
     }
 

--- a/src/facade/node_runtime.rs
+++ b/src/facade/node_runtime.rs
@@ -33,6 +33,10 @@ enum NodeRuntimeOp {
     Start(mpsc::Sender<Result<(), RaftError>>),
     Stop(mpsc::Sender<Result<(), RaftError>>),
     Status(mpsc::Sender<Result<NodeRuntimeStatus, RaftError>>),
+    TransferLeaderOutcome(
+        NodeId,
+        mpsc::Sender<Result<crate::LeaderTransferOutcome, RaftError>>,
+    ),
     WalLifecycleStatus(mpsc::Sender<Result<WalLifecycleStatus, RaftError>>),
     WalRecoveryReport(mpsc::Sender<Result<Option<WalRecoveryReport>, RaftError>>),
     Step(
@@ -825,6 +829,26 @@ impl NodeRuntime {
                 "unexpected leader transfer abort result: {other:?}"
             ))),
         }
+    }
+
+    /// Transfer leadership and report which of the three outcomes occurred.
+    ///
+    /// Prefer this to [`Self::transfer_leader`] when the caller needs to know
+    /// whether leadership actually moved: `transfer_leader` returns `Ok` for an
+    /// ignored request as well as a completed one.
+    pub fn transfer_leader_outcome(
+        &self,
+        target: NodeId,
+    ) -> Result<crate::LeaderTransferOutcome, RaftError> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.sender()?
+            .send(NodeRuntimeOp::TransferLeaderOutcome(target, reply_tx))
+            .map_err(|err| {
+                RaftError::Transport(format!(
+                    "failed to transfer leadership through raft node: {err}"
+                ))
+            })?;
+        recv_runtime_reply(reply_rx)?
     }
 
     pub fn leader_transfer_state(&self) -> Result<Option<LeaderTransferState>, RaftError> {
@@ -1640,6 +1664,12 @@ fn raft_node_runtime_loop(
             NodeRuntimeOp::LeaderTransferState(reply) => {
                 let _ = reply.send(Ok(cluster.leader_transfer_state()));
             }
+            NodeRuntimeOp::TransferLeaderOutcome(target, reply) => {
+                // Performed and classified inside the runtime thread, so the
+                // outcome cannot be invalidated between doing the transfer and
+                // observing it.
+                let _ = reply.send(cluster.transfer_leader_outcome(target));
+            }
             NodeRuntimeOp::Shutdown(reply) => {
                 let result = cluster.stop();
                 let _ = reply.send(record_runtime_result(
@@ -1726,6 +1756,10 @@ fn respond_runtime_error(command: NodeRuntimeOp, error: RaftError) -> bool {
             false
         }
         NodeRuntimeOp::LeaderTransferState(reply) => {
+            let _ = reply.send(Err(error));
+            false
+        }
+        NodeRuntimeOp::TransferLeaderOutcome(_, reply) => {
             let _ = reply.send(Err(error));
             false
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,10 +216,11 @@ pub use status::{
     AdminStatusSurfaceEvidence, AdminStatusSurfaceInput, ApplyHealth,
     BaselineRaftRuntimeCapabilityReport, Blocker, BlockerSeverity, CapabilityEvidence,
     ClusterStatusReport, DiagnosticLogEntry, DiagnosticSeverity, FatalBlockerReport, HealthStatus,
-    LeaderTransferAdmission, LeaderTransferAdmissionKind, LeaderTransferState, OptimizationHint,
-    OptimizationHintSeverity, OptimizationReport, PeerRuntimeState, ProcessNodeEvidence,
-    ProcessOperationalSemanticsEvidence, ProcessReadinessBlocker, ReplicationHealth,
-    RuntimeAdminReport, RuntimeLocalStatusReport, RuntimeTimerStatus,
+    LeaderTransferAdmission, LeaderTransferAdmissionKind, LeaderTransferOutcome,
+    LeaderTransferState, OptimizationHint, OptimizationHintSeverity, OptimizationReport,
+    PeerRuntimeState, ProcessNodeEvidence, ProcessOperationalSemanticsEvidence,
+    ProcessReadinessBlocker, ReplicationHealth, RuntimeAdminReport, RuntimeLocalStatusReport,
+    RuntimeTimerStatus,
 };
 pub use storage::{
     matrixraft_validate_storage_apply_fence, MatrixRaftGroupStorage, MatrixRaftLogCompactionReport,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ pub use node::{
 };
 pub use operational_evidence::{
     matrixraft_baseline_raft_operational_evidence_bundle,
+    matrixraft_baseline_raft_operational_evidence_bundle_from_artifacts,
     matrixraft_validate_baseline_raft_operational_evidence_bundle,
     BaselineRaftOperationalEvidenceBundle, BaselineRaftOperationalEvidenceBundleValidationReport,
 };

--- a/src/membership.rs
+++ b/src/membership.rs
@@ -364,6 +364,19 @@ fn matrixraft_membership_semantics_transition(
     }
 }
 
+/// The built-in **reference** membership-semantics artifact.
+///
+/// This is not a measurement. It takes no inputs, consults no cluster, and its
+/// transitions hardcode their conclusions rather than deriving them --
+/// `old_majority_preserved`, `stale_leader_rejected` and the rest are literals,
+/// and the commit indices are always 128 and 144. It is useful as a schema
+/// example and as a golden vector to validate a runtime's own artifact against.
+///
+/// Because the producer hardcodes exactly the fields
+/// [`matrixraft_validate_membership_semantics_evidence_artifact`] checks,
+/// validating this artifact always succeeds. A `membership_valid: true` derived
+/// from it says nothing about any deployment; the bundle validation report sets
+/// `membership_is_reference` so a reader can tell the two apart.
 pub fn matrixraft_membership_semantics_evidence_artifact() -> MembershipSemanticsEvidenceArtifact {
     MembershipSemanticsEvidenceArtifact {
         schema: "rustraft.membership_semantics_evidence.v1".to_string(),

--- a/src/operational_evidence.rs
+++ b/src/operational_evidence.rs
@@ -38,6 +38,24 @@ pub struct BaselineRaftOperationalEvidenceBundleValidationReport {
     pub replication_pipeline_valid: bool,
     pub snapshot_lifecycle_valid: bool,
     pub wal_lifecycle_valid: bool,
+    /// True when `read_safety` is byte-for-byte the built-in conformance
+    /// vector, i.e. nobody attached evidence from a running cluster.
+    ///
+    /// `read_safety_valid` says the artifact is well formed; it does not say
+    /// where it came from. The vector runs real decision logic over fixed
+    /// inputs, so it does test something -- but it tests this crate, not the
+    /// caller's deployment.
+    #[serde(default)]
+    pub read_safety_is_reference: bool,
+    /// True when `membership` is byte-for-byte the built-in reference artifact.
+    ///
+    /// This one matters more than the read-safety flag: the reference artifact
+    /// hardcodes its conclusions rather than deriving them, so
+    /// `membership_valid` is true for every caller on every cluster whenever
+    /// this flag is set. Treat `membership_valid: true` as evidence about a
+    /// deployment only when this is false.
+    #[serde(default)]
+    pub membership_is_reference: bool,
     #[serde(default)]
     pub missing: Vec<String>,
 }
@@ -50,10 +68,45 @@ pub fn matrixraft_baseline_raft_operational_evidence_bundle(
     snapshot_max_inflights_replicate: u64,
     wal_status: WalLifecycleStatus,
 ) -> BaselineRaftOperationalEvidenceBundle {
+    // Every parameter above feeds the last three artifacts. The first two have
+    // no inputs and so cannot describe the caller's cluster: they are the
+    // built-in reference artifacts. Callers holding real read-safety and
+    // membership evidence should use
+    // [`matrixraft_baseline_raft_operational_evidence_bundle_from_artifacts`],
+    // which takes them, rather than shipping a bundle whose membership half is
+    // fixed. The validation report flags which halves were the reference.
+    matrixraft_baseline_raft_operational_evidence_bundle_from_artifacts(
+        matrixraft_read_safety_evidence_artifact(),
+        matrixraft_membership_semantics_evidence_artifact(),
+        pipeline_peers,
+        pipeline_limits,
+        snapshot_peers,
+        send_snapshot_timeout_ms,
+        snapshot_max_inflights_replicate,
+        wal_status,
+    )
+}
+
+/// Build the bundle from read-safety and membership evidence the caller has
+/// actually observed, rather than the built-in reference artifacts.
+///
+/// The other three artifacts are derived from the runtime state passed in, as
+/// they already were.
+#[allow(clippy::too_many_arguments)]
+pub fn matrixraft_baseline_raft_operational_evidence_bundle_from_artifacts(
+    read_safety: ReadSafetyEvidenceArtifact,
+    membership: MembershipSemanticsEvidenceArtifact,
+    pipeline_peers: Vec<PeerProgress>,
+    pipeline_limits: PipelineLimits,
+    snapshot_peers: Vec<PeerProgress>,
+    send_snapshot_timeout_ms: u64,
+    snapshot_max_inflights_replicate: u64,
+    wal_status: WalLifecycleStatus,
+) -> BaselineRaftOperationalEvidenceBundle {
     BaselineRaftOperationalEvidenceBundle {
         schema: "rustraft.baseline_raft_operational_evidence_bundle.v1".to_string(),
-        read_safety: matrixraft_read_safety_evidence_artifact(),
-        membership: matrixraft_membership_semantics_evidence_artifact(),
+        read_safety,
+        membership,
         replication_pipeline: matrixraft_replication_pipeline_evidence_artifact(
             pipeline_peers,
             pipeline_limits,
@@ -78,6 +131,14 @@ pub fn matrixraft_validate_baseline_raft_operational_evidence_bundle(
     let snapshot_lifecycle =
         matrixraft_validate_snapshot_lifecycle_evidence_artifact(&bundle.snapshot_lifecycle);
     let wal_lifecycle = matrixraft_validate_wal_lifecycle_evidence_artifact(&bundle.wal_lifecycle);
+
+    // Whether each of the two input-free artifacts is still the built-in one.
+    // `*_valid` only says an artifact is well formed; for the membership
+    // reference, well formed is unconditional, because the producer hardcodes
+    // exactly the fields the validator checks.
+    let read_safety_is_reference = bundle.read_safety == matrixraft_read_safety_evidence_artifact();
+    let membership_is_reference =
+        bundle.membership == matrixraft_membership_semantics_evidence_artifact();
 
     let mut missing = Vec::new();
     if !schema_valid {
@@ -112,6 +173,8 @@ pub fn matrixraft_validate_baseline_raft_operational_evidence_bundle(
         replication_pipeline_valid: replication_pipeline.valid,
         snapshot_lifecycle_valid: snapshot_lifecycle.valid,
         wal_lifecycle_valid: wal_lifecycle.valid,
+        read_safety_is_reference,
+        membership_is_reference,
         missing,
     }
 }

--- a/src/read_safety.rs
+++ b/src/read_safety.rs
@@ -354,6 +354,15 @@ pub fn matrixraft_read_safety_runtime_decision(
     }
 }
 
+/// The built-in read-safety **conformance vector**.
+///
+/// Unlike the membership reference artifact, this one does exercise real logic:
+/// each case is a fixed [`ReadSafetyRuntimeInput`] run through
+/// [`matrixraft_read_safety_runtime_decision`]. Only the inputs are fixed.
+///
+/// So it is evidence about *this crate*, not about a caller's deployment. The
+/// bundle validation report sets `read_safety_is_reference` when a bundle still
+/// carries this rather than something observed.
 pub fn matrixraft_read_safety_evidence_artifact() -> ReadSafetyEvidenceArtifact {
     ReadSafetyEvidenceArtifact {
         schema: "rustraft.read_safety_evidence.v1".to_string(),

--- a/src/status.rs
+++ b/src/status.rs
@@ -110,6 +110,31 @@ pub enum LeaderTransferAdmissionKind {
     Replaced,
 }
 
+/// What a leader-transfer request actually did.
+///
+/// `transfer_leader` returns `Ok` for all three, because none of them is an
+/// error: an unknown or ineligible transferee is *ignored* (as etcd/raft drops
+/// a `MsgTransferLeader` naming a peer it does not know), and a transferee that
+/// is still catching up leaves the transfer queued. Only `Transferred` means
+/// leadership moved.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LeaderTransferOutcome {
+    /// The admission declined the request; nothing changed.
+    Ignored,
+    /// Accepted, but the transferee has not caught up yet, so it is queued.
+    Pending,
+    /// Leadership moved to the transferee.
+    Transferred,
+}
+
+impl LeaderTransferOutcome {
+    /// True only when leadership actually moved.
+    pub fn is_transferred(self) -> bool {
+        matches!(self, Self::Transferred)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LeaderTransferAdmission {
     pub kind: LeaderTransferAdmissionKind,

--- a/tests/baseline_raft_runtime_capability.rs
+++ b/tests/baseline_raft_runtime_capability.rs
@@ -4,6 +4,7 @@
 use matrixraft::{
     fault, matrixraft_admin_status_surface_evidence,
     matrixraft_baseline_raft_operational_evidence_bundle,
+    matrixraft_baseline_raft_operational_evidence_bundle_from_artifacts,
     matrixraft_baseline_raft_runtime_capability_prometheus,
     matrixraft_baseline_raft_runtime_capability_report, matrixraft_capability_evidence_from_fields,
     matrixraft_cross_plane_process_evidence_artifact,
@@ -1402,6 +1403,42 @@ fn baseline_raft_operational_evidence_bundle_is_library_owned() {
     assert!(validation.snapshot_lifecycle_valid);
     assert!(validation.wal_lifecycle_valid);
     assert!(validation.missing.is_empty());
+
+    // The name of this test is the point: the bundle is library-owned. Its
+    // read-safety and membership halves take no inputs and so cannot describe
+    // any deployment, and the report now says so. Without these flags,
+    // `membership_valid: true` reads as a fact about the caller's cluster --
+    // and it is unfalsifiable, because the producer hardcodes exactly the
+    // fields the validator checks.
+    assert!(validation.read_safety_is_reference);
+    assert!(validation.membership_is_reference);
+}
+
+#[test]
+fn baseline_raft_operational_evidence_bundle_marks_supplied_evidence_as_not_reference() {
+    let mut observed_membership = matrixraft_membership_semantics_evidence_artifact();
+    // Stand in for evidence taken from a running cluster: same shape, different
+    // commit indices than the reference artifact's fixed 128/144.
+    observed_membership.learner_add.commit_index_before = 900;
+    observed_membership.learner_add.commit_index_after = 916;
+
+    let bundle = matrixraft_baseline_raft_operational_evidence_bundle_from_artifacts(
+        matrixraft_read_safety_evidence_artifact(),
+        observed_membership,
+        complete_replication_pipeline_peers(),
+        PipelineLimits::production_default(),
+        complete_snapshot_lifecycle_peers(),
+        1_000,
+        1,
+        complete_wal_lifecycle_status(),
+    );
+
+    let validation = matrixraft_validate_baseline_raft_operational_evidence_bundle(&bundle);
+    assert!(validation.valid, "{validation:#?}");
+    // Membership came from the caller, so it is no longer the reference; the
+    // read-safety half still is, and the two are reported independently.
+    assert!(!validation.membership_is_reference);
+    assert!(validation.read_safety_is_reference);
 }
 
 #[test]

--- a/tests/matrixraft_compat.rs
+++ b/tests/matrixraft_compat.rs
@@ -465,3 +465,74 @@ fn matrixraft_facade_enforces_witness_and_learner_semantic_edges() {
     let _ = fs::remove_dir_all(witness_wal_dir);
     let _ = fs::remove_dir_all(witness_snapshot_dir);
 }
+
+#[test]
+fn transfer_leader_report_distinguishes_an_ignored_transfer_from_a_completed_one() {
+    let wal_dir = temp_dir("transfer-report-wal");
+    let snapshot_dir = temp_dir("transfer-report-snapshot");
+    let options = NodeOptions {
+        group_id: 506,
+        node_id: 1,
+        raft_addr: "127.0.0.1:41001".to_string(),
+        snapshot_addr: "127.0.0.1:42001".to_string(),
+        wal_dir: wal_dir.display().to_string(),
+        snapshot_dir: snapshot_dir.display().to_string(),
+        role: ReplicaRole::Voter,
+        config: Config {
+            heartbeat_interval_ms: 5,
+            election_timeout_ms: 20,
+            leader_lease_ms: 10,
+            ..Default::default()
+        },
+        peers: vec![
+            peer(1, ReplicaRole::Voter),
+            peer(2, ReplicaRole::Voter),
+            peer(3, ReplicaRole::Voter),
+        ],
+    };
+
+    let mut node = MatrixRaftNode::create(options, 1).expect("create node");
+    node.start(1).expect("start");
+
+    // The defect this pins: a transferee the group does not know is *ignored*,
+    // which is correct, but the report used to claim `transferred: true`.
+    let ignored = node
+        .transfer_leader_with_report(999)
+        .expect("report for an unknown transferee");
+    assert_eq!(
+        ignored.outcome,
+        matrixraft::LeaderTransferOutcome::Ignored,
+        "an unknown transferee cannot be transferred to"
+    );
+    assert!(
+        !ignored.transferred,
+        "an ignored transfer must not report success"
+    );
+    assert_eq!(ignored.transferee_node, None);
+    assert_ne!(
+        node.leader().expect("leader after ignored transfer"),
+        Some(999)
+    );
+
+    // And the invariant that makes the field meaningful at all: `transferred`
+    // is exactly "the outcome was Transferred", for a real peer too. Whether
+    // that peer has caught up yet decides Pending vs Transferred, and that is
+    // timing, so the outcome itself is not asserted here -- only that the two
+    // fields agree.
+    let real = node
+        .transfer_leader_with_report(2)
+        .expect("report for a known voter");
+    assert_eq!(
+        real.transferred,
+        real.outcome == matrixraft::LeaderTransferOutcome::Transferred
+    );
+    assert_ne!(
+        real.outcome,
+        matrixraft::LeaderTransferOutcome::Ignored,
+        "a known voter must not be ignored"
+    );
+
+    node.shutdown().expect("shutdown");
+    let _ = fs::remove_dir_all(wal_dir);
+    let _ = fs::remove_dir_all(snapshot_dir);
+}

--- a/tests/matrixraft_multi_raft_compat.rs
+++ b/tests/matrixraft_multi_raft_compat.rs
@@ -492,6 +492,7 @@ fn matrixraft_async_group_summary_exposes_leadership_payloads_by_status() {
         transferee_node: None,
         state: None,
         transferred: true,
+        outcome: matrixraft::LeaderTransferOutcome::Transferred,
     });
 
     let mut step_result =
@@ -763,6 +764,7 @@ fn matrixraft_route_summaries_expose_response_payloads_by_route() {
         transferee_node: None,
         state: None,
         transferred: true,
+        outcome: matrixraft::LeaderTransferOutcome::Transferred,
     };
     let step_down = MatrixRaftStepDownReport {
         requested_transferee_id: Some(4),
@@ -3059,7 +3061,16 @@ fn matrixraft_multi_raft_server_hosts_groups_and_routes_messages() {
         .transfer_leader
         .as_ref()
         .expect("transfer-leader route report");
-    assert!(transfer_report.transferred);
+    // Queued, not completed: the assertions below read a live
+    // `state.transferee_id` and then abort the transfer, both of which only
+    // make sense while it is still pending. This used to assert `transferred`
+    // as well, which contradicted them -- and passed only because the field was
+    // hardcoded `true`.
+    assert_eq!(
+        transfer_report.outcome,
+        matrixraft::LeaderTransferOutcome::Pending
+    );
+    assert!(!transfer_report.transferred);
     assert_eq!(transfer_report.transferee_id, 2);
     assert_eq!(
         transfer_report
@@ -15902,11 +15913,17 @@ fn matrixraft_multi_raft_server_controls_leadership_by_group() {
         .transfer_leader_on_group(834, 2)
         .expect("transfer leadership by group");
     assert_eq!(transfers.len(), 2);
+    // `transferred` now means "leadership moved" rather than "the call returned
+    // Ok", so it is no longer unconditionally true. Which of Pending/
+    // Transferred/Ignored each routed node reports depends on whether that node
+    // leads and whether the transferee has caught up, neither of which this
+    // test sets up -- so assert the invariant that makes the field meaningful,
+    // and the routing, which is what this test is about.
     assert!(transfers.iter().all(|result| {
-        result
-            .transfer_leader
-            .as_ref()
-            .is_some_and(|report| report.transferred && report.transferee_id == 2)
+        result.transfer_leader.as_ref().is_some_and(|report| {
+            report.transferred == (report.outcome == matrixraft::LeaderTransferOutcome::Transferred)
+                && report.transferee_id == 2
+        })
     }));
     let selected_transfers = server
         .transfer_leader_for_groups([834, 835], 1)
@@ -15918,12 +15935,16 @@ fn matrixraft_multi_raft_server_controls_leadership_by_group() {
             .collect::<Vec<_>>(),
         vec![(834, 2), (835, 1)]
     );
+    // Transferring to node 1, which already leads these groups, so the
+    // admission ignores it as a self-transfer. Same reasoning as above: assert
+    // the invariant and the routing rather than a hardcoded `transferred`.
     assert!(selected_transfers.iter().all(|(_, results)| {
         results.iter().all(|result| {
-            result
-                .transfer_leader
-                .as_ref()
-                .is_some_and(|report| report.transferred && report.transferee_id == 1)
+            result.transfer_leader.as_ref().is_some_and(|report| {
+                report.transferred
+                    == (report.outcome == matrixraft::LeaderTransferOutcome::Transferred)
+                    && report.transferee_id == 1
+            })
         })
     }));
     let selected_transfer_summaries =
@@ -15933,11 +15954,26 @@ fn matrixraft_multi_raft_server_controls_leadership_by_group() {
             .transfer_leader_transferee_ids_by_route_key()
             .iter()
             .all(|(_, transferee_id)| *transferee_id == Some(1))
-            && summary
-                .transfer_leader_transferred_by_route_key()
-                .iter()
-                .all(|(_, transferred)| *transferred == Some(true))
     }));
+    // Group 834 has two members, so leadership can actually move to node 1.
+    // Group 835 has only node 1, which already leads it, so the admission
+    // ignores that request as a self-transfer and nothing moves.
+    //
+    // This used to assert `Some(true)` for every route key, which the
+    // single-node group contradicts. It passed only because `transferred` was
+    // hardcoded `true`; now the field distinguishes the two.
+    assert_eq!(
+        selected_transfer_summaries
+            .iter()
+            .flat_map(|summary| summary.transfer_leader_transferred_by_route_key())
+            .map(|(key, transferred)| (key.group_id, key.node_id, transferred))
+            .collect::<Vec<_>>(),
+        vec![
+            (834, 1, Some(true)),
+            (834, 2, Some(true)),
+            (835, 1, Some(false)),
+        ]
+    );
     let selected_transfers_best_effort = server
         .transfer_leader_for_groups_best_effort([834, 835], 1)
         .expect("best-effort transfer selected meta and data groups");
@@ -15951,10 +15987,15 @@ fn matrixraft_multi_raft_server_controls_leadership_by_group() {
     assert!(selected_transfers_best_effort.iter().all(|(_, results)| {
         results.iter().all(|result| {
             result.result.as_ref().is_some_and(|route| {
-                route
-                    .transfer_leader
-                    .as_ref()
-                    .is_some_and(|report| report.transferred && report.transferee_id == 1)
+                route.transfer_leader.as_ref().is_some_and(|report| {
+                    // By now node 1 already leads 834 as well, so this
+                    // second round is a self-transfer everywhere. Assert
+                    // the invariant and the routing; the exact values are
+                    // pinned once, above.
+                    report.transferred
+                        == (report.outcome == matrixraft::LeaderTransferOutcome::Transferred)
+                        && report.transferee_id == 1
+                })
             })
         })
     }));
@@ -15969,7 +16010,12 @@ fn matrixraft_multi_raft_server_controls_leadership_by_group() {
             && summary
                 .transfer_leader_transferred_by_route_key()
                 .iter()
-                .all(|(_, transferred)| *transferred == Some(true))));
+                // The summary's job here is to surface a value per route key.
+                // What that value is depends on which node leads which group by
+                // this point, and is pinned exactly once above; asserting
+                // `Some(true)` for every key was only ever satisfiable because
+                // the field was hardcoded.
+                .all(|(_, transferred)| transferred.is_some())));
     let transfer_callback_hits =
         std::cell::RefCell::new(Vec::<(MatrixRaftRouteKey, MatrixRaftAsyncOperation)>::new());
     let transfer_callbacks = server
@@ -16016,7 +16062,9 @@ fn matrixraft_multi_raft_server_controls_leadership_by_group() {
             && summary
                 .transfer_leader_transferred_by_route_key()
                 .iter()
-                .all(|(_, transferred)| *transferred == Some(true))
+                // As above: the summary must report a value per route key. The
+                // value itself is pinned exactly once, earlier in this test.
+                .all(|(_, transferred)| transferred.is_some())
             && summary
                 .timeout_now_presence_by_route_key()
                 .iter()


### PR DESCRIPTION
`matrixraft_baseline_raft_operational_evidence_bundle` takes six parameters describing the caller's runtime, and all six feed only three of its five artifacts. `read_safety` and `membership` take no inputs, so they cannot describe anyone's cluster — yet the validation report graded all five identically and said nothing about the difference.

The bundle now says which artifacts are derived from the caller's runtime and which are built-in, fixed content, so a validation report cannot present canned material as evidence about a live cluster.
