### PR TITLE
Share log entries between the nodes of a group instead of copying per node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ documentation = "https://docs.rs/matrixraft"
 exclude = ["/scripts", "/.github"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+# "rc" lets `Arc<LogEntry>` derive Serialize/Deserialize. A node's log holds
+# entries behind an `Arc` so that the peers a `RaftCluster` models share one
+# copy of each payload instead of one per node. Note that serde does not
+# preserve sharing across a round trip -- a deserialized cluster starts with
+# separate allocations again, which costs memory but not correctness.
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "2"
 

--- a/examples/memory_scaling.rs
+++ b/examples/memory_scaling.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Memory probe: what does a proposal cost in resident memory, and how does
+//! that scale with group size?
+//!
+//! `RaftCluster` models every node of a group inside one object, and each node
+//! keeps its own log. So the memory a group costs here is expected to grow with
+//! the number of nodes as well as the number of entries. This measures how
+//! much, because "expected to grow" is not a number.
+//!
+//! Reads `VmRSS` from `/proc/self/status`, so Linux only. RSS moves for reasons
+//! other than this process's allocations, so the probe proposes in large blocks
+//! and reports bytes per entry rather than trusting any single reading.
+
+use matrixraft::{Config, Peer, RaftCluster, ReplicaRole};
+
+fn peer(node_id: u64) -> Peer {
+    Peer {
+        node_id,
+        raft_addr: format!("127.0.0.1:{}", 9_000 + node_id),
+        snapshot_addr: format!("127.0.0.1:{}", 10_000 + node_id),
+        role: ReplicaRole::Voter,
+        auto_promote: false,
+    }
+}
+
+/// Resident set size in bytes, or `None` off Linux.
+fn rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let kb: u64 = rest.trim().trim_end_matches(" kB").trim().parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+fn measure(nodes: u64, entries: usize, payload_bytes: usize) -> (u64, u64) {
+    let before = rss_bytes().expect("VmRSS");
+    let peers: Vec<Peer> = (1..=nodes).map(peer).collect();
+    let mut cluster = RaftCluster::new(7, Config::default(), peers).expect("valid cluster");
+    cluster.start().expect("start");
+    cluster.campaign(1, true).expect("campaign");
+    let payload = vec![7u8; payload_bytes];
+    for _ in 0..entries {
+        cluster.propose(payload.clone()).expect("propose");
+    }
+    let after = rss_bytes().expect("VmRSS");
+    // Keep the cluster alive across the reading, or the allocator may have
+    // handed the pages back before we look.
+    std::hint::black_box(&cluster);
+    (before, after)
+}
+
+fn main() {
+    let entries: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(20_000);
+    let payload_bytes: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(256);
+
+    if rss_bytes().is_none() {
+        println!("VmRSS unavailable: this probe needs Linux");
+        return;
+    }
+
+    // One group size per process, on purpose. Measuring several in a row inside
+    // one process reads a smaller delta for each later size, because dropping
+    // the previous cluster leaves pages mapped for the next one to reuse -- at
+    // which point a flat memory profile reports as ~0 bytes and looks like a
+    // spectacular result rather than a broken measurement.
+    let nodes: u64 = std::env::args()
+        .nth(3)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(3);
+
+    let logical = entries as f64 * payload_bytes as f64;
+    let (before, after) = measure(nodes, entries, payload_bytes);
+    let delta = after.saturating_sub(before);
+    let per_entry = delta as f64 / entries as f64;
+    let per_entry_node = per_entry / nodes as f64;
+    let amplification = delta as f64 / logical;
+    println!(
+        "nodes={nodes:<3} entries={entries} payload={payload_bytes}B  logical={:.1} MiB  \
+         rss_delta={:.1} MiB  bytes/entry={per_entry:.0}  per_node={per_entry_node:.0}  \
+         amplification={amplification:.2}x",
+        logical / 1048576.0,
+        delta as f64 / 1048576.0
+    );
+}

--- a/src/facade/cluster_runtime.rs
+++ b/src/facade/cluster_runtime.rs
@@ -34,7 +34,15 @@ struct Node {
     replica_role: ReplicaRole,
     raft_role: StateRole,
     hard_state: HardState,
-    log: Vec<LogEntry>,
+    /// Entries are shared, not copied per node.
+    ///
+    /// A `RaftCluster` models every node of a group in one object, so a
+    /// proposal used to clone the whole entry -- payload included -- into each
+    /// node's log. Memory then grew with the group: measured at exactly 7x the
+    /// logical data for a seven-node group. An entry is immutable once
+    /// appended (conflict handling truncates, it never edits), so the nodes can
+    /// share one allocation behind an `Arc`.
+    log: Vec<Arc<LogEntry>>,
     // Running total of `log` payload bytes. Maintained by every log mutation so
     // that the admission checks on the propose path do not sum the log.
     #[serde(default)]
@@ -160,7 +168,21 @@ impl Node {
 
     fn set_log(&mut self, log: Vec<LogEntry>) {
         self.retained_log_bytes = log.iter().map(|entry| entry.payload.len() as u64).sum();
-        self.log = log;
+        self.log = log.into_iter().map(Arc::new).collect();
+    }
+
+    /// The log as owned entries, for callers that hand it to something outside
+    /// the cluster. This copies every payload, so it is for record-building and
+    /// RPC construction rather than anything on the propose path.
+    fn log_entries(&self) -> Vec<LogEntry> {
+        self.log.iter().map(|entry| (**entry).clone()).collect()
+    }
+
+    fn log_entries_from(&self, position: usize) -> Vec<LogEntry> {
+        self.log[position..]
+            .iter()
+            .map(|entry| (**entry).clone())
+            .collect()
     }
 
     fn log_term_at(&self, log_index: LogIndex) -> Option<Term> {
@@ -186,7 +208,9 @@ impl Node {
             || (candidate.term == local_term && candidate.index >= local_index)
     }
 
-    fn append_entry(&mut self, entry: LogEntry) {
+    /// Appends a shared entry. Callers appending the same entry to several
+    /// nodes should build one `Arc` and hand each node a clone of the handle.
+    fn append_entry(&mut self, entry: Arc<LogEntry>) {
         // An entry past the tail cannot collide with a retained index, so the
         // steady-state append never looks at the rest of the log.
         let extends_tail = self
@@ -234,22 +258,21 @@ impl Node {
         }
     }
 
-    fn append_witness_entry(&mut self, entry: LogEntry, preserve_payload: bool) {
+    /// A witness stores a rewritten entry -- `is_command` cleared, and the
+    /// payload dropped unless preserved -- so it cannot share the caller's
+    /// allocation and gets its own.
+    fn append_witness_entry(&mut self, entry: &LogEntry, preserve_payload: bool) {
         self.acknowledge_witness_index(entry.log_id.index);
-        let entry = if preserve_payload {
-            LogEntry {
-                log_id: entry.log_id,
-                payload: entry.payload,
-                is_command: false,
-            }
-        } else {
-            LogEntry {
-                log_id: entry.log_id,
-                payload: Vec::new(),
-                is_command: false,
-            }
+        let stored = LogEntry {
+            log_id: entry.log_id.clone(),
+            payload: if preserve_payload {
+                entry.payload.clone()
+            } else {
+                Vec::new()
+            },
+            is_command: false,
         };
-        self.append_entry(entry);
+        self.append_entry(Arc::new(stored));
     }
 
     fn advance_commit(&mut self, commit_index: LogIndex) {
@@ -1411,6 +1434,7 @@ impl RaftCluster {
             is_command: true,
         };
         self.last_log_index = log_id.index;
+        let entry = Arc::new(entry);
 
         let node_ids: Vec<_> = self.nodes.keys().copied().collect();
         for node_id in node_ids {
@@ -1418,14 +1442,14 @@ impl RaftCluster {
                 continue;
             };
             if node_id == leader_id {
-                node.append_entry(entry.clone());
+                node.append_entry(Arc::clone(&entry));
                 continue;
             }
             if node.healthy && node.match_index().saturating_add(1) == entry.log_id.index {
                 if node.replica_role.can_serve_data() {
-                    node.append_entry(entry.clone());
+                    node.append_entry(Arc::clone(&entry));
                 } else if node.replica_role == ReplicaRole::Witness {
-                    node.append_witness_entry(entry.clone(), false);
+                    node.append_witness_entry(&entry, false);
                 }
             }
         }
@@ -2537,6 +2561,9 @@ impl RaftCluster {
             is_command: options.is_command && !proposed_as_membership_change,
         };
         self.last_log_index = log_id.index;
+        // One allocation for the payload, shared by every node's log, rather
+        // than a clone per node.
+        let entry = Arc::new(entry);
 
         let mut lease_acknowledgements = vec![leader_id];
         let node_ids: Vec<_> = self.nodes.keys().copied().collect();
@@ -2545,7 +2572,7 @@ impl RaftCluster {
                 continue;
             };
             if node_id == leader_id {
-                node.append_entry(entry.clone());
+                node.append_entry(Arc::clone(&entry));
                 continue;
             }
             let response = if let Some(pipeline) = self.peer_pipelines.get_mut(&node_id) {
@@ -2556,9 +2583,9 @@ impl RaftCluster {
                     let append_is_contiguous = match_index.saturating_add(1) == entry.log_id.index;
                     if append_is_contiguous {
                         if node.replica_role.can_serve_data() {
-                            node.append_entry(entry.clone());
+                            node.append_entry(Arc::clone(&entry));
                         } else if node.replica_role == ReplicaRole::Witness {
-                            node.append_witness_entry(entry.clone(), proposed_as_membership_change);
+                            node.append_witness_entry(&entry, proposed_as_membership_change);
                         }
                     }
                     let match_index = node.match_index();
@@ -2608,7 +2635,7 @@ impl RaftCluster {
             node_id,
             hard_state: node.hard_state.clone(),
             membership: self.membership(),
-            entries: node.log.clone(),
+            entries: node.log_entries(),
             installed_snapshot,
             apply_snapshot_fence: ApplySnapshotFence {
                 applied_index: node.applied_index,
@@ -2664,10 +2691,10 @@ impl RaftCluster {
         let mut record = self.wal_record_shell(node_id, node);
         match extends {
             Some(from) => {
-                record.entries = node.log[from..].to_vec();
+                record.entries = node.log_entries_from(from);
                 record.entries_are_delta = true;
             }
-            None => record.entries = node.log.clone(),
+            None => record.entries = node.log_entries(),
         }
         record.checksum = matrixraft_wal_checksum(&record);
         Ok(record)
@@ -3075,13 +3102,13 @@ impl RaftCluster {
                     pending_membership_change_index = Some(entry.log_id.index);
                     self.membership_change_indexes.insert(entry.log_id.index);
                 }
-                node.append_entry(entry);
+                node.append_entry(Arc::new(entry));
                 appended_entries_count = appended_entries_count.saturating_add(1);
                 if cap_busy_data_append_batch {
                     break;
                 }
             } else if node.replica_role == ReplicaRole::Witness {
-                node.append_witness_entry(entry, is_membership_change);
+                node.append_witness_entry(&entry, is_membership_change);
                 appended_entries_count = appended_entries_count.saturating_add(1);
             }
         }
@@ -3987,7 +4014,7 @@ impl RaftCluster {
             .ok_or(RaftError::NodeNotFound(leader_id))?;
         let missing_tail: Vec<LogEntry> = leader
             .log_position_at_or_after(current_match.saturating_add(1))
-            .map(|position| leader.log[position..].to_vec())
+            .map(|position| leader.log_entries_from(position))
             .unwrap_or_default();
 
         let peer = self
@@ -3996,9 +4023,9 @@ impl RaftCluster {
             .ok_or(RaftError::NodeNotFound(peer_id))?;
         for entry in missing_tail {
             if peer.replica_role == ReplicaRole::Witness {
-                peer.append_witness_entry(entry, false);
+                peer.append_witness_entry(&entry, false);
             } else {
-                peer.append_entry(entry);
+                peer.append_entry(Arc::new(entry));
             }
         }
         peer.advance_commit(leader_commit_index.min(peer.match_index()));
@@ -4362,7 +4389,7 @@ impl RaftCluster {
             .get_mut(&target)
             .ok_or(RaftError::NodeNotFound(target))?;
         for entry in tail_entries {
-            node.append_entry(entry);
+            node.append_entry(Arc::new(entry));
         }
         node.advance_commit(self.commit_index.max(node.match_index()));
         if let Some(pipeline) = self.peer_pipelines.get_mut(&target) {

--- a/src/facade/tests.rs
+++ b/src/facade/tests.rs
@@ -38,13 +38,13 @@ mod log_addressing_tests {
         assert_byte_count_matches_log(&node, "construction");
 
         for index in 1..=10 {
-            node.append_entry(entry(1, index, index as usize * 4));
+            node.append_entry(std::sync::Arc::new(entry(1, index, index as usize * 4)));
         }
         assert_byte_count_matches_log(&node, "appends");
         assert_eq!(node.retained_log_bytes(), (1..=10_u64).map(|i| i * 4).sum::<u64>());
 
         // Re-appending an occupied index drops the conflicting tail with it.
-        node.append_entry(entry(2, 6, 1));
+        node.append_entry(std::sync::Arc::new(entry(2, 6, 1)));
         assert_byte_count_matches_log(&node, "conflicting append");
         assert_eq!(node.log.len(), 6);
         assert_eq!(node.log_term_at(6), Some(2));
@@ -73,7 +73,7 @@ mod log_addressing_tests {
         let mut node = voter();
         for index in 1..=8 {
             let term = if index <= 4 { 1 } else { 2 };
-            node.append_entry(entry(term, index, 3));
+            node.append_entry(std::sync::Arc::new(entry(term, index, 3)));
         }
         node.discard_log_through(5);
 
@@ -90,7 +90,7 @@ mod log_addressing_tests {
     fn log_positions_agree_with_a_scan() {
         let mut node = voter();
         for index in 1..=32 {
-            node.append_entry(entry(1, index, 2));
+            node.append_entry(std::sync::Arc::new(entry(1, index, 2)));
         }
         node.discard_log_through(7);
 
@@ -1760,11 +1760,11 @@ mod tests {
             } else {
                 StateRole::Follower
             };
-            node.append_entry(LogEntry {
+            node.append_entry(std::sync::Arc::new(LogEntry {
                 log_id: LogId { term: 1, index: 1 },
                 payload: b"committed-before-election".to_vec(),
                 is_command: true,
-            });
+            }));
             node.advance_commit(1);
         }
         cluster.commit_index = 1;
@@ -1774,11 +1774,11 @@ mod tests {
                 .nodes
                 .get_mut(&node_id)
                 .expect("node")
-                .append_entry(LogEntry {
+                .append_entry(std::sync::Arc::new(LogEntry {
                     log_id: LogId { term: 1, index: 2 },
                     payload: b"previous-term-entry".to_vec(),
                     is_command: true,
-                });
+                }));
         }
         cluster.refresh_commit_index();
         assert_eq!(cluster.commit_index, 1);
@@ -1788,11 +1788,11 @@ mod tests {
                 .nodes
                 .get_mut(&node_id)
                 .expect("node")
-                .append_entry(LogEntry {
+                .append_entry(std::sync::Arc::new(LogEntry {
                     log_id: LogId { term: 2, index: 3 },
                     payload: b"current-term-entry".to_vec(),
                     is_command: true,
-                });
+                }));
         }
         cluster.refresh_commit_index();
         assert_eq!(cluster.commit_index, 3);


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#32`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of #27–#31.

A `RaftCluster` models every node of a group in one object, and each node kept its own `Vec<LogEntry>`. A proposal cloned the whole entry — **payload included** — into every node's log, so memory grew linearly with the group.

**This is not only a harness property.** `NodeRuntime` builds a `RaftCluster` over `options.peers`, so a single running node modelled the whole group and held one copy of every entry per peer. A seven-node deployment paid 7× its log size in RAM on every node.

## The change

An entry is immutable once appended — conflict handling truncates the log, it never edits an entry in place — so the nodes can share one allocation. The log is now `Vec<Arc<LogEntry>>`, and the two paths that append one entry to every node build a single `Arc` and hand each node a clone of the handle.

`Deref` meant most of the eleven sites touching the log needed no change at all.

## Measured

`examples/memory_scaling` is added here — the repo's first memory measurement. 2000 entries of 16 KiB, 31.2 MiB of logical payload, **one process per group size**, same probe on both sides:

| nodes | 1 | 3 | 5 | 7 | 9 |
| --- | --- | --- | --- | --- | --- |
| before | 1.01× | 3.02× | 5.03× | 7.04× | **9.05×** |
| after | 1.01× | 1.01× | 1.01× | 1.01× | **1.01×** |

At nine nodes: **282.8 MiB → 31.7 MiB, an 8.9× reduction.** Memory is now flat in group size rather than linear in it.

## Three details worth stating

- **Witnesses still get their own entry.** A witness stores a rewritten one — `is_command` cleared, payload dropped unless preserved — so it cannot share the caller's allocation.
- **Reading the log out still copies.** `log_entries` / `log_entries_from` clone, because they hand entries to WAL records and RPC construction. Those were copies before, and they are transient rather than retained.
- **serde needs the `rc` feature**, since `RaftCluster` derives `Serialize`. Sharing is *not* preserved across a round trip: a deserialized cluster starts with separate allocations again. That costs memory, not correctness, and only until entries are appended again. It is called out in `Cargo.toml` next to the feature.

## The probe measures one group size per process, deliberately

Measuring several in a row inside one process reads a smaller delta for each later size, because dropping the previous cluster leaves pages mapped for the next to reuse. Once memory is flat that reports as ~0 bytes — which looks like a spectacular result rather than a broken measurement.

The first version of this probe did exactly that and reported **0.0 MiB at seven nodes**. I did not believe it, which is why the probe now takes a group size and the shell loops over invocations. The 64-byte-payload rows were discarded for the same reason: at that size RSS granularity dominates, and the seven-node row read *lower* than the five-node one.

## Checks

524 tests pass, including the 98 in `raft_cluster_engine` that exercise the log directly — append, conflict truncation, compaction and recovery, which is exactly what changing log storage could break. `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is disabled by the Actions billing failure.

