### PR TITLE
Recompute the commit index and lease quorum once per proposal, not once per peer

### DIFF
--- a/examples/op_node_scaling.rs
+++ b/examples/op_node_scaling.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scaling probe across operations, not just proposals.
+//!
+//! `propose_node_scaling` found that a proposal recomputed two group-wide
+//! aggregates once per peer, making it O(N^2) in group size. That shape is not
+//! specific to proposing: any operation that loops over peers and recomputes
+//! something group-wide inside the loop has it. This times several operations
+//! against group size so the same signature shows up if it is there.
+//!
+//! Read the growth column. An operation that touches every peer should grow
+//! about linearly with the group; markedly faster than linear is worth reading
+//! the code for.
+
+use std::time::Instant;
+
+use matrixraft::{Config, Peer, RaftCluster, ReplicaRole};
+
+fn peer(node_id: u64) -> Peer {
+    Peer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role: ReplicaRole::Voter,
+        auto_promote: false,
+    }
+}
+
+fn cluster_of(nodes: u64) -> RaftCluster {
+    let peers: Vec<Peer> = (1..=nodes).map(peer).collect();
+    let mut cluster = RaftCluster::new(7, Config::default(), peers).expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+    cluster
+}
+
+fn time_op(nodes: u64, iterations: usize, op: &str) -> f64 {
+    let mut cluster = cluster_of(nodes);
+    // Give every operation a log to work against.
+    for _ in 0..200 {
+        cluster.propose(vec![7u8; 64]).expect("seed propose");
+    }
+    let started = Instant::now();
+    for i in 0..iterations {
+        match op {
+            "tick" => {
+                let _ = cluster.tick_peer_liveness(1);
+            }
+            "status" => {
+                let _ = cluster.status(1);
+            }
+            "membership" => {
+                let _ = cluster.membership();
+            }
+            "heartbeat" => {
+                let _ = cluster.tick_leader_lease(1);
+            }
+            "propose" => {
+                cluster.propose(vec![7u8; 64]).expect("propose");
+            }
+            other => panic!("unknown op {other}"),
+        }
+        std::hint::black_box(i);
+    }
+    started.elapsed().as_secs_f64()
+}
+
+fn main() {
+    let iterations: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(4000);
+    println!("iterations={iterations}");
+    for op in ["propose", "tick", "heartbeat", "status", "membership"] {
+        println!("\n--- {op}");
+        println!(
+            "{:>6}  {:>10}  {:>12}  {:>10}",
+            "nodes", "seconds", "us/op", "vs 1 node"
+        );
+        let mut baseline: Option<f64> = None;
+        for nodes in [1_u64, 3, 5, 7, 9] {
+            let seconds = time_op(nodes, iterations, op);
+            let us = seconds * 1e6 / iterations as f64;
+            let ratio = baseline.map(|base| seconds / base).unwrap_or(1.0);
+            println!("{nodes:>6}  {seconds:>10.4}  {us:>12.3}  {ratio:>9.2}x");
+            baseline.get_or_insert(seconds);
+        }
+    }
+}

--- a/examples/propose_node_scaling.rs
+++ b/examples/propose_node_scaling.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scaling probe: how does the cost of one proposal grow with the number of
+//! nodes in the group?
+//!
+//! `propose_scaling` shows the per-propose cost is flat in *log length*. This
+//! asks the other question. `RaftCluster` models every node in one object, so a
+//! proposal appends the entry to each node's log -- if the payload is copied
+//! per node, the cost per proposal grows with the group size, and the growth
+//! shows up only at large payloads where the copy dominates the bookkeeping.
+//!
+//! Read the `us/entry-byte` column: if it is flat across group sizes the
+//! payload is not being copied per node, and if it rises with the group the
+//! copies are real.
+
+use std::time::Instant;
+
+use matrixraft::{Config, Peer, RaftCluster, ReplicaRole};
+
+fn peer(node_id: u64) -> Peer {
+    Peer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role: ReplicaRole::Voter,
+        auto_promote: false,
+    }
+}
+
+fn run(nodes: u64, entries: usize, payload_bytes: usize) -> f64 {
+    let peers: Vec<Peer> = (1..=nodes).map(peer).collect();
+    let mut cluster = RaftCluster::new(7, Config::default(), peers).expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+
+    let payload = vec![200_u8; payload_bytes];
+    let started = Instant::now();
+    for _ in 0..entries {
+        cluster.propose(payload.clone()).expect("propose");
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    assert!(cluster.leader_id().is_some());
+    elapsed
+}
+
+fn main() {
+    let payload_bytes: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(4096);
+    let entries: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(4000);
+    println!("payload_bytes={payload_bytes}  entries={entries}");
+    println!(
+        "{:>6}  {:>10}  {:>12}  {:>14}  {:>8}",
+        "nodes", "seconds", "us/propose", "ns/entry-byte", "vs 1 node"
+    );
+    let mut baseline: Option<f64> = None;
+    for nodes in [1_u64, 3, 5, 7, 9] {
+        // Odd sizes only: an even voter count changes the quorum arithmetic and
+        // would confound the copy signal with a different commit path.
+        let seconds = run(nodes, entries, payload_bytes);
+        let us = seconds * 1e6 / entries as f64;
+        let ns_per_byte = seconds * 1e9 / (entries as f64 * payload_bytes as f64);
+        let ratio = baseline.map(|base| seconds / base).unwrap_or(1.0);
+        println!("{nodes:>6}  {seconds:>10.4}  {us:>12.2}  {ns_per_byte:>14.2}  {ratio:>8.2}x");
+        baseline.get_or_insert(seconds);
+    }
+}

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -844,6 +844,24 @@ impl RaftCluster {
         confirmation_epoch: u64,
         duration_ms: u64,
     ) -> bool {
+        self.receive_leader_lease_confirmation_inner(node_id, confirmation_epoch, duration_ms, true)
+    }
+
+    /// `recompute_quorum` lets a caller recording a whole round of
+    /// confirmations evaluate the lease quorum once at the end rather than
+    /// after each one.
+    ///
+    /// `leader_lease_quorum_reached` walks every confirmation and looks up its
+    /// node, so recomputing per confirmation makes a round of N cost O(N^2).
+    /// The result depends only on the final set, so the intermediate passes
+    /// cannot change it.
+    fn receive_leader_lease_confirmation_inner(
+        &mut self,
+        node_id: NodeId,
+        confirmation_epoch: u64,
+        duration_ms: u64,
+        recompute_quorum: bool,
+    ) -> bool {
         if self.leader_id == Some(node_id) {
             return false;
         }
@@ -877,7 +895,9 @@ impl RaftCluster {
                 && existing_remaining_ms >= duration_ms
             {
                 existing.confirmation_epoch = confirmation_epoch;
-                self.leader_lease_valid = self.leader_lease_quorum_reached();
+                if recompute_quorum {
+                    self.leader_lease_valid = self.leader_lease_quorum_reached();
+                }
                 return true;
             }
         }
@@ -893,18 +913,29 @@ impl RaftCluster {
                 elapsed_ms: 0,
             },
         );
-        self.leader_lease_valid = self.leader_lease_quorum_reached();
+        if recompute_quorum {
+            self.leader_lease_valid = self.leader_lease_quorum_reached();
+        }
         true
     }
 
-    fn record_leader_lease_confirmation(&mut self, node_id: NodeId) {
+    /// Record a self-generated confirmation for `node_id`.
+    ///
+    /// `recompute_quorum` is false when the caller records a round of these and
+    /// evaluates the quorum once afterwards.
+    fn record_leader_lease_confirmation_inner(&mut self, node_id: NodeId, recompute_quorum: bool) {
         let confirmation_epoch = self
             .leader_lease_confirmation_epochs
             .get(&node_id)
             .copied()
             .unwrap_or_default()
             .saturating_add(1);
-        let _ = self.receive_leader_lease_confirmation(node_id, confirmation_epoch);
+        let _ = self.receive_leader_lease_confirmation_inner(
+            node_id,
+            confirmation_epoch,
+            self.config.leader_lease_ms,
+            recompute_quorum,
+        );
     }
 
     fn renew_leader_lease_from_acknowledgements<I>(&mut self, acknowledgements: I) -> bool
@@ -919,7 +950,10 @@ impl RaftCluster {
         self.leader_lease_elapsed_ms = 0;
         self.leader_lease_confirmations.clear();
         for node_id in acknowledgements {
-            self.record_leader_lease_confirmation(node_id);
+            // Deferred: the quorum is evaluated once below, so evaluating it
+            // per acknowledgement was O(N^2) for a result that only depends on
+            // the final set.
+            self.record_leader_lease_confirmation_inner(node_id, false);
         }
         self.leader_lease_valid = self.leader_lease_quorum_reached();
         self.leader_lease_valid
@@ -2270,6 +2304,27 @@ impl RaftCluster {
         peer_id: NodeId,
         response: AppendEntriesResponse,
     ) -> Result<(), RaftError> {
+        self.handle_append_entries_response_inner(local_node_id, peer_id, response, true)
+    }
+
+    /// `recompute_aggregates` exists so a caller applying a whole round of
+    /// responses can recompute the two group-wide aggregates -- the commit
+    /// index and the leader-lease quorum -- once at the end, instead of once
+    /// per response.
+    ///
+    /// Both walk every node: `refresh_commit_index` collects, sorts and
+    /// re-walks the node set, and `leader_lease_quorum_reached` walks every
+    /// confirmation and looks up its node. Doing either per response makes a
+    /// round of N responses cost O(N^2). Both results depend only on the final
+    /// state, so the intermediate passes cannot change the outcome -- only how
+    /// long it takes to reach it.
+    fn handle_append_entries_response_inner(
+        &mut self,
+        local_node_id: NodeId,
+        peer_id: NodeId,
+        response: AppendEntriesResponse,
+        recompute_aggregates: bool,
+    ) -> Result<(), RaftError> {
         self.nodes
             .get(&local_node_id)
             .ok_or(RaftError::NodeNotFound(local_node_id))?;
@@ -2303,13 +2358,14 @@ impl RaftCluster {
             return Ok(());
         }
         if response.lease_confirmation_epoch > 0 && response.lease_duration_ms > 0 {
-            let _ = self.receive_leader_lease_confirmation_with_duration(
+            let _ = self.receive_leader_lease_confirmation_inner(
                 peer_id,
                 response.lease_confirmation_epoch,
                 response.lease_duration_ms,
+                recompute_aggregates,
             );
         } else if self.config.enable_lease_read {
-            self.record_leader_lease_confirmation(peer_id);
+            self.record_leader_lease_confirmation_inner(peer_id, recompute_aggregates);
         }
         let mut append_response_result = Ok(());
         if let Some(pipeline) = self.peer_pipelines.get_mut(&peer_id) {
@@ -2319,7 +2375,9 @@ impl RaftCluster {
                 self.config.election_timeout_ms.max(1),
             );
             append_response_result = pipeline.handle_append_response(&response);
-            self.refresh_commit_index();
+            if recompute_aggregates {
+                self.refresh_commit_index();
+            }
         }
         if let Some(required_snapshot_index) = response.require_snapshot {
             self.trigger_new_snapshot_if_leader_snapshot_is_stale(
@@ -2584,7 +2642,12 @@ impl RaftCluster {
                 if response.success {
                     lease_acknowledgements.push(node_id);
                 }
-                let _ = self.handle_append_entries_response(leader_id, node_id, response);
+                // Defer the commit-index refresh: this loop applies one response
+                // per node and then refreshes once below, so refreshing inside
+                // each response made a proposal cost O(N^2 log N) in group size.
+                let _ = self.handle_append_entries_response_inner(
+                    leader_id, node_id, response, false,
+                );
             }
         }
         self.refresh_commit_index();


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#30`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of #29 — that one is `src/wal.rs`, this is `src/facade/cluster_runtime.rs`. No overlap, mergeable in either order.

A proposal applies one append response per node in a loop. Two group-wide aggregates were recomputed **inside** that loop, and both walk every node:

- `refresh_commit_index` collects every node's match index, sorts them, picks the quorum index, then re-walks the nodes to advance their commit index.
- `leader_lease_quorum_reached` walks every lease confirmation and looks up the node behind it.

So a round of N responses cost **O(N²)** — and the propose path already recomputed both once more after the loop: `refresh_commit_index()` at the end, and `renew_leader_lease_from_acknowledgements`, which *clears the confirmations and rebuilds them*. The per-response passes could not change the outcome, only how long it took to reach it.

Both now take a flag. The public entry points pass `true` and behave exactly as before; the propose loop and `renew_leader_lease_from_acknowledgements` pass `false` and rely on the pass they already performed.

## Measured

`examples/propose_node_scaling` is added here — 4000 proposals per row:

**8-byte payload (µs/propose)**

| nodes | 1 | 3 | 5 | 7 | 9 | growth 1→9 |
| --- | --- | --- | --- | --- | --- | --- |
| before | 0.40 | 2.83 | 7.60 | 9.52 | 16.78 | **41.9×** |
| after | 0.47 | 1.38 | 2.73 | 3.52 | 5.22 | **11.2×** |

**4 KiB payload (µs/propose)**

| nodes | 1 | 3 | 5 | 7 | 9 | growth 1→9 |
| --- | --- | --- | --- | --- | --- | --- |
| before | 2.63 | 8.64 | 15.93 | 23.38 | 33.20 | 12.6× |
| after | 3.47 | 8.88 | 17.88 | 22.06 | 26.27 | 7.6× |

Three nodes — the ordinary case — is **2× faster** on a small payload, nine is **3.2×**. The change in *shape* matters more than any single figure: growth in group size was superlinear and is now close to linear.

## How the small payload found the cause

I started from the wrong hypothesis. The earlier `propose_scaling` probe showed ~2.4 ns/byte of in-memory cost, far slower than memcpy, so I expected the payload to be copied once per node.

Varying node count refuted that. If per-node *copying* dominated, the large payload would grow faster with group size. It grew **slower** — 12.6× against 41.9× — so the per-node cost was fixed bookkeeping, not bytes. That pointed at work done per response regardless of payload, which is what these two aggregates are.

## On the numbers

These are wall-clock measurements on a contended machine, so treat individual microsecond figures as approximate — the 1-node row moves by more than the change could explain, which is noise. The argument does not rest on timing: the change removes O(N) calls to two O(N) functions per proposal, and the growth-ratio column is the robust signal.

## Checks

524 tests pass, including the 98 in `raft_cluster_engine` that cover the commit rule and the lease quorum — those are the semantics this touches. `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean.

One `persistent_wal` failure appeared on an earlier gate run and did not reproduce, either alone (10/10) or on a re-run of the full suite; it is the load-sensitivity documented on #16, not this change.

Repository CI is disabled by the Actions billing failure, so its checks are not evidence.

