### PR TITLE
Shrink the WAL record: base64 payloads, and stop writing two always-default fields

### DIFF
--- a/examples/wal_record_anatomy.rs
+++ b/examples/wal_record_anatomy.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Anatomy probe: shows where the bytes in one WAL record go.
+//!
+//! `wal_amplification` reports that a 64-byte proposal costs ~598 WAL bytes.
+//! This says which fields those bytes are, so an optimisation targets the part
+//! that is actually large rather than the part that is easiest to see.
+
+use matrixraft::{Config, Peer, RaftCluster, ReplicaRole};
+use serde_json::Value;
+
+fn peer(node_id: u64, role: ReplicaRole) -> Peer {
+    Peer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role,
+        auto_promote: false,
+    }
+}
+
+fn field_sizes(label: &str, json: &str) {
+    let value: Value = serde_json::from_str(json).expect("record is json");
+    println!("{label}: {} bytes total", json.len());
+    let Value::Object(map) = &value else {
+        return;
+    };
+    let mut rows: Vec<(String, usize)> = map
+        .iter()
+        .map(|(key, field)| {
+            // key + quotes + colon + comma, plus the encoded value
+            let encoded = serde_json::to_string(field).expect("field encodes");
+            (key.clone(), key.len() + 4 + encoded.len())
+        })
+        .collect();
+    rows.sort_by_key(|(_, size)| std::cmp::Reverse(*size));
+    for (key, size) in rows {
+        let share = size as f64 * 100.0 / json.len() as f64;
+        println!("    {size:>6} B  {share:>5.1}%  {key}");
+    }
+    println!();
+}
+
+fn record_json(payload_bytes: usize, byte_value: u8) -> String {
+    let mut cluster = RaftCluster::new(
+        7,
+        Config::default(),
+        vec![
+            peer(1, ReplicaRole::Voter),
+            peer(2, ReplicaRole::Voter),
+            peer(3, ReplicaRole::Voter),
+        ],
+    )
+    .expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+    cluster
+        .propose(vec![byte_value; payload_bytes])
+        .expect("propose");
+    let record = cluster.wal_record_for(1).expect("wal record");
+    serde_json::to_string(&record).expect("record encodes")
+}
+
+/// How often each top-level field actually changes from one record to the next.
+///
+/// A field that almost never changes is a candidate for the delta treatment
+/// `entries` already gets: write it on the first record of a segment and omit
+/// it afterwards while it is unchanged. A field that changes every time is not,
+/// however large it looks in the anatomy above.
+fn field_volatility(proposals: usize, payload_bytes: usize) {
+    let mut cluster = RaftCluster::new(
+        7,
+        Config::default(),
+        vec![
+            peer(1, ReplicaRole::Voter),
+            peer(2, ReplicaRole::Voter),
+            peer(3, ReplicaRole::Voter),
+        ],
+    )
+    .expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+
+    let mut previous: Option<serde_json::Map<String, Value>> = None;
+    let mut changes: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut sizes: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut compared = 0usize;
+
+    for _ in 0..proposals {
+        cluster
+            .propose(vec![200u8; payload_bytes])
+            .expect("propose");
+        let record = cluster.wal_record_for(1).expect("wal record");
+        let value = serde_json::to_value(&record).expect("record to value");
+        let Value::Object(map) = value else { continue };
+        for (key, field) in &map {
+            let encoded = serde_json::to_string(field).expect("field encodes");
+            sizes.insert(key.clone(), key.len() + 4 + encoded.len());
+        }
+        if let Some(prev) = &previous {
+            compared += 1;
+            for (key, field) in &map {
+                if prev.get(key) != Some(field) {
+                    *changes.entry(key.clone()).or_default() += 1;
+                }
+            }
+        }
+        previous = Some(map);
+    }
+
+    // `entries` here is the whole retained log, because `wal_record_for` builds
+    // a full record. The WAL's own append path writes a delta instead, so treat
+    // the `entries` row below as "changes every record", not as its real size.
+    println!("field volatility over {compared} consecutive records (payload {payload_bytes} B)");
+    let mut rows: Vec<(String, usize, usize)> = sizes
+        .into_iter()
+        .map(|(key, size)| {
+            let changed = changes.get(&key).copied().unwrap_or(0);
+            (key, size, changed)
+        })
+        .collect();
+    rows.sort_by_key(|(_, size, _)| std::cmp::Reverse(*size));
+    println!(
+        "    {:>7}  {:>9}  {:>10}  field",
+        "bytes", "changed", "rate"
+    );
+    let mut stable_bytes = 0usize;
+    for (key, size, changed) in rows {
+        let rate = changed as f64 * 100.0 / compared.max(1) as f64;
+        if changed == 0 {
+            stable_bytes += size;
+        }
+        println!("    {size:>7}  {changed:>9}  {rate:>9.1}%  {key}");
+    }
+    println!("    -> {stable_bytes} B per record never changed and could be omitted\n");
+}
+
+fn main() {
+    // Byte value matters: serde_json writes each byte as a decimal number, so a
+    // payload of 7s costs two characters per byte and a payload of 200s costs
+    // four. Raw bytes are uniform in practice, so the high case is the honest
+    // one to design against.
+    for (label, payload_bytes, byte_value) in [
+        ("empty payload", 0usize, 0u8),
+        ("64 B payload of 0x07", 64, 7),
+        ("64 B payload of 0xC8", 64, 200),
+        ("4096 B payload of 0xC8", 4096, 200),
+    ] {
+        let json = record_json(payload_bytes, byte_value);
+        field_sizes(label, &json);
+        if payload_bytes > 0 {
+            let ratio = json.len() as f64 / payload_bytes as f64;
+            println!("    -> {ratio:.1}x amplification for this record\n");
+        }
+    }
+
+    // Size alone does not say what is worth compressing. A big field that
+    // changes every record has to be written every record.
+    field_volatility(200, 64);
+}

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -69,22 +69,35 @@ pub struct WalCompactionReport {
     pub blocker: Option<String>,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WalRecord {
     pub group_id: GroupId,
     pub node_id: NodeId,
     pub hard_state: HardState,
     pub membership: Membership,
-    #[serde(default)]
+    #[serde(
+        default,
+        with = "wal_entry_payloads",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub entries: Vec<LogEntry>,
     /// When true, `entries` carries only what was appended since the previous
     /// record in the same segment rather than the whole retained log. The first
     /// record of every segment is always a full one, so a segment can be read
     /// without reading any other -- which is what lets whole-segment compaction
     /// stay as simple as it was.
-    #[serde(default)]
+    // Both of these already carry `#[serde(default)]`, so omitting them when
+    // they hold that default is invisible to any reader, old or new -- no
+    // format version and no delta bookkeeping. Measured over 199 consecutive
+    // records, neither ever changed from its default, so this is 52 bytes off
+    // every record for nothing.
+    #[serde(default, skip_serializing_if = "is_false")]
     pub entries_are_delta: bool,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installed_snapshot: Option<SnapshotMetadata>,
     pub apply_snapshot_fence: ApplySnapshotFence,
     pub checksum: String,
@@ -472,5 +485,255 @@ pub fn matrixraft_validate_wal_lifecycle_evidence_artifact(
         slow_fsync_backpressure_observed,
         compaction_after_slow_fsync_observed,
         missing,
+    }
+}
+
+/// On-disk encoding for WAL entry payloads.
+///
+/// `serde_json` writes a `Vec<u8>` as an array of decimal numbers, so a byte
+/// costs up to four characters on disk (`200,`). Payload dominates a WAL record
+/// once it is more than a few dozen bytes -- 97.7% of a record carrying a 4 KiB
+/// payload -- so that encoding sets the write amplification almost by itself.
+/// Base64 costs 1.33 characters per byte instead of 4.
+///
+/// Reading accepts both forms. Records written before this change carry numeric
+/// arrays, and they must still recover, so the deserializer takes either a
+/// base64 string or the legacy array. Only writing changed.
+///
+/// This is deliberately local to the WAL record rather than applied to
+/// `GenericLogEntry` itself: the same type is serialized for RPC and for the
+/// JSON debug surfaces, where an array of numbers is the readable form and
+/// nothing is paying for it by the megabyte.
+pub(crate) mod wal_entry_payloads {
+    use serde::de::{Deserializer, Error as DeError};
+    use serde::ser::{SerializeSeq, Serializer};
+    use serde::Deserialize;
+
+    use crate::{LogEntry, LogId};
+
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    pub(crate) fn encode(input: &[u8]) -> String {
+        let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+        for chunk in input.chunks(3) {
+            let b0 = chunk[0] as u32;
+            let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+            let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+            let triple = (b0 << 16) | (b1 << 8) | b2;
+            out.push(ALPHABET[((triple >> 18) & 63) as usize] as char);
+            out.push(ALPHABET[((triple >> 12) & 63) as usize] as char);
+            out.push(if chunk.len() > 1 {
+                ALPHABET[((triple >> 6) & 63) as usize] as char
+            } else {
+                '='
+            });
+            out.push(if chunk.len() > 2 {
+                ALPHABET[(triple & 63) as usize] as char
+            } else {
+                '='
+            });
+        }
+        out
+    }
+
+    fn sextet(byte: u8) -> Option<u32> {
+        match byte {
+            b'A'..=b'Z' => Some((byte - b'A') as u32),
+            b'a'..=b'z' => Some((byte - b'a') as u32 + 26),
+            b'0'..=b'9' => Some((byte - b'0') as u32 + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn decode(input: &str) -> Result<Vec<u8>, String> {
+        let bytes = input.as_bytes();
+        if bytes.len() % 4 != 0 {
+            return Err(format!(
+                "base64 length {} is not a multiple of four",
+                bytes.len()
+            ));
+        }
+        let chunk_count = bytes.len() / 4;
+        let mut out = Vec::with_capacity(chunk_count * 3);
+        for (chunk_index, chunk) in bytes.chunks(4).enumerate() {
+            let is_last = chunk_index + 1 == chunk_count;
+            let mut triple = 0u32;
+            let mut padding = 0usize;
+            for &byte in chunk {
+                if byte == b'=' {
+                    if !is_last {
+                        return Err("base64 padding before the final quad".to_string());
+                    }
+                    padding += 1;
+                    triple <<= 6;
+                    continue;
+                }
+                if padding > 0 {
+                    return Err("base64 padding inside a quad".to_string());
+                }
+                let value =
+                    sextet(byte).ok_or_else(|| format!("invalid base64 byte {byte:#04x}"))?;
+                triple = (triple << 6) | value;
+            }
+            if padding > 2 {
+                return Err("base64 quad is entirely padding".to_string());
+            }
+            out.push((triple >> 16) as u8);
+            if padding < 2 {
+                out.push((triple >> 8) as u8);
+            }
+            if padding < 1 {
+                out.push(triple as u8);
+            }
+        }
+        Ok(out)
+    }
+
+    /// One entry as written: `payload` is base64 rather than a number array.
+    #[derive(serde::Serialize)]
+    struct EntryOut<'a> {
+        log_id: &'a LogId,
+        payload: String,
+        is_command: bool,
+    }
+
+    /// One entry as read. `payload` takes either encoding so that WAL segments
+    /// written before this change still recover.
+    #[derive(Deserialize)]
+    struct EntryIn {
+        log_id: LogId,
+        #[serde(default)]
+        payload: PayloadIn,
+        #[serde(default)]
+        is_command: bool,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum PayloadIn {
+        /// Current form.
+        Base64(String),
+        /// The form `serde_json` produces for a `Vec<u8>`, written by earlier
+        /// versions.
+        Legacy(Vec<u8>),
+    }
+
+    impl Default for PayloadIn {
+        fn default() -> Self {
+            Self::Legacy(Vec::new())
+        }
+    }
+
+    pub(crate) fn serialize<S>(entries: &[LogEntry], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(entries.len()))?;
+        for entry in entries {
+            seq.serialize_element(&EntryOut {
+                log_id: &entry.log_id,
+                payload: encode(&entry.payload),
+                is_command: entry.is_command,
+            })?;
+        }
+        seq.end()
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<LogEntry>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = Vec::<EntryIn>::deserialize(deserializer)?;
+        raw.into_iter()
+            .map(|entry| {
+                let payload = match entry.payload {
+                    PayloadIn::Base64(text) => decode(&text).map_err(DeError::custom)?,
+                    PayloadIn::Legacy(bytes) => bytes,
+                };
+                Ok(LogEntry {
+                    log_id: entry.log_id,
+                    payload,
+                    is_command: entry.is_command,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod wal_entry_payload_codec_tests {
+    use super::wal_entry_payloads::{decode, encode};
+
+    /// RFC 4648 section 10 test vectors. Hand-rolled base64 is easy to get
+    /// subtly wrong in the padded cases, which are exactly the short payloads a
+    /// Raft log is full of.
+    #[test]
+    fn matches_the_rfc4648_vectors() {
+        for (plain, encoded) in [
+            ("", ""),
+            ("f", "Zg=="),
+            ("fo", "Zm8="),
+            ("foo", "Zm9v"),
+            ("foob", "Zm9vYg=="),
+            ("fooba", "Zm9vYmE="),
+            ("foobar", "Zm9vYmFy"),
+        ] {
+            assert_eq!(encode(plain.as_bytes()), encoded, "encoding {plain:?}");
+            assert_eq!(
+                decode(encoded).expect("decodes"),
+                plain.as_bytes(),
+                "decoding {encoded:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_every_length_and_every_byte_value() {
+        // Lengths through several multiples of three cover all three padding
+        // cases repeatedly; the byte pattern walks the whole 0..=255 range so
+        // the sextet table is exercised end to end.
+        for len in 0..=64usize {
+            let payload: Vec<u8> = (0..len).map(|i| (i * 7 % 256) as u8).collect();
+            let encoded = encode(&payload);
+            assert_eq!(encoded.len() % 4, 0, "length {len} is not padded to a quad");
+            assert_eq!(decode(&encoded).expect("decodes"), payload, "length {len}");
+        }
+        let all_bytes: Vec<u8> = (0..=255u8).collect();
+        assert_eq!(decode(&encode(&all_bytes)).expect("decodes"), all_bytes);
+    }
+
+    #[test]
+    fn rejects_malformed_input_rather_than_guessing() {
+        // A truncated quad, a character outside the alphabet, and padding in
+        // the wrong place all mean the segment is damaged. Recovery treats a
+        // decode failure as a corrupt tail, so these must be errors and not
+        // silently short reads.
+        assert!(decode("Zm9").is_err(), "length not a multiple of four");
+        assert!(decode("Zm9*").is_err(), "character outside the alphabet");
+        assert!(decode("Zg==Zg==").is_err(), "padding before the final quad");
+        assert!(decode("Z=g=").is_err(), "padding inside a quad");
+        assert!(decode("====").is_err(), "quad that is entirely padding");
+    }
+
+    #[test]
+    fn costs_a_third_of_what_a_number_array_costs() {
+        // The reason this module exists. `serde_json` writes a byte >= 100 as
+        // four characters ("200,"); base64 writes three bytes as four.
+        let payload = vec![200u8; 4096];
+        let as_numbers = serde_json::to_string(&payload).expect("array encodes");
+        let as_base64 = serde_json::to_string(&encode(&payload)).expect("string encodes");
+        // The ratio is 4 chars/byte against 4 chars per 3 bytes, so very close
+        // to 3x -- close enough that asserting exactly 3x fails on the quotes
+        // and brackets. Assert the conservative half, and report the real
+        // figure so a regression shows the number rather than just a boolean.
+        assert!(
+            as_base64.len() * 2 < as_numbers.len(),
+            "expected base64 ({}) to be well under half the array form ({}), ratio {:.2}x",
+            as_base64.len(),
+            as_numbers.len(),
+            as_numbers.len() as f64 / as_base64.len() as f64
+        );
     }
 }

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -523,3 +523,107 @@ fn a_tail_rewritten_at_the_same_index_is_stored_whole() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+/// Build a real WAL record carrying `payload`, then rewrite its entry payloads
+/// back into the JSON number array that earlier versions wrote.
+///
+/// Derived from a live record rather than hand-written so it cannot drift from
+/// the struct shape -- only the payload encoding is turned back to the old form.
+fn legacy_wal_record_json(payload: &[u8]) -> (matrixraft::WalRecord, String) {
+    fn peer(node_id: u64) -> matrixraft::Peer {
+        matrixraft::Peer {
+            node_id,
+            raft_addr: format!("127.0.0.1:{}", 9_400 + node_id),
+            snapshot_addr: format!("127.0.0.1:{}", 9_500 + node_id),
+            role: matrixraft::ReplicaRole::Voter,
+            auto_promote: false,
+        }
+    }
+    let mut cluster = matrixraft::RaftCluster::new(
+        7,
+        matrixraft::Config::default(),
+        vec![peer(1), peer(2), peer(3)],
+    )
+    .expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+    cluster.propose(payload.to_vec()).expect("propose");
+    let record = cluster.wal_record_for(1).expect("wal record");
+
+    let mut value = serde_json::to_value(&record).expect("record to value");
+    for entry in value["entries"]
+        .as_array_mut()
+        .expect("entries is an array")
+        .iter_mut()
+    {
+        // Whatever this entry's payload is, write it the old way.
+        let bytes = record
+            .entries
+            .iter()
+            .find(|candidate| candidate.log_id.index == entry["log_id"]["index"].as_u64().unwrap())
+            .map(|candidate| candidate.payload.clone())
+            .expect("entry present in the typed record");
+        entry["payload"] =
+            serde_json::Value::Array(bytes.into_iter().map(serde_json::Value::from).collect());
+    }
+    (record, serde_json::to_string(&value).expect("legacy json"))
+}
+
+#[test]
+fn wal_records_written_before_base64_payloads_still_recover() {
+    // Segments in the old encoding exist on disk in deployments, so the reader
+    // has to keep taking them even though nothing writes them any more.
+    let (original, legacy_json) = legacy_wal_record_json(b"foobar");
+    assert!(
+        legacy_json.contains(r#""payload":[102,111,111,98,97,114]"#),
+        "fixture should be in the old number-array form: {legacy_json}"
+    );
+
+    let parsed: matrixraft::WalRecord =
+        serde_json::from_str(&legacy_json).expect("legacy WAL record still parses");
+    assert_eq!(
+        parsed, original,
+        "legacy decoding must reproduce the record"
+    );
+
+    // Re-encoding uses the compact form and round-trips, so a segment rewritten
+    // by compaction keeps its contents.
+    let reencoded = serde_json::to_string(&original).expect("record encodes");
+    assert!(
+        reencoded.contains(r#""payload":"Zm9vYmFy""#),
+        "expected a base64 payload, got: {reencoded}"
+    );
+    let reparsed: matrixraft::WalRecord =
+        serde_json::from_str(&reencoded).expect("re-encoded record parses");
+    assert_eq!(reparsed, original);
+}
+
+#[test]
+fn wal_payload_encoding_shrinks_a_realistic_record() {
+    // Guards the win, not the mechanism. A uniform 4 KiB payload is the case
+    // where `serde_json`'s number array costs four characters a byte, and it is
+    // ~98% of the record, so it sets the amplification on its own.
+    let (record, legacy_json) = legacy_wal_record_json(&vec![200u8; 4096]);
+    let encoded = serde_json::to_string(&record).expect("record encodes");
+
+    assert!(
+        legacy_json.len() > 16_000,
+        "expected the old form to cost over 16000 bytes, got {}",
+        legacy_json.len()
+    );
+    assert!(
+        encoded.len() < 6_500,
+        "expected a 4 KiB payload to cost under 6500 WAL bytes, got {}",
+        encoded.len()
+    );
+
+    // The shared entry type is untouched: RPC and the JSON debug surfaces still
+    // see a number array, which is the readable form there and is not paid for
+    // by the megabyte.
+    let bare_entries = serde_json::to_string(&record.entries).expect("bare entries encode");
+    assert!(
+        bare_entries.len() > 16_000,
+        "expected the shared entry encoding to be unchanged, got {}",
+        bare_entries.len()
+    );
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#29`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of #27 and #28 — no file overlap, mergeable in any order.

Two changes that shrink the WAL record, both measured before being made.

## 1. Payloads are base64, not a number array

`serde_json` encodes a `Vec<u8>` as an array of decimal numbers, so one payload byte costs up to four characters on disk — `200,`. The WAL is JSON lines, so that encoding set the write amplification almost by itself.

`examples/wal_record_anatomy` is added here; it reports where the bytes in one record actually go, so the change targets the part that is large rather than the part that is easy to see.

| | before | after |
| --- | --- | --- |
| 4 KiB record | 16,928 B (**4.1×**) | 5,999 B (**1.5×**) |

For a 4 KiB payload the `entries` field was **97.7%** of the record. Base64 costs 1.33 characters per byte instead of 4, so the record is **2.8× smaller**.

Also: **record size no longer depends on payload content.** A byte below 10 cost two characters and one above 99 cost four, so an identical proposal cost 672 B or 800 B depending on the *data*. It is 623 B either way now.

**Old segments still recover.** The deserializer takes either a base64 string or the legacy number array; only writing changed. A test builds a real record, rewrites its payloads back into the old form, and checks it parses to the identical record. The checksum covers `entries.payload_len` rather than the encoded bytes, so it is unaffected.

The codec is on the WAL record's `entries` field, **not** on `GenericLogEntry`. That type is also serialized for RPC and the JSON debug surfaces, where a number array is the readable form and nothing is paying by the megabyte; a test asserts that encoding is unchanged.

Base64 is implemented here rather than added as a dependency — the crate has three, and this is a well-specified transform. Tested against the **RFC 4648 vectors**, round-tripped over every length 0–64 and all 256 byte values, and checked to reject truncated quads, out-of-alphabet characters and misplaced padding: a decode failure is how recovery detects a corrupt tail, so it must not silently short-read.

## 2. Two fields that never leave their default are no longer written

`installed_snapshot` and `entries_are_delta` already carry `#[serde(default)]`, so omitting them when they hold that default is invisible to any reader, old or new. No format version, no delta bookkeeping, 52 bytes off every record.

Which fields those are is measured, not guessed. The anatomy probe now also reports **how often each field changes between consecutive records**, because size alone does not say what is worth compressing — a large field that changes every record still has to be written every record. Over 199 records:

| field | bytes | changes |
| --- | --- | --- |
| `apply_snapshot_fence` | 122 | **every record** |
| `hard_state` | 81 | **every record** |
| `membership` | 84 | never |
| `entries_are_delta` | 26 | never |
| `installed_snapshot` | 26 | never |
| `group_id` | 13 | never |
| `node_id` | 12 | never |

That corrected an assumption I would otherwise have shipped: `apply_snapshot_fence` is the second-largest field and looks static, but its indices advance with every proposal, so it is not a candidate for omission at all.

## What is deliberately left

The other three stable fields — `membership`, `group_id`, `node_id`, **109 B between them** — would need the delta treatment `entries` already gets, where the first record of a segment is full and later ones omit what has not changed. That is a real format change with recovery consequences, so it is written down rather than bundled in here.

Small payloads are still dominated by a metadata floor: the 64 B case improves only 598 → 532 B/proposal, and I am not claiming the 2.8× figure applies there.

## Net

| payload | before | after |
| --- | --- | --- |
| 64 B | 598 B/proposal | 532 B/proposal |
| 4 KiB | ~16.9 KB/record | 5,909 B/proposal |

530 tests pass, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is disabled by the Actions billing failure, so its checks are not evidence.

