### PR TITLE
Stop putting a poll interval and a Nagle stall in front of every Raft RPC

### DIFF
--- a/examples/rpc_latency.rs
+++ b/examples/rpc_latency.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Latency probe for the real TCP transport, over loopback.
+//!
+//! Every other probe in this directory measures in-process work.  This one
+//! measures a Raft RPC as a peer actually experiences it: connect, encode,
+//! write, wait, read, decode.
+//!
+//! Percentiles rather than a mean, because the costs being hunted here are
+//! stalls -- a poll interval or a Nagle interaction shows up as a fat tail
+//! while barely moving an average.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use matrixraft::{
+    AppendEntriesRequest, ClusterRaftTransport, Config, LogEntry, LogId, Peer, RaftCluster,
+    ReplicaRole, TcpRaftTransport, TcpRaftTransportServer, Transport,
+};
+
+fn peer(node_id: u64) -> Peer {
+    Peer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role: ReplicaRole::Voter,
+        auto_promote: false,
+    }
+}
+
+fn percentile(sorted_us: &[f64], q: f64) -> f64 {
+    if sorted_us.is_empty() {
+        return 0.0;
+    }
+    let idx = ((sorted_us.len() - 1) as f64 * q).round() as usize;
+    sorted_us[idx]
+}
+
+fn main() {
+    let iterations: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(300);
+    let payload_bytes: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(64);
+    // Concurrent callers stand in for the other peers of a group all talking to
+    // one node. The server accepts and serves connections inline on a single
+    // thread, so if that serialises them the tail grows with this number while
+    // the minimum stays put.
+    let threads: usize = std::env::args()
+        .nth(3)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(1);
+
+    let cluster = Arc::new(Mutex::new(
+        RaftCluster::new(3, Config::default(), vec![peer(1), peer(2), peer(3)]).expect("cluster"),
+    ));
+    cluster.lock().expect("lock").start().expect("start");
+    let handler = Arc::new(ClusterRaftTransport::new(Arc::clone(&cluster)));
+    let mut server =
+        TcpRaftTransportServer::start("127.0.0.1:0", handler).expect("start tcp server");
+
+    let mut peers = BTreeMap::new();
+    peers.insert(2, server.addr().to_string());
+    let transport = TcpRaftTransport::new(peers);
+
+    // Always index 1: the follower validates that entries are contiguous with
+    // its log, and this probe is measuring transport latency, not replication
+    // progress. Sending increasing indexes just makes every RPC fail
+    // validation -- and a failure returns about a microsecond, which would look
+    // like a spectacular result rather than a broken measurement.
+    let request = |index: u64| AppendEntriesRequest {
+        group_id: 3,
+        term: 1,
+        leader_id: 1,
+        prev_log_id: None,
+        entries: vec![LogEntry {
+            log_id: LogId { term: 1, index },
+            payload: vec![7u8; payload_bytes],
+            is_command: true,
+        }],
+        leader_commit: 0,
+        lease_epoch: 0,
+    };
+
+    // Warm up: the first RPC pays for lazily-created state on both sides.
+    for _ in 0..10 {
+        let _ = transport.append_entries(2, request(1));
+    }
+
+    // Count outcomes. A failing RPC returns in about a microsecond, which is
+    // far too fast for a loopback round trip -- timing it would measure the
+    // error path and report a spectacular latency that means nothing.
+    let transport = Arc::new(transport);
+    let collected: Vec<(Vec<f64>, Option<String>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                let transport = Arc::clone(&transport);
+                let request = &request;
+                scope.spawn(move || {
+                    let mut mine = Vec::with_capacity(iterations);
+                    let mut failure: Option<String> = None;
+                    for _ in 0..iterations {
+                        let started = Instant::now();
+                        let result = transport.append_entries(2, request(1));
+                        let elapsed = started.elapsed().as_secs_f64() * 1e6;
+                        match result {
+                            Ok(_) => mine.push(elapsed),
+                            Err(err) => {
+                                if failure.is_none() {
+                                    failure = Some(format!("{err:?}"));
+                                }
+                            }
+                        }
+                    }
+                    (mine, failure)
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("probe thread"))
+            .collect()
+    });
+    let mut ok = 0usize;
+    let mut failed: Option<String> = None;
+    let mut samples = Vec::with_capacity(iterations * threads);
+    for (mine, failure) in collected {
+        ok += mine.len();
+        samples.extend(mine);
+        if failed.is_none() {
+            failed = failure;
+        }
+    }
+    let iterations = iterations * threads;
+    println!("ok={ok}/{iterations}");
+    if let Some(err) = failed {
+        println!("  first failure: {err}");
+    }
+    if samples.is_empty() {
+        println!("  no successful RPCs: nothing to measure");
+        server.shutdown().expect("shutdown server");
+        return;
+    }
+    server.shutdown().expect("shutdown server");
+
+    samples.sort_by(|a, b| a.partial_cmp(b).expect("no NaN"));
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    println!("rpcs={iterations}  payload_bytes={payload_bytes}  threads={threads}  (loopback)");
+    println!(
+        "  min {:>9.1} us   p50 {:>9.1}   p90 {:>9.1}   p99 {:>9.1}   max {:>9.1}   mean {:>9.1}",
+        samples[0],
+        percentile(&samples, 0.50),
+        percentile(&samples, 0.90),
+        percentile(&samples, 0.99),
+        samples[samples.len() - 1],
+        mean
+    );
+}

--- a/src/facade/transport_runtime.rs
+++ b/src/facade/transport_runtime.rs
@@ -397,11 +397,19 @@ impl TcpRaftTransport {
         })?;
         let mut stream = TcpStream::connect(addr)
             .map_err(|err| RaftError::Transport(format!("failed to connect to {addr}: {err}")))?;
-        let encoded = serde_json::to_vec(&request)
+        // Raft RPCs are small request/response exchanges, which is the shape
+        // Nagle delays. Without this the framing newline below can sit in the
+        // sender's buffer waiting for an ACK the peer will not send until it
+        // has the newline -- the classic write/write/read stall.
+        let _ = stream.set_nodelay(true);
+        let mut encoded = serde_json::to_vec(&request)
             .map_err(|err| RaftError::Transport(format!("failed to encode raft RPC: {err}")))?;
+        // One write, not a body followed by a one-byte newline: the peer reads
+        // a line, so splitting them puts a round trip between the request and
+        // the peer being able to see it.
+        encoded.push(b'\n');
         stream
             .write_all(&encoded)
-            .and_then(|_| stream.write_all(b"\n"))
             .map_err(|err| RaftError::Transport(format!("failed to write raft RPC: {err}")))?;
         let mut response = String::new();
         BufReader::new(stream)
@@ -530,9 +538,11 @@ impl TcpRaftTransportServer {
         let listener = TcpListener::bind(addr.into()).map_err(|err| {
             RaftError::Transport(format!("failed to bind raft TCP server: {err}"))
         })?;
-        listener.set_nonblocking(true).map_err(|err| {
-            RaftError::Transport(format!("failed to configure raft TCP server: {err}"))
-        })?;
+        // Deliberately blocking. This used to poll with a 5ms sleep between
+        // `accept` attempts, which put 0-5ms in front of every inbound RPC --
+        // measured at a 5.35ms median on loopback, where the round trip itself
+        // costs about 275us. `shutdown` already wakes a blocked `accept` by
+        // connecting to its own address, so nothing needed the poll.
         let addr = listener
             .local_addr()
             .map_err(|err| RaftError::Transport(format!("failed to read raft TCP addr: {err}")))?
@@ -545,10 +555,14 @@ impl TcpRaftTransportServer {
                 while !worker_shutdown.load(Ordering::Relaxed) {
                     match listener.accept() {
                         Ok((stream, _)) => {
+                            // `shutdown` wakes this thread by connecting to us,
+                            // so re-check before serving what may be that
+                            // wake-up rather than a peer.
+                            if worker_shutdown.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            let _ = stream.set_nodelay(true);
                             let _ = handle_tcp_raft_stream(stream, handler.as_ref());
-                        }
-                        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                            thread::sleep(Duration::from_millis(5));
                         }
                         Err(_) => break,
                     }


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#31`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of #27–#30 — `src/facade/transport_runtime.rs`, which none of them touch.

This is the first probe in the repo that measures a Raft RPC **as a peer actually experiences it**: connect, encode, write, wait, read, decode. Everything else in `examples/` measures in-process work.

## The TCP server polled for connections

The listener was non-blocking and the accept loop slept 5 ms whenever nothing was pending. So an inbound RPC arriving at an idle server waited **0–5 ms before it was even accepted** — and a Raft node is idle between heartbeats by design.

`examples/rpc_latency` is added here. 300 append RPCs, 64-byte payload, loopback:

| | min | **p50** | p90 | p99 | max | mean |
| --- | --- | --- | --- | --- | --- | --- |
| before | 274 µs | **5,351 µs** | 7,100 µs | 12,211 µs | 16,275 µs | 5,409 µs |
| after | 192 µs | **344 µs** | 554 µs | 1,005 µs | 2,953 µs | 390 µs |

**15.6× lower median.**

The check that the poll was really the cause, rather than something else moving: the before-**min** (274 µs) is about the after-**median** (344 µs). The minimum was the case where a connection happened to arrive while `accept` was awake — which is what every call gets now.

Percentiles rather than a mean throughout, because a poll interval shows up as a fat tail; a mean would have blurred a 5 ms stall into something that looks like general slowness.

The listener is blocking again. Nothing needed the poll — `shutdown` already wakes a blocked `accept` by connecting to its own address — so the loop re-checks the shutdown flag after accepting, in case what it accepted was that wake-up rather than a peer.

## Two more, on the classic list

- **No `TCP_NODELAY`.** `set_nodelay` appeared nowhere in the crate. Raft RPCs are small request/response exchanges, exactly the shape Nagle delays.
- **A write/write/read exchange.** The client wrote the encoded request, then wrote a one-byte newline *separately* — and the peer reads a line, so it cannot respond until that second write lands. With Nagle on, the newline waits for an ACK the peer will not send until it has the newline. The newline is now appended and sent in one write.

**Neither shows on loopback**, where ACKs are immediate — I am not claiming the measurement above demonstrates them. They are fixed here because the cost is a line each and the failure mode is a ~40 ms stall that is very hard to attribute after the fact.

## Not addressed — worth their own change

- The transport opens a **fresh TCP connection per RPC**, so every Raft message pays a handshake.
- The accept loop serves connections **inline**, so one peer blocks the others.
- There is **no read timeout**, so a peer that connects and then stops blocks the loop indefinitely.

The first is the largest remaining latency item; all three want a connection-reuse design rather than a patch.

## A note on the measurement

The "after" numbers were taken while the machine was at load average 45 from other work, so if anything they understate the improvement. The "before" numbers were taken earlier under lighter load. The mechanism — a 5 ms sleep in front of every accept — is not a timing argument, and the min/median relationship above is the part that does not depend on machine conditions.

## Checks

524 tests pass, including the 16 transport tests covering server start, round trip and shutdown — the behaviour the blocking-accept change could plausibly break. `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is disabled by the Actions billing failure.

