### PR TITLE
Stop cloning the whole WAL to count it

### DIFF
--- a/examples/wal_recovery_scaling.rs
+++ b/examples/wal_recovery_scaling.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Restart probe: how long does a node take to recover its WAL, and what does
+//! holding it cost, as the log grows?
+//!
+//! Restart time is a scale metric in its own right -- it is how long a node is
+//! unavailable after a crash or a deploy. `PersistentRaftWal` reads its
+//! segments into memory on open, so this measures both the time and the
+//! resident cost, and reports per-record figures so a non-linear term shows up
+//! as a rising column rather than a bigger total.
+
+use std::time::Instant;
+
+use matrixraft::{
+    ApplySnapshotFence, HardState, LogEntry, LogId, Membership, PersistentRaftWal,
+    PersistentRaftWalOptions, WalRecord,
+};
+
+fn record(index: u64, payload_bytes: usize) -> WalRecord {
+    WalRecord {
+        group_id: 9,
+        node_id: 1,
+        hard_state: HardState {
+            current_term: 3,
+            voted_for: Some(1),
+            committed: Some(LogId { term: 3, index }),
+        },
+        membership: Membership {
+            group_id: 9,
+            voters: vec![1, 2, 3],
+            learners: Vec::new(),
+            witnesses: Vec::new(),
+            epoch: 3,
+        },
+        entries: vec![LogEntry {
+            log_id: LogId { term: 3, index },
+            payload: vec![7u8; payload_bytes],
+            is_command: true,
+        }],
+        entries_are_delta: false,
+        installed_snapshot: None,
+        apply_snapshot_fence: ApplySnapshotFence {
+            applied_index: index,
+            commit_index: index,
+            installed_snapshot_index: 0,
+            first_retained_log_index: 1,
+        },
+        checksum: String::new(),
+    }
+}
+
+fn rss_bytes() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            if let Ok(kb) = rest.trim().trim_end_matches(" kB").trim().parse::<u64>() {
+                return kb * 1024;
+            }
+        }
+    }
+    0
+}
+
+fn options(dir: std::path::PathBuf) -> PersistentRaftWalOptions {
+    PersistentRaftWalOptions {
+        dir,
+        // One segment, so this measures recovery of a log rather than segment
+        // rolling.
+        max_records_per_segment: 10_000_000,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        // Off: this is about recovery cost, and fsync would make the write
+        // phase dominate the run.
+        fsync_on_append: false,
+    }
+}
+
+fn main() {
+    let payload_bytes: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(256);
+    let records: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(20_000);
+
+    let dir = std::env::temp_dir().join(format!(
+        "matrixraft-wal-recovery-{}-{records}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let write_started = Instant::now();
+    {
+        let mut wal = PersistentRaftWal::open(options(dir.clone())).expect("open wal");
+        for index in 1..=records as u64 {
+            wal.append(record(index, payload_bytes)).expect("append");
+        }
+    }
+    let write_seconds = write_started.elapsed().as_secs_f64();
+
+    let on_disk: u64 = std::fs::read_dir(&dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter_map(|e| e.metadata().ok().map(|m| m.len()))
+                .sum()
+        })
+        .unwrap_or(0);
+
+    let rss_before = rss_bytes();
+    let open_started = Instant::now();
+    let mut wal = PersistentRaftWal::open(options(dir.clone())).expect("reopen wal");
+    let open_seconds = open_started.elapsed().as_secs_f64();
+
+    let recover_started = Instant::now();
+    let report = wal.recover().expect("recover");
+    let recover_seconds = recover_started.elapsed().as_secs_f64();
+    let rss_after = rss_bytes();
+
+    assert_eq!(report.surviving_records, records);
+
+    // `status` is the observability surface and gets polled routinely, so its
+    // cost per call matters as much as recovery's one-off cost.
+    let status_started = Instant::now();
+    for _ in 0..20 {
+        std::hint::black_box(wal.status());
+    }
+    let status_us = status_started.elapsed().as_secs_f64() * 1e6 / 20.0;
+
+    std::hint::black_box(&wal);
+
+    let total = open_seconds + recover_seconds;
+    println!(
+        "records={records:<7} payload={payload_bytes}B  on_disk={:.1} MiB  write={write_seconds:.3}s\n  \
+         open={open_seconds:.3}s  recover={recover_seconds:.3}s  restart_total={total:.3}s  \
+         us/record={:.1}  rss_held={:.1} MiB  bytes/record={:.0}  status={status_us:.1}us/call",
+        on_disk as f64 / 1048576.0,
+        total * 1e6 / records as f64,
+        rss_after.saturating_sub(rss_before) as f64 / 1048576.0,
+        rss_after.saturating_sub(rss_before) as f64 / records as f64,
+    );
+
+    drop(wal);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -506,12 +506,11 @@ impl PersistentRaftWal {
 
     pub fn recover(&mut self) -> Result<WalRecoveryReport, RaftError> {
         let (segments, truncated_corrupt_tail) = read_wal_segments_from_dir(&self.options.dir)?;
-        let original_len = self.records().len();
-        let stored: Vec<_> = segments
-            .iter()
-            .flat_map(|segment| segment.records.iter().cloned())
-            .collect();
-        let records = matrixraft_fold_wal_records(&stored);
+        // Counting used to clone every retained record, payloads included.
+        let original_len = self.retained_record_count() as usize;
+        let records = matrixraft_fold_wal_record_iter(
+            segments.iter().flat_map(|segment| segment.records.iter()),
+        );
         self.segments = if segments.is_empty() {
             vec![WalSegment {
                 segment_id: 0,
@@ -620,7 +619,9 @@ impl PersistentRaftWal {
     }
 
     pub fn status(&self) -> WalLifecycleStatus {
-        let total_records = self.records().len() as u64;
+        // `status` is polled routinely, and this used to clone the entire
+        // WAL on each call just to read its length.
+        let total_records = self.retained_record_count();
         let total_bytes = self
             .segments
             .iter()
@@ -702,6 +703,14 @@ impl PersistentRaftWal {
 
     pub fn checksum_format(&self) -> WalChecksumFormat {
         matrixraft_wal_checksum_format()
+    }
+
+    /// Number of retained records, without materialising them.
+    fn retained_record_count(&self) -> u64 {
+        self.segments
+            .iter()
+            .map(|segment| segment.records.len() as u64)
+            .sum()
     }
 
     pub fn records(&self) -> Vec<WalRecord> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,8 +243,9 @@ pub use unique_id::{
     MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK,
 };
 pub use wal::{
-    matrixraft_fold_wal_records, matrixraft_recover_latest_wal_record,
-    matrixraft_validate_apply_snapshot_fence, matrixraft_validate_hard_state_persistence,
+    matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
+    matrixraft_recover_latest_wal_record, matrixraft_validate_apply_snapshot_fence,
+    matrixraft_validate_hard_state_persistence,
     matrixraft_validate_wal_lifecycle_evidence_artifact, matrixraft_wal_checksum,
     matrixraft_wal_checksum_format, matrixraft_wal_checksum_valid, matrixraft_wal_delta_base,
     matrixraft_wal_lifecycle_evidence, matrixraft_wal_lifecycle_evidence_artifact,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -308,8 +308,21 @@ pub fn matrixraft_validate_apply_snapshot_fence(record: &WalRecord) -> Result<()
 /// scanning for a valid prefix would have stopped. The folded records are then
 /// re-checksummed so they validate as the whole-log records they now are.
 pub fn matrixraft_fold_wal_records(stored: &[WalRecord]) -> Vec<WalRecord> {
+    matrixraft_fold_wal_record_iter(stored)
+}
+
+/// Fold from any iterator of records.
+///
+/// Recovery holds its records in per-segment vectors, so the slice form above
+/// forced it to concatenate a clone of the whole WAL first -- payloads
+/// included -- purely to get one contiguous slice. This takes the segments as
+/// they are.
+pub fn matrixraft_fold_wal_record_iter<'a, I>(stored: I) -> Vec<WalRecord>
+where
+    I: IntoIterator<Item = &'a WalRecord>,
+{
     let mut folded_entries: Vec<LogEntry> = Vec::new();
-    let mut out = Vec::with_capacity(stored.len());
+    let mut out = Vec::new();
     for record in stored {
         if !matrixraft_wal_checksum_valid(record) {
             break;


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#33`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of #27–#32.

`PersistentRaftWal::records()` clones every retained record, payloads included. Three places called it for something that is not the records:

```
status()     self.records().len() as u64
recover()    self.records().len()
recover()    concatenated a clone of every segment, to pass a slice to the fold
```

**`status` is the one that matters.** It is the observability surface, polled routinely, and it cloned the entire WAL on every call purely to read a length.

## Measured

`examples/wal_recovery_scaling` is added here. 40,000 records of 256 bytes:

| | before | after |
| --- | --- | --- |
| `status()` per call | **~97 ms** | **6.1 µs** |
| resident after recovery | 113.9 MiB | 90.5 MiB |
| bytes/record retained | 2,985 | 2,371 |

Before, `status` also **grew with the log** — 39 ms per call at 10,000 records, ~90 ms at 40,000. After it is single-digit microseconds and flat, because counting sums the per-segment record counts.

The resident drop is the recovery clone. It was transient, but it raised peak RSS and the allocator does not hand that back.

`matrixraft_fold_wal_record_iter` takes an iterator so recovery can fold the segments as they are; the slice form is kept and delegates to it, so no existing caller changes.

## Restart time is deliberately not claimed

It looked like an improvement in one ordering and a regression in the other, so I ran it three times alternating:

| run | restart_total |
| --- | --- |
| BEFORE (first) | 1.957 s |
| AFTER (second) | 1.432 s |
| BEFORE (third) | **1.193 s** |

The figure falls with each successive run *whichever branch is in the tree* — warm page cache and machine load, not the change. Recovery does one less full clone so the direction should be favourable, but this measurement cannot show it, and I would rather leave it unquoted than present a number the data does not support.

## What this does not fix

The WAL still holds **every record of every retained segment in memory** — about 2.4 KB per record after this change, so roughly 2.4 GB for a million-record log. That is the larger memory problem at scale and it needs lazy segment loading, not fewer clones. Related: on #29 I measured that a smaller on-disk encoding does not move this number either, because the cost is the decoded structs rather than the bytes.

## Checks

524 tests pass, including the 10 in `persistent_wal` and 5 in `membership_wal_snapshot` covering recovery, compaction and checksum validation — the behaviour the fold change could break. `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is disabled by the Actions billing failure.

