### PR TITLE
Generate deployable Grafana and Prometheus artifacts from the metrics model

### DIFF
--- a/examples/metrics_exporter.rs
+++ b/examples/metrics_exporter.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! A Prometheus endpoint, so the Grafana stack has something to scrape.
+//!
+//! The crate renders Prometheus text but does not serve it -- every
+//! `*_prometheus` function takes a report and hands back a
+//! [`matrixraft::PrometheusMetricSet`], leaving exposition to the embedder.
+//! That means the dashboards in `observability/` have nothing to draw until
+//! something publishes the text, which is what this does.
+//!
+//! It serves the metrics that exist without a running cluster: the operator
+//! runbook, and the provisioning validation that compares the advertised
+//! contract against the dashboard and alert rules. **A real deployment should
+//! serve its own reports** -- the per-node latency and queue-depth series the
+//! dashboard also plots come from a live node, not from here.
+//!
+//!     cargo run --example metrics_exporter -- 0.0.0.0:9464
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+
+use matrixraft::{
+    matrixraft_observability_provisioning, matrixraft_observability_provisioning_runbook_steps,
+    matrixraft_observability_provisioning_validation_prometheus,
+    matrixraft_operator_runbook_prometheus, matrixraft_validate_observability_provisioning,
+};
+
+fn metrics_text() -> String {
+    let labels: [(&str, &str); 1] = [("service", "matrixraft")];
+    let runbook = matrixraft_operator_runbook_prometheus(
+        &matrixraft_observability_provisioning_runbook_steps(),
+        &labels,
+    );
+    let validation =
+        matrixraft_validate_observability_provisioning(&matrixraft_observability_provisioning());
+    let provisioning =
+        matrixraft_observability_provisioning_validation_prometheus(&validation, &labels);
+    format!("{}{}", runbook.text, provisioning.text)
+}
+
+fn serve(mut stream: TcpStream) -> std::io::Result<()> {
+    let mut request_line = String::new();
+    BufReader::new(stream.try_clone()?).read_line(&mut request_line)?;
+    let body = metrics_text();
+    // Prometheus is content-type sensitive; this is the text exposition format
+    // it expects, and the version matters to older scrapers.
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream.write_all(response.as_bytes())
+}
+
+fn main() -> std::io::Result<()> {
+    let addr = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "0.0.0.0:9464".to_string());
+    let listener = TcpListener::bind(&addr)?;
+    println!("serving matrixraft metrics on http://{addr}/metrics");
+    for stream in listener.incoming() {
+        match stream {
+            // One connection at a time is enough for a scrape every 15s, and
+            // keeps this example about exposition rather than about serving.
+            Ok(stream) => {
+                let _ = serve(stream);
+            }
+            Err(err) => eprintln!("accept failed: {err}"),
+        }
+    }
+    Ok(())
+}

--- a/examples/render_observability_artifacts.rs
+++ b/examples/render_observability_artifacts.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Writes the deployable observability artifacts, or checks the checked-in ones
+//! still match.
+//!
+//! The dashboard and the alert rules are rendered from the model in
+//! `metrics.rs`, so a panel or an alert added there reaches the deployed files
+//! by regenerating rather than by being copied by hand.
+//!
+//!     cargo run --example render_observability_artifacts
+//!     cargo run --example render_observability_artifacts -- --check
+
+use std::path::Path;
+
+use matrixraft::observability_artifacts::matrixraft_observability_artifacts;
+
+fn main() -> std::io::Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let check = args.iter().any(|arg| arg == "--check");
+    let root = args
+        .iter()
+        .find(|arg| !arg.starts_with("--"))
+        .cloned()
+        .unwrap_or_else(|| "observability".to_string());
+    let root = Path::new(&root);
+
+    let mut drifted = Vec::new();
+    for artifact in matrixraft_observability_artifacts() {
+        let path = root.join(&artifact.path);
+        if check {
+            match std::fs::read_to_string(&path) {
+                Ok(found) if found == artifact.contents => {}
+                Ok(_) => drifted.push(format!(
+                    "{} differs from what the model renders",
+                    artifact.path
+                )),
+                Err(err) => drifted.push(format!("{}: {err}", artifact.path)),
+            }
+            continue;
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, artifact.contents.as_bytes())?;
+        println!("wrote {}", path.display());
+    }
+
+    if check {
+        if drifted.is_empty() {
+            println!("observability artifacts match the model");
+            return Ok(());
+        }
+        for issue in &drifted {
+            eprintln!("drift: {issue}");
+        }
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,67 @@
+# MatrixRaft observability
+
+Prometheus and Grafana, provisioned from the model in `src/metrics.rs`.
+
+```sh
+cargo run --example metrics_exporter -- 0.0.0.0:9464   # something to scrape
+docker compose -f observability/docker-compose.yml up  # Prometheus + Grafana
+```
+
+Grafana comes up on <http://localhost:3000> with the dashboard already loaded
+(anonymous admin, no login). Prometheus is on <http://localhost:9090>, with the
+alert rules loaded and evaluating.
+
+## What is here
+
+| Path | What it is |
+| --- | --- |
+| `grafana/dashboards/matrixraft-runtime-overview.json` | 55 panels, importable as-is |
+| `grafana/provisioning/datasources/prometheus.yaml` | points Grafana at Prometheus |
+| `grafana/provisioning/dashboards/matrixraft.yaml` | loads the dashboard on start |
+| `prometheus/prometheus.yml` | scrape config, 15s interval |
+| `prometheus/rules/matrixraft-alerts.yaml` | the 16 modelled alert rules |
+| `docker-compose.yml` | both services, already wired together |
+
+## These files are generated
+
+They are rendered from `matrixraft_grafana_dashboard()` and
+`matrixraft_alert_rules()`, not maintained beside them. Add a panel or an alert
+in `src/metrics.rs` and regenerate:
+
+```sh
+cargo run --example render_observability_artifacts
+cargo run --example render_observability_artifacts -- --check   # CI form
+```
+
+`tests/observability_artifacts.rs` fails if the checked-in files stop matching
+the model, so a panel added without regenerating is a test failure rather than a
+dashboard that quietly lacks it.
+
+The crate's own dashboard model is not importable into Grafana: its panels carry
+one `expr` each and no `gridPos`, `targets`, or datasource. That model is the
+right shape for the validation `metrics.rs` does against advertised metric
+names; it is the wrong shape for Grafana. The rendering in
+`src/observability_artifacts.rs` exists to bridge exactly that, which is why the
+dashboard is generated rather than serialised.
+
+## What the exporter does and does not serve
+
+The crate renders Prometheus text but does not serve it — every `*_prometheus`
+function takes a report and returns a `PrometheusMetricSet`, leaving exposition
+to the embedder. `examples/metrics_exporter` closes that gap so the stack has
+something to scrape, but it only serves what exists without a running cluster:
+the operator runbook, and the provisioning validation.
+
+**The per-node series the dashboard also plots — append and vote latency, peer
+queue depth, snapshot indices — come from a live node.** A real deployment
+should serve its own reports through the same functions. Those panels stay empty
+against the example exporter, and that is the exporter's limit rather than the
+dashboard being wrong.
+
+## Names here are an interface
+
+The metric names, the alert names, and the dashboard `uid`
+(`rustraft-runtime-overview`) are what existing scrapes, alert routes, and
+dashboard links already refer to. They are deliberately not renamed to match the
+crate's Rust identifiers — renaming them would break every consumer to make the
+strings look tidier.

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  grafana:
+    image: grafana/grafana:11.1.4
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards/matrixraft:ro

--- a/observability/grafana/dashboards/matrixraft-runtime-overview.json
+++ b/observability/grafana/dashboards/matrixraft-runtime-overview.json
@@ -1,0 +1,1846 @@
+{
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Cluster-level RustRaft readiness gauge.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_ready",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Raft Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 append RPC latency from RustRaft metrics.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rustraft_append_latency_ms_bucket[5m])))",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Append Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 vote RPC latency from RustRaft metrics.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rustraft_vote_latency_ms_bucket[5m])))",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Vote Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 pre-vote RPC latency from RustRaft metrics.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rustraft_pre_vote_latency_ms_bucket[5m])))",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Pre-Vote Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 read-index and lease-read latency.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rustraft_read_index_latency_ms_bucket[5m])))",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Index Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "p99 snapshot install latency.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rustraft_snapshot_install_latency_ms_bucket[5m])))",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Snapshot Install Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-peer append pipeline queue depth.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_peer_append_queue_depth",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Append Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-peer message reorder queue depth.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_peer_reorder_queue_depth",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Reorder Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Installed snapshot index by peer.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 9,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_peer_snapshot_installed_index",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Snapshot Installed Index",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "WAL segment count for retention and compaction tracking.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_wal_segment_count",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Segment Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Active blocker totals grouped by blocker label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (blocker) (rustraft_blocker_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Blockers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Fatal blocker totals grouped by blocker label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (blocker) (rustraft_fatal_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Fatal Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Structured RustRaft diagnostic log entries grouped by severity; follow inspect_error_diagnostics when errors appear.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 32
+      },
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (severity) (rustraft_diagnostic_log_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Diagnostic Log Entries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Structured RustRaft diagnostic log entries grouped by target, severity, and message for inspect_error_diagnostics.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 32
+      },
+      "id": 14,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (target, severity, message) (rustraft_diagnostic_log_entry_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Diagnostic Log Entry Detail",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Optimization readiness gauge; 1 means no critical hints. When it drops to 0, follow resolve_critical_optimization_hints.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "id": 15,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_optimization_ready",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Optimization Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Critical optimization hints exported by RustRaft status evidence; drive resolve_critical_optimization_hints before rollout.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 40
+      },
+      "id": 16,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_optimization_critical_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Optimization Critical Hints",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Warning optimization hints exported by RustRaft status evidence.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 40
+      },
+      "id": 17,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_optimization_warning_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Optimization Warning Hints",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Optimization hints grouped by hint, component, and severity.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 40
+      },
+      "id": 18,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (hint, component, severity) (rustraft_optimization_hint_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Optimization Hint Detail",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Optimization hints grouped by component and severity.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 48
+      },
+      "id": 19,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (component, severity) (rustraft_optimization_component_hint_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Optimization Component Hints",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Current operator triage status labeled by status and severity.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 48
+      },
+      "id": 20,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_status",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Operator Triage Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Diagnostic error count from the operator triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 48
+      },
+      "id": 21,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_diagnostic_error_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Diagnostic Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Diagnostic warning count from the operator triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 56
+      },
+      "id": 22,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_diagnostic_warning_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Diagnostic Warnings",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Critical optimization count from the operator triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 56
+      },
+      "id": 23,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_optimization_critical_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Critical Optimizations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Warning optimization count from the operator triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 56
+      },
+      "id": 24,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_optimization_warning_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Warning Optimizations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "First operator action selected by the triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 64
+      },
+      "id": 25,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_first_action",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage First Action",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Alert rule count from the operator triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 64
+      },
+      "id": 26,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_alert_rule_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Alert Rules",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Top diagnostic entry selected by the operator triage summary for inspect_error_diagnostics.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 64
+      },
+      "id": 27,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_top_diagnostic",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Top Diagnostic",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Top alert selected by the operator triage summary.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 72
+      },
+      "id": 28,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_top_alert",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Top Alert",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Top optimization hint selected by the operator triage summary for resolve_critical_optimization_hints.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 72
+      },
+      "id": 29,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_triage_top_optimization_hint",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Triage Top Optimization Hint",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Active operator runbook steps grouped by severity and target.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 72
+      },
+      "id": 30,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (severity, target) (rustraft_operator_runbook_step_total)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Runbook Steps",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Active operator runbook steps grouped by step, severity, and target.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 80
+      },
+      "id": 31,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (step, severity, target) (rustraft_operator_runbook_step_present)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Runbook Step Presence",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "First active operator runbook step selected for remediation.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 80
+      },
+      "id": 32,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_operator_runbook_first_step",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Runbook First Step",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Debug snapshot generation timestamp in Unix milliseconds.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 80
+      },
+      "id": 33,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_generated_at_unix_ms",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Generated At",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Debug snapshot age in milliseconds when metadata metrics are exported.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 88
+      },
+      "id": 34,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_age_ms",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Unix millisecond timestamp when the debug snapshot crosses the stale threshold; refresh the debug artifact before this deadline.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 88
+      },
+      "id": 35,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_stale_after_unix_ms",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Stale After",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Milliseconds remaining before RustRaftDebugSnapshotFreshnessLost can fire; RustRaftDebugSnapshotFreshnessLow warns below the low-fresh threshold and refresh_debug_snapshot expects this above rustraft_debug_snapshot_low_fresh_ms.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 88
+      },
+      "id": 36,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_remaining_fresh_ms",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Remaining Fresh",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Debug snapshot freshness; RustRaftDebugSnapshotFreshnessLost fires when this drops to 0.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 96
+      },
+      "id": 37,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_fresh",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Fresh",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support bundle validator readiness; 1 means bundle contract checks pass.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 96
+      },
+      "id": 38,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_bundle_validation_ready",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Bundle Validation Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total support bundle validation issues emitted by RustRaft tooling.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 96
+      },
+      "id": 39,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_bundle_validation_issue_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Bundle Validation Issues",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support bundle validation issues grouped by issue label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 104
+      },
+      "id": 40,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (issue) (rustraft_debug_bundle_validation_issue)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Bundle Issue Breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "First support bundle validation issue selected for operator triage.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 104
+      },
+      "id": 41,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_bundle_validation_first_issue",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Bundle First Issue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support envelope self-validation readiness; 1 means advertised artifacts and scrape payloads match the emitted bundle.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 104
+      },
+      "id": 42,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_bundle_validation_ready{artifact=\"support_envelope\"}",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope Validation Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total support envelope validation issues emitted by RustRaft tooling.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 112
+      },
+      "id": 43,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_bundle_validation_issue_total{artifact=\"support_envelope\"}",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope Validation Issues",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support envelope validation issues grouped by issue label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 112
+      },
+      "id": 44,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (issue) (rustraft_debug_bundle_validation_issue{artifact=\"support_envelope\"})",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope Issue Breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "First support envelope validation issue selected for operator triage.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 112
+      },
+      "id": 45,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_bundle_validation_first_issue{artifact=\"support_envelope\"}",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope First Issue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Observability provisioning validation readiness; 1 means dashboard and alert contracts match.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 120
+      },
+      "id": 46,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_observability_provisioning_validation_ready",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Provisioning Validation Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "First observability provisioning validation issue selected for operator triage.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 120
+      },
+      "id": 47,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_observability_provisioning_validation_first_issue",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Provisioning First Issue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total observability provisioning validation issues emitted by RustRaft tooling.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 120
+      },
+      "id": 48,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_observability_provisioning_validation_issue_total",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Provisioning Validation Issues",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Observability provisioning validation issues grouped by issue label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 128
+      },
+      "id": 49,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (issue) (rustraft_observability_provisioning_validation_issue)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Provisioning Issue Breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Configured freshness window for debug snapshots; stale and freshness alerts compare age against this threshold.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 128
+      },
+      "id": 50,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_max_age_ms",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Max Age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Configured runway threshold for RustRaftDebugSnapshotFreshnessLow before the freshness window expires.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 128
+      },
+      "id": 51,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_low_fresh_ms",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Low Fresh Threshold",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Debug snapshot early-warning freshness; 1 means remaining freshness is above rustraft_debug_snapshot_low_fresh_ms.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 136
+      },
+      "id": 52,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rustraft_debug_snapshot_low_fresh",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Debug Snapshot Low Fresh",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support envelope readiness grouped by debug snapshot freshness_status label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 136
+      },
+      "id": 53,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (freshness_status) (rustraft_debug_bundle_validation_ready{artifact=\"support_envelope\"})",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope Freshness Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support envelope readiness grouped by derived support_envelope_status label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 136
+      },
+      "id": 54,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (support_envelope_status) (rustraft_debug_bundle_validation_ready{artifact=\"support_envelope\"})",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Support envelope readiness grouped by derived support_envelope_severity label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bool"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 144
+      },
+      "id": 55,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (support_envelope_severity) (rustraft_debug_bundle_validation_ready{artifact=\"support_envelope\"})",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Envelope Severity",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "rustraft",
+    "raft",
+    "grafana"
+  ],
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "label": "Data source",
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "RustRaft Runtime Overview",
+  "uid": "rustraft-runtime-overview"
+}

--- a/observability/grafana/provisioning/dashboards/matrixraft.yaml
+++ b/observability/grafana/provisioning/dashboards/matrixraft.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: matrixraft
+    orgId: 1
+    folder: MatrixRaft
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/matrixraft
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources/prometheus.yaml
+++ b/observability/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: matrixraft-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+rule_files:
+  - /etc/prometheus/rules/matrixraft-alerts.yaml
+scrape_configs:
+  - job_name: matrixraft
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["host.docker.internal:9464"]

--- a/observability/prometheus/rules/matrixraft-alerts.yaml
+++ b/observability/prometheus/rules/matrixraft-alerts.yaml
@@ -1,0 +1,115 @@
+groups:
+  - name: matrixraft
+    rules:
+      - alert: RustRaftOptimizationNotReady
+        expr: "rustraft_optimization_ready == 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft optimization readiness is not passing; follow resolve_critical_optimization_hints."
+      - alert: RustRaftOptimizationCriticalHints
+        expr: "rustraft_optimization_critical_total > 0"
+        for: 5m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "RustRaft has critical optimization hints; follow resolve_critical_optimization_hints before rollout."
+      - alert: RustRaftOptimizationWarningHints
+        expr: "rustraft_optimization_warning_total > 0"
+        for: 10m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft has warning optimization hints to review before rollout."
+      - alert: RustRaftFatalEvents
+        expr: "rustraft_fatal_total > 0"
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "RustRaft fatal blocker events are present."
+      - alert: RustRaftDiagnosticErrors
+        expr: "rustraft_diagnostic_log_total{severity=\"error\"} > 0"
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "RustRaft diagnostic errors are present; follow inspect_error_diagnostics."
+      - alert: RustRaftBlockersPresent
+        expr: "rustraft_blocker_total > 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft readiness blockers are present."
+      - alert: RustRaftOperatorTriageWatch
+        expr: "rustraft_operator_triage_status{status=\"watch\"} > 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft operator triage is in watch status."
+      - alert: RustRaftOperatorTriageNeedsAttention
+        expr: "rustraft_operator_triage_status{status=\"needs_attention\"} > 0"
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "RustRaft operator triage needs attention."
+      - alert: RustRaftRunbookCriticalSteps
+        expr: "rustraft_operator_runbook_step_total{severity=\"critical\"} > 0"
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "RustRaft critical runbook steps are active; inspect operator_runbook_first_step for the first action."
+      - alert: RustRaftDebugBundleValidationFailed
+        expr: "rustraft_debug_bundle_validation_ready == 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft debug bundle validation is not passing."
+      - alert: RustRaftSupportEnvelopeValidationFailed
+        expr: "rustraft_debug_bundle_validation_ready{artifact=\"support_envelope\"} == 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft support envelope validation is not passing; inspect rustraft_debug_bundle_validation_first_issue{artifact=\"support_envelope\"} and rustraft_debug_bundle_validation_issue{artifact=\"support_envelope\"} for debug_snapshot_stale or debug_snapshot_low_fresh."
+      - alert: RustRaftSupportEnvelopeCritical
+        expr: "rustraft_debug_bundle_validation_ready{artifact=\"support_envelope\",support_envelope_severity=\"critical\"} == 0"
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "RustRaft support envelope is critical; inspect rustraft_debug_bundle_validation_first_issue{artifact=\"support_envelope\",support_envelope_severity=\"critical\"} and the support_envelope_status label."
+      - alert: RustRaftDebugSnapshotStale
+        expr: "rustraft_debug_snapshot_age_ms > rustraft_debug_snapshot_max_age_ms"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft debug snapshot metadata is older than the configured freshness window."
+      - alert: RustRaftDebugSnapshotFreshnessLow
+        expr: "rustraft_debug_snapshot_low_fresh == 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft debug snapshot has less than five minutes before the freshness window expires."
+      - alert: RustRaftDebugSnapshotFreshnessLost
+        expr: "rustraft_debug_snapshot_fresh == 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft debug snapshot freshness flag is not passing."
+      - alert: RustRaftObservabilityProvisioningValidationFailed
+        expr: "rustraft_observability_provisioning_validation_ready == 0"
+        for: 5m
+        labels:
+          severity: "warning"
+        annotations:
+          summary: "RustRaft observability provisioning validation is not passing."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub mod mailbox;
 pub mod membership;
 pub mod metrics;
 pub mod node;
+pub mod observability_artifacts;
 pub mod operational_evidence;
 pub mod pipeline;
 pub mod rate_limit;

--- a/src/observability_artifacts.rs
+++ b/src/observability_artifacts.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Deployable observability artifacts, rendered from the in-crate model.
+//!
+//! [`crate::matrixraft_grafana_dashboard`] describes the dashboard in a shape
+//! that suits validation: a flat list of panels, each with one expression. That
+//! shape is not what Grafana imports -- a Grafana panel needs a `gridPos`, a
+//! datasource, and its query under `targets`, none of which the model carries.
+//! So [`matrixraft_grafana_dashboard_import_json`] renders the model into the
+//! schema Grafana actually accepts, rather than the model being serialised
+//! directly and rejected at import.
+//!
+//! Everything here is derived from the model, never written alongside it, so a
+//! panel or an alert added in `metrics.rs` cannot go missing from what gets
+//! deployed. `tests/observability_artifacts.rs` asserts the checked-in files
+//! match what these functions render.
+
+use serde_json::json;
+
+use crate::metrics::{
+    matrixraft_alert_rules, matrixraft_grafana_dashboard, AlertRule, GrafanaDashboard,
+};
+
+/// One rendered file: where it belongs, and what goes in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservabilityArtifact {
+    pub path: String,
+    pub contents: String,
+}
+
+/// Panels are laid out three to a row on Grafana's 24-column grid.
+const PANEL_WIDTH: u32 = 8;
+const PANEL_HEIGHT: u32 = 8;
+const PANELS_PER_ROW: u32 = 3;
+
+/// The datasource variable the dashboard is parameterised on, so an import can
+/// pick a Prometheus without the JSON naming one.
+const DATASOURCE_VARIABLE: &str = "${DS_PROMETHEUS}";
+
+/// Quotes a scalar for YAML, escaping what a double-quoted scalar must escape.
+///
+/// Alert summaries are prose and contain apostrophes and colons, either of
+/// which turns an unquoted scalar into a parse error or a map.
+fn yaml_quoted(value: &str) -> String {
+    // Written with unicode escapes rather than literal backslashes so the
+    // intent stays readable: a backslash becomes two, a quote becomes
+    // backslash-quote, and the whole scalar is wrapped in quotes.
+    let escaped = value
+        .replace('\u{5c}', "\u{5c}\u{5c}")
+        .replace('\u{22}', "\u{5c}\u{22}");
+    format!("\u{22}{escaped}\u{22}")
+}
+
+/// Renders the dashboard model into the schema Grafana imports.
+pub fn matrixraft_grafana_dashboard_import_json() -> String {
+    let dashboard: GrafanaDashboard = matrixraft_grafana_dashboard();
+    let datasource = json!({ "type": "prometheus", "uid": DATASOURCE_VARIABLE });
+
+    let panels: Vec<_> = dashboard
+        .panels
+        .iter()
+        .enumerate()
+        .map(|(position, panel)| {
+            let position = position as u32;
+            json!({
+                "id": panel.id,
+                "title": panel.title,
+                "type": panel.panel_type,
+                "description": panel.description,
+                "datasource": datasource,
+                "gridPos": {
+                    "h": PANEL_HEIGHT,
+                    "w": PANEL_WIDTH,
+                    "x": (position % PANELS_PER_ROW) * PANEL_WIDTH,
+                    "y": (position / PANELS_PER_ROW) * PANEL_HEIGHT,
+                },
+                "fieldConfig": {
+                    "defaults": { "unit": panel.unit },
+                    "overrides": [],
+                },
+                "targets": [{
+                    "refId": "A",
+                    "expr": panel.expr,
+                    "datasource": datasource,
+                    "legendFormat": "__auto",
+                }],
+            })
+        })
+        .collect();
+
+    let rendered = json!({
+        "uid": dashboard.uid,
+        "title": dashboard.title,
+        "timezone": dashboard.timezone,
+        "schemaVersion": dashboard.schema_version,
+        "refresh": dashboard.refresh,
+        "tags": dashboard.tags,
+        "editable": true,
+        "time": { "from": "now-6h", "to": "now" },
+        "templating": {
+            "list": [{
+                "name": "DS_PROMETHEUS",
+                "label": "Data source",
+                "type": "datasource",
+                "query": "prometheus",
+                "hide": 0,
+                "refresh": 1,
+            }],
+        },
+        "panels": panels,
+    });
+
+    format!(
+        "{}\n",
+        serde_json::to_string_pretty(&rendered).expect("dashboard must serialize")
+    )
+}
+
+/// Renders the alert rules as a Prometheus rule file.
+pub fn matrixraft_prometheus_alert_rules_yaml() -> String {
+    let rules: Vec<AlertRule> = matrixraft_alert_rules();
+    let mut out = String::from("groups:\n  - name: matrixraft\n    rules:\n");
+    for rule in &rules {
+        out.push_str(&format!("      - alert: {}\n", rule.alert));
+        out.push_str(&format!("        expr: {}\n", yaml_quoted(&rule.expr)));
+        out.push_str(&format!("        for: {}\n", rule.duration));
+        out.push_str("        labels:\n");
+        out.push_str(&format!(
+            "          severity: {}\n",
+            yaml_quoted(&rule.severity)
+        ));
+        out.push_str("        annotations:\n");
+        out.push_str(&format!(
+            "          summary: {}\n",
+            yaml_quoted(&rule.summary)
+        ));
+    }
+    out
+}
+
+/// Where Prometheus looks for the node's metrics text.
+///
+/// The crate does not serve this itself -- it renders Prometheus text from
+/// `metrics.rs` and leaves exposing it to the embedder. `examples/metrics_exporter`
+/// is a runnable one, and is what this target points at.
+pub const DEFAULT_SCRAPE_TARGET: &str = "host.docker.internal:9464";
+
+/// Renders the Prometheus server configuration.
+pub fn matrixraft_prometheus_config_yaml() -> String {
+    format!(
+        "global:\n  \
+           scrape_interval: 15s\n  \
+           evaluation_interval: 15s\n\
+         rule_files:\n  \
+           - /etc/prometheus/rules/matrixraft-alerts.yaml\n\
+         scrape_configs:\n  \
+           - job_name: matrixraft\n    \
+               metrics_path: /metrics\n    \
+               static_configs:\n      \
+                 - targets: [{}]\n",
+        yaml_quoted(DEFAULT_SCRAPE_TARGET)
+    )
+}
+
+/// Renders the Grafana datasource provisioning file.
+pub fn matrixraft_grafana_datasource_provisioning_yaml() -> String {
+    "apiVersion: 1\n\
+     datasources:\n  \
+       - name: Prometheus\n    \
+           uid: matrixraft-prometheus\n    \
+           type: prometheus\n    \
+           access: proxy\n    \
+           url: http://prometheus:9090\n    \
+           isDefault: true\n"
+        .to_string()
+}
+
+/// Renders the Grafana dashboard provisioning file.
+pub fn matrixraft_grafana_dashboard_provisioning_yaml() -> String {
+    "apiVersion: 1\n\
+     providers:\n  \
+       - name: matrixraft\n    \
+           orgId: 1\n    \
+           folder: MatrixRaft\n    \
+           type: file\n    \
+           disableDeletion: false\n    \
+           updateIntervalSeconds: 30\n    \
+           allowUiUpdates: true\n    \
+           options:\n      \
+             path: /etc/grafana/provisioning/dashboards/matrixraft\n      \
+             foldersFromFilesStructure: false\n"
+        .to_string()
+}
+
+/// Renders a Compose file that brings up Prometheus and Grafana already
+/// provisioned with the dashboard and the alert rules.
+pub fn matrixraft_observability_compose_yaml() -> String {
+    "services:\n  \
+       prometheus:\n    \
+           image: prom/prometheus:v2.54.1\n    \
+           ports:\n      \
+             - \"9090:9090\"\n    \
+           volumes:\n      \
+             - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro\n      \
+             - ./prometheus/rules:/etc/prometheus/rules:ro\n    \
+           extra_hosts:\n      \
+             - \"host.docker.internal:host-gateway\"\n  \
+       grafana:\n    \
+           image: grafana/grafana:11.1.4\n    \
+           depends_on:\n      \
+             - prometheus\n    \
+           ports:\n      \
+             - \"3000:3000\"\n    \
+           environment:\n      \
+             GF_AUTH_ANONYMOUS_ENABLED: \"true\"\n      \
+             GF_AUTH_ANONYMOUS_ORG_ROLE: Admin\n    \
+           volumes:\n      \
+             - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro\n      \
+             - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro\n      \
+             - ./grafana/dashboards:/etc/grafana/provisioning/dashboards/matrixraft:ro\n"
+        .to_string()
+}
+
+/// Every artifact, with the path it belongs at under the observability root.
+///
+/// One list, used by the renderer that writes the files and by the test that
+/// asserts the checked-in copies still match. Adding an artifact here is enough
+/// to have it written and guarded.
+pub fn matrixraft_observability_artifacts() -> Vec<ObservabilityArtifact> {
+    vec![
+        ObservabilityArtifact {
+            path: "grafana/dashboards/matrixraft-runtime-overview.json".to_string(),
+            contents: matrixraft_grafana_dashboard_import_json(),
+        },
+        ObservabilityArtifact {
+            path: "grafana/provisioning/datasources/prometheus.yaml".to_string(),
+            contents: matrixraft_grafana_datasource_provisioning_yaml(),
+        },
+        ObservabilityArtifact {
+            path: "grafana/provisioning/dashboards/matrixraft.yaml".to_string(),
+            contents: matrixraft_grafana_dashboard_provisioning_yaml(),
+        },
+        ObservabilityArtifact {
+            path: "prometheus/prometheus.yml".to_string(),
+            contents: matrixraft_prometheus_config_yaml(),
+        },
+        ObservabilityArtifact {
+            path: "prometheus/rules/matrixraft-alerts.yaml".to_string(),
+            contents: matrixraft_prometheus_alert_rules_yaml(),
+        },
+        ObservabilityArtifact {
+            path: "docker-compose.yml".to_string(),
+            contents: matrixraft_observability_compose_yaml(),
+        },
+    ]
+}

--- a/tests/observability_artifacts.rs
+++ b/tests/observability_artifacts.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! The checked-in observability artifacts have to stay what the model renders.
+//!
+//! `metrics.rs` is the source of the panels and the alert rules. If someone
+//! adds a panel there and does not regenerate, the dashboard that gets deployed
+//! silently lacks it -- these tests are what turns that into a failure.
+
+use std::path::Path;
+
+use matrixraft::matrixraft_alert_rules;
+use matrixraft::matrixraft_grafana_dashboard;
+use matrixraft::observability_artifacts::{
+    matrixraft_grafana_dashboard_import_json, matrixraft_observability_artifacts,
+};
+
+#[test]
+fn the_checked_in_artifacts_match_what_the_model_renders() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("observability");
+    for artifact in matrixraft_observability_artifacts() {
+        let path = root.join(&artifact.path);
+        let found = std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("{} is missing: {err}", artifact.path));
+        assert_eq!(
+            found, artifact.contents,
+            "{} drifted from the model; run `cargo run --example render_observability_artifacts`",
+            artifact.path
+        );
+    }
+}
+
+/// The model's own JSON is not importable -- it has no `gridPos`, no
+/// `targets`, and no datasource. This asserts the rendered form has them for
+/// every panel, since a dashboard missing them fails at import rather than
+/// looking wrong.
+#[test]
+fn every_rendered_panel_carries_what_grafana_needs_to_import_it() {
+    let rendered: serde_json::Value =
+        serde_json::from_str(&matrixraft_grafana_dashboard_import_json()).expect("valid json");
+    let panels = rendered["panels"].as_array().expect("panels array");
+
+    assert_eq!(
+        panels.len(),
+        matrixraft_grafana_dashboard().panels.len(),
+        "every modelled panel has to reach the dashboard"
+    );
+    assert!(!panels.is_empty(), "a dashboard with no panels is not one");
+
+    for panel in panels {
+        let title = panel["title"].as_str().unwrap_or("<untitled>");
+        assert!(
+            panel["gridPos"]["w"].is_number() && panel["gridPos"]["h"].is_number(),
+            "panel {title} has no gridPos, so Grafana would stack it at the origin"
+        );
+        let targets = panel["targets"].as_array().expect("targets array");
+        assert_eq!(targets.len(), 1, "panel {title} should carry its one query");
+        let expr = targets[0]["expr"].as_str().unwrap_or_default();
+        assert!(
+            !expr.is_empty(),
+            "panel {title} has an empty query and would draw nothing"
+        );
+        assert_eq!(
+            panel["datasource"]["type"], "prometheus",
+            "panel {title} must name a Prometheus datasource"
+        );
+    }
+}
+
+#[test]
+fn every_alert_rule_reaches_the_prometheus_rule_file() {
+    let rendered = matrixraft_observability_artifacts()
+        .into_iter()
+        .find(|artifact| artifact.path.ends_with("matrixraft-alerts.yaml"))
+        .expect("the alert rule file is rendered");
+    let rules = matrixraft_alert_rules();
+    assert!(!rules.is_empty());
+    for rule in &rules {
+        assert!(
+            rendered
+                .contents
+                .contains(&format!("- alert: {}", rule.alert)),
+            "{} is modelled but missing from the rule file",
+            rule.alert
+        );
+        // The expression is a quoted YAML scalar, so a matcher like
+        // severity="error" is stored escaped. Comparing against the raw
+        // expression would fail on exactly the rules that have label
+        // matchers, so this asserts the escaped scalar the file must carry.
+        let quoted = rule
+            .expr
+            .replace('\u{5c}', "\u{5c}\u{5c}")
+            .replace('\u{22}', "\u{5c}\u{22}");
+        assert!(
+            rendered
+                .contents
+                .contains(&format!("expr: \u{22}{quoted}\u{22}")),
+            "{} is in the rule file without its expression",
+            rule.alert
+        );
+    }
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#36`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of #27–#35.

The crate already modelled a Grafana dashboard and 16 alert rules in `src/metrics.rs`, and `matrixraft_grafana_dashboard_json` serialised that model directly. **Grafana cannot import it.** A panel in the model carries one `expr` and no `gridPos`, no `targets`, and no datasource — which is where Grafana reads a query from. So the dashboard existed as a contract to validate against, and as nothing an operator could load.

There was also nothing to scrape. Every `*_prometheus` function takes a report and returns a `PrometheusMetricSet`, and the only `TcpListener` in the crate is the Raft transport.

## What this adds

| Path | What it is |
| --- | --- |
| `observability/grafana/dashboards/matrixraft-runtime-overview.json` | **55 panels**, importable as-is |
| `observability/prometheus/rules/matrixraft-alerts.yaml` | the **16** modelled alert rules |
| `observability/prometheus/prometheus.yml` | scrape config, 15s |
| `observability/grafana/provisioning/…` | datasource + dashboard auto-load |
| `observability/docker-compose.yml` | Prometheus + Grafana, pre-wired |
| `examples/metrics_exporter` | an HTTP endpoint, no new dependency |

```sh
cargo run --example metrics_exporter -- 0.0.0.0:9464
docker compose -f observability/docker-compose.yml up
```

## Generated, not maintained alongside

`matrixraft_observability_artifacts()` is one list, used by `examples/render_observability_artifacts` to write the files and by `tests/observability_artifacts.rs` to assert the checked-in copies still match. A panel added to `metrics.rs` without regenerating is a **test failure**, not a dashboard that quietly lacks it.

`--check` is the CI form and passes today.

## The exporter's limit, stated

It serves what exists without a running cluster — the operator runbook and the provisioning validation, **15 series** across 5 metric families, verified over HTTP with the right `text/plain; version=0.0.4` content type.

**The latency and queue-depth panels need a live node's reports and stay empty against it.** That is the exporter's limit rather than the dashboard being wrong, and `observability/README.md` says so rather than leaving someone to discover it.

## The escaping is the part worth reviewing

An alert expression like `rustraft_diagnostic_log_total{severity="error"} > 0` has to become an escaped YAML scalar. My first version of `every_alert_rule_reaches_the_prometheus_rule_file` compared against the raw expression — it passed for the rules without label matchers and failed for `RustRaftDiagnosticErrors`, which is exactly the rule that has one. The rendered file was right and the assertion was naive; it now compares the escaped scalar the file must carry.

## Names left alone

Metric names, alert names, and the dashboard uid `rustraft-runtime-overview` are what existing scrapes, alert routes, and dashboard links already refer to. Renaming them to match the crate's Rust identifiers would break every consumer to tidy strings.

## Checks

527 tests pass (524 + 3 added here). `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean, and the artifacts re-verified with `--check` after formatting. Repository CI is still disabled by the Actions billing failure.

