### PR TITLE
Materialise the whole record at compaction, not at every segment roll

### DIFF
--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -286,7 +286,7 @@ impl PersistentRaftWal {
             fsync_count: 0,
             active_covered: None,
         };
-        wal.active_covered = wal.covered_from_active_segment();
+        wal.active_covered = wal.covered_from_segments();
         Ok(wal)
     }
 
@@ -330,16 +330,19 @@ impl PersistentRaftWal {
         delta
     }
 
-    /// Rebuilds the active segment's coverage by folding what is already on
-    /// disk, so an appended-to WAL keeps writing deltas after a reopen.
+    /// Rebuilds what the retained records already cover, by folding what is
+    /// already on disk, so an appended-to WAL keeps writing deltas after a
+    /// reopen.
     ///
-    /// Only the log as the segment leaves it is wanted here. Folding to a record
-    /// per step built one whole-log record for every record in the segment --
-    /// at the default ten thousand records per segment that is ten thousand
-    /// copies of the log, on every open.
-    fn covered_from_active_segment(&self) -> Option<(LogIndex, LogIndex, Term)> {
-        let segment = self.segments.last()?;
-        let entries = matrixraft_fold_wal_entries(segment.records.iter());
+    /// This folds every segment rather than only the active one: a segment's
+    /// first record is now a delta against the segment before it, so the active
+    /// segment on its own no longer describes the whole log.
+    fn covered_from_segments(&self) -> Option<(LogIndex, LogIndex, Term)> {
+        let entries = matrixraft_fold_wal_entries(
+            self.segments
+                .iter()
+                .flat_map(|segment| segment.records.iter()),
+        );
         let first = entries.first()?;
         let last = entries.last()?;
         Some((first.log_id.index, last.log_id.index, last.log_id.term))
@@ -403,19 +406,9 @@ impl PersistentRaftWal {
                 .map(|segment| segment.records.len())
                 .unwrap_or_default();
             let rolling_by_count = active_records >= self.options.max_records_per_segment;
-            let stored = if rolling_by_count {
-                whole_record(&record)
-            } else {
-                self.delta_record(&record)
-            };
+            let stored = self.delta_record(&record);
             // Deferred deliberately: one fsync covers the whole batch, below.
-            reports.push(self.write_record(
-                stored,
-                active_records,
-                rolling_by_count,
-                false,
-                || Ok(whole_record(&record)),
-            )?);
+            reports.push(self.write_record(stored, active_records, rolling_by_count, false)?);
         }
         if self.options.fsync_on_append {
             let (elapsed_ms, slow) = self.fsync_active_segment()?;
@@ -445,10 +438,12 @@ impl PersistentRaftWal {
     /// Appends a record the caller builds on demand.
     ///
     /// `build` is handed the coverage the record should be written against, or
-    /// `None` when a whole-log record is required -- at the start of a segment,
-    /// and again if rolling turns out to be necessary after the record was
-    /// built. Callers that can produce a delta cheaply should use this instead
-    /// of [`Self::append`], which has to be given the whole log every time.
+    /// `None` when a whole-log record is required -- at the very start of the
+    /// log, before anything is covered. A roll no longer forces one: the new
+    /// segment opens with the delta, and compaction materialises the whole
+    /// record at the boundary it actually moves. Callers that can produce a
+    /// delta cheaply should use this instead of [`Self::append`], which has to
+    /// be given the whole log every time.
     pub fn append_built<F>(&mut self, mut build: F) -> Result<WalWriteReport, RaftError>
     where
         F: FnMut(
@@ -461,18 +456,12 @@ impl PersistentRaftWal {
             .map(|segment| segment.records.len())
             .unwrap_or_default();
         let rolling_by_count = active_records >= self.options.max_records_per_segment;
-        let coverage = if rolling_by_count {
-            None
-        } else {
-            self.active_covered
-        };
-        let record = build(coverage)?;
+        let record = build(self.active_covered)?;
         self.write_record(
             record,
             active_records,
             rolling_by_count,
             self.options.fsync_on_append,
-            || build(None),
         )
     }
 
@@ -490,36 +479,29 @@ impl PersistentRaftWal {
             .map(|segment| segment.records.len())
             .unwrap_or_default();
         let rolling_by_count = active_records >= self.options.max_records_per_segment;
-        let stored = if rolling_by_count {
-            whole_record(&record)
-        } else {
-            self.delta_record(&record)
-        };
+        let stored = self.delta_record(&record);
         self.write_record(
             stored,
             active_records,
             rolling_by_count,
             self.options.fsync_on_append,
-            || Ok(whole_record(&record)),
         )
     }
 
     /// Writes a record that has already been reduced to what will be stored.
     ///
-    /// `whole` is only called when rolling turns out to be necessary after the
-    /// record was built, since the segment it was a delta against is then
-    /// sealed and the new segment has to open with a whole-log record.
-    fn write_record<W>(
+    /// Rolling a segment no longer rewrites the record whole. A segment used to
+    /// open with the entire retained log so that it could be read without
+    /// reading any other, which cost a copy of the log at every roll and made N
+    /// appends cost about N^2/2S entries. Compaction materialises that record
+    /// instead, at the one moment the boundary it protects actually moves.
+    fn write_record(
         &mut self,
-        mut record: WalRecord,
+        record: WalRecord,
         active_records: usize,
         rolling_by_count: bool,
         fsync: bool,
-        whole: W,
-    ) -> Result<WalWriteReport, RaftError>
-    where
-        W: FnOnce() -> Result<WalRecord, RaftError>,
-    {
+    ) -> Result<WalWriteReport, RaftError> {
         let hard_state_persisted = matrixraft_validate_hard_state_persistence(&record).is_ok();
         let active_len = self
             .active_segment
@@ -528,8 +510,8 @@ impl PersistentRaftWal {
                 RaftError::Storage(format!("failed to read WAL active segment metadata: {err}"))
             })?
             .len();
-        let mut encoded = encode_wal_record(&record)?;
-        let mut record_bytes = encoded.len() as u64 + 1;
+        let encoded = encode_wal_record(&record)?;
+        let record_bytes = encoded.len() as u64 + 1;
 
         let mut segment_rolled = false;
         if rolling_by_count
@@ -537,13 +519,6 @@ impl PersistentRaftWal {
         {
             self.roll_segment()?;
             segment_rolled = true;
-            if record.entries_are_delta {
-                record = whole()?;
-                record.entries_are_delta = false;
-                record.checksum = matrixraft_wal_checksum(&record);
-                encoded = encode_wal_record(&record)?;
-                record_bytes = encoded.len() as u64 + 1;
-            }
         }
 
         self.active_segment
@@ -617,7 +592,7 @@ impl PersistentRaftWal {
         }
         self.active_segment = open_segment_for_append(&self.options.dir, active_id)?;
         self.next_segment_id = active_id + 1;
-        self.active_covered = self.covered_from_active_segment();
+        self.active_covered = self.covered_from_segments();
         let observed_corrupt_tail = self.truncated_corrupt_tail || truncated_corrupt_tail;
         self.truncated_corrupt_tail = observed_corrupt_tail;
         Ok(WalRecoveryReport {
@@ -646,6 +621,13 @@ impl PersistentRaftWal {
             .filter(|segment| segment.last_index > 0 && segment.last_index <= log_index)
             .map(|segment| segment.segment_id)
             .collect();
+        // A surviving segment can now open with a delta against a segment that
+        // is about to be deleted. Turn it back into a whole record, and write it
+        // before anything is removed: a crash between the two leaves the base
+        // still on disk, and recovery folds it exactly as it did before.
+        if !removable_ids.is_empty() {
+            self.materialize_first_surviving_record(&removable_ids)?;
+        }
         for segment_id in &removable_ids {
             let path = wal_segment_path(&self.options.dir, *segment_id);
             match fs::remove_file(&path) {
@@ -668,6 +650,44 @@ impl PersistentRaftWal {
             }
         }
         Ok(removable_ids.len() as u64)
+    }
+
+    /// Turns the first surviving record into a whole one when compaction is
+    /// about to delete the records it is a delta against.
+    ///
+    /// This is the cost that used to be paid at every segment roll. It is paid
+    /// here instead, once per compaction that actually removes something, which
+    /// is the only point where a segment stops having its base on disk.
+    fn materialize_first_surviving_record(
+        &mut self,
+        removable_ids: &[u64],
+    ) -> Result<(), RaftError> {
+        let Some(position) = self
+            .segments
+            .iter()
+            .position(|segment| !removable_ids.contains(&segment.segment_id))
+        else {
+            return Ok(());
+        };
+        let entries = {
+            let Some(first) = self.segments[position].records.first() else {
+                return Ok(());
+            };
+            if !first.entries_are_delta {
+                return Ok(());
+            }
+            matrixraft_fold_wal_entries(
+                self.segments[..position]
+                    .iter()
+                    .flat_map(|segment| segment.records.iter())
+                    .chain(std::iter::once(first)),
+            )
+        };
+        let record = &mut self.segments[position].records[0];
+        record.entries = entries;
+        record.entries_are_delta = false;
+        record.checksum = matrixraft_wal_checksum(record);
+        write_wal_segment_file(&self.options.dir, &self.segments[position])
     }
 
     pub fn compact_through_with_fence(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,9 +247,8 @@ pub use unique_id::{
 };
 pub use wal::{
     matrixraft_fold_wal_entries, matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
-    matrixraft_recover_from_wal_records,
-    matrixraft_recover_latest_wal_record, matrixraft_validate_apply_snapshot_fence,
-    matrixraft_validate_hard_state_persistence,
+    matrixraft_recover_from_wal_records, matrixraft_recover_latest_wal_record,
+    matrixraft_validate_apply_snapshot_fence, matrixraft_validate_hard_state_persistence,
     matrixraft_validate_wal_lifecycle_evidence_artifact, matrixraft_wal_checksum,
     matrixraft_wal_checksum_format, matrixraft_wal_checksum_valid, matrixraft_wal_delta_base,
     matrixraft_wal_lifecycle_evidence, matrixraft_wal_lifecycle_evidence_artifact,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -382,9 +382,10 @@ fn whole_from_folded(record: &WalRecord, folded: &[LogEntry]) -> WalRecord {
 /// step.
 ///
 /// [`matrixraft_fold_wal_records`] answers "what did the log look like at each
-/// record", and pays a whole-log record per step to do it. Callers that only
-/// want the log as it ends up -- reopening to see what a segment already
-/// covers, for one -- want this instead.
+/// record". This answers only "what does it look like at the end", which is what
+/// compaction needs when it has to turn a delta back into a whole record, and
+/// what a reopen needs to know what the retained records already cover. Both
+/// share one `fold_wal_entries_step`, so the two cannot drift apart.
 ///
 /// Like the record fold, this stops at the first record whose checksum does not
 /// validate, which is where a reader scanning for a valid prefix would stop.

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -473,8 +473,9 @@ fn each_segment_can_be_read_without_the_ones_compaction_removed() {
             wal.append(growing_wal_record(index, 3)).expect("append");
         }
         assert!(wal.segments().len() >= 4);
-        // Drop the early segments. Every segment opens with a whole-log record,
-        // so the survivors stay readable on their own.
+        // Drop the early segments. Segments no longer open with a whole-log
+        // record, so compaction has to materialise the first surviving one
+        // before it deletes the records that one is a delta against.
         wal.compact_through(20).expect("compact");
     }
 
@@ -741,6 +742,62 @@ fn a_batch_pays_for_one_fsync_not_one_per_record() {
     fs::remove_dir_all(&dir).ok();
 }
 
+fn roll_options(dir: PathBuf) -> PersistentRaftWalOptions {
+    PersistentRaftWalOptions {
+        dir,
+        max_records_per_segment: 10,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        fsync_on_append: false,
+    }
+}
+
+fn retained_entries(wal: &PersistentRaftWal) -> usize {
+    wal.segments()
+        .iter()
+        .flat_map(|segment| segment.records.iter())
+        .map(|record| record.entries.len())
+        .sum()
+}
+
+fn whole_record_count(wal: &PersistentRaftWal) -> usize {
+    wal.segments()
+        .iter()
+        .flat_map(|segment| segment.records.iter())
+        .filter(|record| !record.entries_are_delta)
+        .count()
+}
+
+/// A segment roll used to rewrite the whole retained log, so N appends cost
+/// about N^2/2S entries rather than N.
+///
+/// This asserts the shape by counting rather than by timing: entries held has
+/// an exact expected value, and does not move with machine load.
+#[test]
+fn a_segment_roll_no_longer_rewrites_the_whole_log() {
+    let dir = temp_wal_dir("roll-cost");
+    let mut wal = PersistentRaftWal::open(roll_options(dir.clone())).expect("open");
+    for index in 1..=50 {
+        wal.append(growing_wal_record(index, 3)).expect("append");
+    }
+
+    assert!(
+        wal.segments().len() >= 5,
+        "the log has to cross several segments for this to mean anything"
+    );
+    assert_eq!(
+        whole_record_count(&wal),
+        1,
+        "only the very first record of the WAL is stored whole"
+    );
+    assert_eq!(
+        retained_entries(&wal),
+        50,
+        "each append should retain one entry; rewriting the log at every roll          retained 150 here, and grows quadratically from there"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
 /// Batching changes when the fsync happens, and nothing else. What is stored
 /// and what recovers has to be identical to appending one at a time.
 #[test]
@@ -785,4 +842,83 @@ fn a_batched_wal_recovers_exactly_as_a_one_at_a_time_wal_does() {
     );
     fs::remove_dir_all(&batched_dir).ok();
     fs::remove_dir_all(&single_dir).ok();
+}
+
+/// Compaction deletes whole segment files. A survivor that opens with a delta
+/// has just lost the records it was a delta against, so compaction has to turn
+/// it back into a whole record first -- and must do it without losing an entry.
+#[test]
+fn compaction_materialises_the_record_its_survivors_depend_on() {
+    let dir = temp_wal_dir("materialise");
+    let options = roll_options(dir.clone());
+    {
+        let mut wal = PersistentRaftWal::open(options.clone()).expect("open");
+        for index in 1..=50 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        let first_survivor_was_a_delta = wal.segments()[1]
+            .records
+            .first()
+            .expect("the second segment has records")
+            .entries_are_delta;
+        assert!(
+            first_survivor_was_a_delta,
+            "the segment that survives has to start as a delta, or this proves nothing"
+        );
+        wal.compact_through(20).expect("compact");
+    }
+
+    let mut reopened = PersistentRaftWal::open(options).expect("reopen");
+    assert!(
+        !reopened.segments()[0]
+            .records
+            .first()
+            .expect("the surviving segment has records")
+            .entries_are_delta,
+        "the first surviving record must have been materialised on disk"
+    );
+    let recovered = reopened
+        .recover()
+        .expect("recover")
+        .recovered
+        .expect("a record survives recovery");
+    assert_eq!(
+        recovered.entries.len(),
+        50,
+        "compaction must not drop an entry it was still the base for"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+/// Compaction happening more than once is the case where a materialised record
+/// becomes the base for the next materialisation.
+#[test]
+fn a_log_recovers_exactly_after_repeated_compaction() {
+    let dir = temp_wal_dir("repeat-compaction");
+    let options = roll_options(dir.clone());
+    {
+        let mut wal = PersistentRaftWal::open(options.clone()).expect("open");
+        for index in 1..=30 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        wal.compact_through(10).expect("first compaction");
+        for index in 31..=60 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+        wal.compact_through(40).expect("second compaction");
+    }
+
+    let mut reopened = PersistentRaftWal::open(options).expect("reopen");
+    let recovered = reopened
+        .recover()
+        .expect("recover")
+        .recovered
+        .expect("a record survives recovery");
+    assert_eq!(recovered.entries.len(), 60);
+    assert_eq!(
+        recovered.entries.last().expect("tail").log_id.index,
+        60,
+        "the tail has to survive two compactions intact"
+    );
+    fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#35`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #34**, which measures the problem this fixes. Review #34 first; merge it first too.

The first record of every segment was stored whole so a segment could be read without reading any other. #34 measured the price: that record is the **whole retained log**, so the k-th roll writes and retains about `k*S` entries and N appends cost roughly **N²/2S** rather than N. Every doubling of the log doubled the cost of an append.

Segments open with a delta now, and the invariant compaction depends on is restored where it is actually needed — `compact_through` materialises the first surviving record before it deletes anything.

## Measured

`examples/wal_segment_roll_cost` from #34, 64-byte payloads, 256 records per segment, one log size per process. It **counts** retained entries rather than timing anything.

| appends | retained entries | on disk | resident |
| ---: | ---: | ---: | ---: |
| 2048 | 9,216 → **2,048** | 2.57 → 1.20 MiB | 2.59 → 1.35 MiB |
| 4096 | 34,816 → **4,096** | 8.31 → 2.40 MiB | 6.82 → 2.67 MiB |
| 8192 | 135,168 → **8,192** | 29.28 → 4.80 MiB | 24.37 → 5.29 MiB |

Entries retained per append was 4.5, 8.5, 16.5. It is **1.0 at every size now** — flat rather than rising, which is the whole point. At 8192 appends that is 16.5× fewer entries held, 6.1× less on disk, 4.6× less resident.

## What changed

- `append_built` and `append_with_report` no longer force a whole record when the segment is about to roll, so a delta continues across the boundary.
- `covered_from_active_segment` → `covered_from_segments`, folding **every** segment. The active segment alone no longer describes the whole log, so a reopen that folded only it would resume from a truncated base.
- `compact_through` calls `materialize_first_surviving_record` **before removing any file**. That order is deliberate: a crash between the write and the deletes leaves the base still on disk, and recovery folds it exactly as it did before.
- `matrixraft_fold_wal_entries` folds an iterator of records into just the log, without building a record per step. It and `matrixraft_fold_wal_records` share `fold_wal_entries_step`, so the two cannot drift apart.

`recover()` already folded across all segments, so it needed no change.

## On the risk

This changes `compact_through`, the one path in the crate that deletes data, so I did not take the test suite passing as evidence on its own.

Three tests are added, and I checked each **fails without the fix** rather than assuming:

- `a_segment_roll_no_longer_rewrites_the_whole_log` — fails on old code with 5 whole records instead of 1.
- `compaction_materialises_the_record_its_survivors_depend_on` — fails on old code, and asserts the survivor *was* a delta first, so it cannot pass vacuously.
- `a_log_recovers_exactly_after_repeated_compaction` — a materialised record becoming the base for the next materialisation. This one passes on old code too, because segments were self-contained there; it guards the new path.

Then I disabled the materialisation call on this branch to check the guard is load-bearing. **Three tests fail, including the pre-existing `each_segment_can_be_read_without_the_ones_compaction_removed`, which recovers 30 entries of 50** — real data loss. That is the failure mode this change could have introduced, and it is caught.

## Note on a measurement I threw away

My first A/B showed both branches identical. `git checkout` had carried the uncommitted fix across branches, so every run measured the fixed code — including a four-run alternation of the slow suite. The numbers above are from committed branches with a clean tree asserted before each run.

Separately, `real_baseline_raft_benchmark_contract` took 261s in one run and ~18s in four others. That is a timing-sensitive suite and the box was at load 24 on 8 cores; alternating runs put both branches in the same range, so it is contention, not this change.

## Conflict to expect

This touches `matrixraft_fold_wal_records`, which #33 also changes (it adds an iterator form there). Both edits are in the same function; whichever lands second needs a small manual resolution — the two are compatible, since #33's iterator fold and this one's `fold_wal_entries_step` do the same thing at different levels.

## Checks

527 tests pass. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure, so these are local runs.

