### PR TITLE
Keep RPC connections open, and stop serving them on the accept thread

### DIFF
--- a/src/facade/transport_runtime.rs
+++ b/src/facade/transport_runtime.rs
@@ -376,11 +376,63 @@ pub enum TcpRaftTransportResponse {
 #[derive(Debug, Clone, Default)]
 pub struct TcpRaftTransport {
     peers: BTreeMap<NodeId, String>,
+    /// Connections kept open per peer, so an RPC does not pay a TCP handshake.
+    ///
+    /// Shared across clones on purpose: a cloned transport talks to the same
+    /// peers, and a per-clone pool would only multiply idle sockets. The reader
+    /// is pooled rather than the raw stream so that anything a read buffered
+    /// stays with its connection instead of being dropped.
+    idle: Arc<Mutex<BTreeMap<NodeId, Vec<BufReader<TcpStream>>>>>,
 }
 
+/// Enough to keep a leader's concurrent RPCs to one follower off the handshake
+/// path, without holding sockets open for a peer that has gone quiet.
+const MAX_IDLE_CONNECTIONS_PER_PEER: usize = 4;
+
 impl TcpRaftTransport {
+    fn take_idle(&self, target: NodeId) -> Option<BufReader<TcpStream>> {
+        self.idle.lock().ok()?.get_mut(&target)?.pop()
+    }
+
+    fn store_idle(&self, target: NodeId, connection: BufReader<TcpStream>) {
+        if let Ok(mut idle) = self.idle.lock() {
+            let pooled = idle.entry(target).or_default();
+            if pooled.len() < MAX_IDLE_CONNECTIONS_PER_PEER {
+                pooled.push(connection);
+            }
+        }
+    }
+
+    /// Sends one framed request and reads one framed response.
+    ///
+    /// Hands the connection back so a successful exchange can return it to the
+    /// pool. A failed one drops it, which is what closes a broken socket.
+    fn exchange(
+        &self,
+        mut connection: BufReader<TcpStream>,
+        encoded: &[u8],
+    ) -> Result<(String, BufReader<TcpStream>), RaftError> {
+        connection
+            .get_mut()
+            .write_all(encoded)
+            .map_err(|err| RaftError::Transport(format!("failed to write raft RPC: {err}")))?;
+        let mut response = String::new();
+        connection
+            .read_line(&mut response)
+            .map_err(|err| RaftError::Transport(format!("failed to read raft RPC: {err}")))?;
+        if response.is_empty() {
+            return Err(RaftError::Transport(
+                "raft RPC connection closed before a response".to_string(),
+            ));
+        }
+        Ok((response, connection))
+    }
+
     pub fn new(peers: BTreeMap<NodeId, String>) -> Self {
-        Self { peers }
+        Self {
+            peers,
+            idle: Arc::default(),
+        }
     }
 
     pub fn set_peer_addr(&mut self, node_id: NodeId, addr: impl Into<String>) {
@@ -395,26 +447,38 @@ impl TcpRaftTransport {
         let addr = self.peers.get(&target).ok_or_else(|| {
             RaftError::Transport(format!("raft transport target {target} has no address"))
         })?;
-        let mut stream = TcpStream::connect(addr)
-            .map_err(|err| RaftError::Transport(format!("failed to connect to {addr}: {err}")))?;
-        // Raft RPCs are small request/response exchanges, which is the shape
-        // Nagle delays. Without this the framing newline below can sit in the
-        // sender's buffer waiting for an ACK the peer will not send until it
-        // has the newline -- the classic write/write/read stall.
-        let _ = stream.set_nodelay(true);
         let mut encoded = serde_json::to_vec(&request)
             .map_err(|err| RaftError::Transport(format!("failed to encode raft RPC: {err}")))?;
         // One write, not a body followed by a one-byte newline: the peer reads
         // a line, so splitting them puts a round trip between the request and
         // the peer being able to see it.
         encoded.push(b'\n');
-        stream
-            .write_all(&encoded)
-            .map_err(|err| RaftError::Transport(format!("failed to write raft RPC: {err}")))?;
-        let mut response = String::new();
-        BufReader::new(stream)
-            .read_line(&mut response)
-            .map_err(|err| RaftError::Transport(format!("failed to read raft RPC: {err}")))?;
+
+        // A pooled connection can have been closed by the peer while it sat
+        // idle, and there is no way to learn that but to use it. So a failure
+        // on a *pooled* connection is retried once on a fresh one, while a
+        // failure on a fresh connection is returned. The retry is sound because
+        // it only happens where the peer had closed the socket, and because
+        // these are the RPCs Raft already re-sends: an AppendEntries or a Vote
+        // at the same term from the same sender lands the same way twice.
+        if let Some(connection) = self.take_idle(target) {
+            if let Ok((response, connection)) = self.exchange(connection, &encoded) {
+                self.store_idle(target, connection);
+                return serde_json::from_str(&response).map_err(|err| {
+                    RaftError::Transport(format!("failed to decode raft RPC: {err}"))
+                });
+            }
+        }
+
+        let stream = TcpStream::connect(addr)
+            .map_err(|err| RaftError::Transport(format!("failed to connect to {addr}: {err}")))?;
+        // Raft RPCs are small request/response exchanges, which is the shape
+        // Nagle delays. Without this the framing newline below can sit in the
+        // sender's buffer waiting for an ACK the peer will not send until it
+        // has the newline -- the classic write/write/read stall.
+        let _ = stream.set_nodelay(true);
+        let (response, connection) = self.exchange(BufReader::new(stream), &encoded)?;
+        self.store_idle(target, connection);
         serde_json::from_str(&response)
             .map_err(|err| RaftError::Transport(format!("failed to decode raft RPC: {err}")))
     }
@@ -562,7 +626,29 @@ impl TcpRaftTransportServer {
                                 break;
                             }
                             let _ = stream.set_nodelay(true);
-                            let _ = handle_tcp_raft_stream(stream, handler.as_ref());
+                            // A connection is served on its own thread now. It
+                            // used to be served inline here, so one peer's RPC
+                            // blocked every other peer's for its whole round
+                            // trip -- and with connections kept alive that
+                            // would have been a stall for as long as the
+                            // connection lived rather than for one exchange.
+                            let conn_handler = Arc::clone(&handler);
+                            let conn_shutdown = Arc::clone(&worker_shutdown);
+                            let spawned = thread::Builder::new()
+                                .name("rustraft-tcp-conn".to_string())
+                                .spawn(move || {
+                                    let _ = serve_tcp_raft_connection(
+                                        stream,
+                                        conn_handler.as_ref(),
+                                        &conn_shutdown,
+                                    );
+                                });
+                            if spawned.is_err() {
+                                // Out of threads. Drop the connection rather
+                                // than serve it here and stall the listener;
+                                // the peer sees a closed socket and retries.
+                                continue;
+                            }
                         }
                         Err(_) => break,
                     }
@@ -600,31 +686,59 @@ impl Drop for TcpRaftTransportServer {
     }
 }
 
-fn handle_tcp_raft_stream<T>(stream: TcpStream, handler: &T) -> Result<(), RaftError>
+/// Serves one connection until the peer closes it.
+///
+/// This used to serve exactly one request and hang up, which made every RPC pay
+/// a TCP handshake. The loop is what lets a caller keep the connection.
+fn serve_tcp_raft_connection<T>(
+    stream: TcpStream,
+    handler: &T,
+    shutdown: &AtomicBool,
+) -> Result<(), RaftError>
 where
     T: Transport + ?Sized,
 {
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
-    reader
-        .read_line(&mut line)
-        .map_err(|err| RaftError::Transport(format!("failed to read raft TCP request: {err}")))?;
-    if line.trim().is_empty() {
-        return Ok(());
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        line.clear();
+        let read = reader.read_line(&mut line).map_err(|err| {
+            RaftError::Transport(format!("failed to read raft TCP request: {err}"))
+        })?;
+        // A zero-length read is the peer closing, which is the ordinary way a
+        // kept-alive connection ends rather than a failure.
+        if read == 0 {
+            return Ok(());
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Re-checked after the read, not only before it. A thread parked in
+        // `read_line` when shutdown was signalled would otherwise wake on the
+        // next request and serve it, so a kept-alive connection could be served
+        // by a server that had already been shut down.
+        if shutdown.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        let request: TcpRaftTransportRequest = serde_json::from_str(&line).map_err(|err| {
+            RaftError::Transport(format!("failed to decode raft TCP request: {err}"))
+        })?;
+        require_transport_validation(matrixraft_validate_tcp_transport_request(&request))?;
+        let response = handle_tcp_raft_request(request, handler);
+        let mut encoded = serde_json::to_vec(&response).map_err(|err| {
+            RaftError::Transport(format!("failed to encode raft TCP response: {err}"))
+        })?;
+        // One write, for the same reason the request side does it: the caller
+        // is reading a line, so a separate one-byte newline puts a round trip
+        // between the response and the caller being able to see it.
+        encoded.push(b'\n');
+        reader.get_mut().write_all(&encoded).map_err(|err| {
+            RaftError::Transport(format!("failed to write raft TCP response: {err}"))
+        })?;
     }
-    let request: TcpRaftTransportRequest = serde_json::from_str(&line)
-        .map_err(|err| RaftError::Transport(format!("failed to decode raft TCP request: {err}")))?;
-    require_transport_validation(matrixraft_validate_tcp_transport_request(&request))?;
-    let response = handle_tcp_raft_request(request, handler);
-    let encoded = serde_json::to_vec(&response).map_err(|err| {
-        RaftError::Transport(format!("failed to encode raft TCP response: {err}"))
-    })?;
-    let stream = reader.get_mut();
-    stream
-        .write_all(&encoded)
-        .and_then(|_| stream.write_all(b"\n"))
-        .map_err(|err| RaftError::Transport(format!("failed to write raft TCP response: {err}")))?;
-    Ok(())
 }
 
 fn handle_tcp_raft_request<T>(

--- a/tests/transport_contract.rs
+++ b/tests/transport_contract.rs
@@ -793,3 +793,110 @@ fn tcp_transport_batches_mixed_rpc_requests() {
 
     server.shutdown().expect("shutdown server");
 }
+
+/// Builds a cluster and a TCP server for it, on an ephemeral loopback port.
+fn tcp_server_for_a_three_node_cluster() -> TcpRaftTransportServer {
+    let cluster = Arc::new(Mutex::new(
+        RaftCluster::new(
+            3,
+            Default::default(),
+            vec![
+                peer(1, ReplicaRole::Voter),
+                peer(2, ReplicaRole::Voter),
+                peer(3, ReplicaRole::Voter),
+            ],
+        )
+        .expect("cluster"),
+    ));
+    cluster.lock().expect("lock").start().expect("start");
+    let handler = Arc::new(ClusterRaftTransport::new(Arc::clone(&cluster)));
+    TcpRaftTransportServer::start("127.0.0.1:0", handler).expect("start tcp server")
+}
+
+/// Always index 1: with `prev_log_id: None` the request has to start the log,
+/// and anything else fails contiguity validation before the transport is even
+/// exercised. Re-sending the same append is fine -- it is idempotent, and what
+/// is under test here is the connection rather than the log.
+fn append_one(transport: &TcpRaftTransport) -> Result<AppendEntriesResponse, RaftError> {
+    transport.append_entries(
+        2,
+        AppendEntriesRequest {
+            group_id: 3,
+            term: 1,
+            leader_id: 1,
+            prev_log_id: None,
+            entries: vec![LogEntry {
+                log_id: LogId { term: 1, index: 1 },
+                payload: b"x".to_vec(),
+                is_command: true,
+            }],
+            leader_commit: 1,
+            lease_epoch: 0,
+        },
+    )
+}
+
+/// Connections are kept open, so a caller can hand back one the peer has since
+/// closed. There is no way to learn that but to use it, so the failure has to
+/// be retried on a fresh connection rather than surfaced.
+#[test]
+fn a_pooled_connection_the_peer_closed_is_retried_on_a_fresh_one() {
+    let mut first = tcp_server_for_a_three_node_cluster();
+    let addr = first.addr().to_string();
+
+    let mut peers = BTreeMap::new();
+    peers.insert(2, addr.clone());
+    let transport = TcpRaftTransport::new(peers);
+
+    append_one(&transport).expect("the first append opens and pools a connection");
+
+    // Take the peer away, then bring it back at the same address. The pooled
+    // connection is now dead, and the caller has no way to know.
+    first.shutdown().expect("shut the first server down");
+    let cluster = Arc::new(Mutex::new(
+        RaftCluster::new(
+            3,
+            Default::default(),
+            vec![
+                peer(1, ReplicaRole::Voter),
+                peer(2, ReplicaRole::Voter),
+                peer(3, ReplicaRole::Voter),
+            ],
+        )
+        .expect("cluster"),
+    ));
+    cluster.lock().expect("lock").start().expect("start");
+    let handler = Arc::new(ClusterRaftTransport::new(Arc::clone(&cluster)));
+    let mut second =
+        TcpRaftTransportServer::start(addr.as_str(), handler).expect("rebind the same address");
+
+    append_one(&transport).expect("a dead pooled connection must not fail the RPC");
+    second.shutdown().expect("shut the second server down");
+}
+
+/// The listener used to serve each connection inline, so one peer's round trip
+/// blocked every other peer's. With connections kept open that would have been
+/// a stall for as long as the connection lived, so this covers the concurrency
+/// the reuse depends on.
+#[test]
+fn concurrent_callers_are_all_served() {
+    let mut server = tcp_server_for_a_three_node_cluster();
+    let mut peers = BTreeMap::new();
+    peers.insert(2, server.addr().to_string());
+    let transport = Arc::new(TcpRaftTransport::new(peers));
+
+    let workers: Vec<_> = (0..6)
+        .map(|_worker| {
+            let transport = Arc::clone(&transport);
+            std::thread::spawn(move || {
+                for _round in 0..10 {
+                    append_one(&transport).expect("every concurrent RPC has to be served");
+                }
+            })
+        })
+        .collect();
+    for worker in workers {
+        worker.join().expect("no worker panics");
+    }
+    server.shutdown().expect("shutdown");
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#37`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #31**, which removed the poll interval and the Nagle stall. Review and merge that first.

Every Raft RPC opened a TCP connection, used it once, and hung up — a handshake in front of each one. The server made it worse: a connection was served **inline on the accept thread**, so one peer's round trip blocked every other peer's.

These have to change together. Keeping connections open while they are served inline would turn a per-exchange stall into one lasting as long as the connection — worse than what it replaces.

## Measured

`examples/rpc_latency`, 400 RPCs of 256 bytes per thread, two alternating rounds, every run `ok=N/N`.

| threads | before p50 | after p50 | |
| ---: | --- | --- | --- |
| 1 | 218.7 / 230.9 µs | **68.3 / 70.8 µs** | ~3.2× |
| 8 | 1353.4 / 1092.6 µs | **105.0 / 97.1 µs** | ~12× |

**The scaling matters more than the medians.** p50 used to rise **6.2×** going from one thread to eight; it now rises **1.5×**. That is the accept thread no longer serialising every peer.

Both sides were built once and the binaries kept, so no rebuild sat inside the measurement, and each branch's tree was asserted clean before running — after the A/B on #35 that silently measured the same code twice.

## Retry semantics

Connections are pooled per peer, four at most. The `BufReader` is pooled rather than the raw stream, so anything a read buffered stays with its connection.

A pooled connection can have been closed by the peer while it sat idle, and there is no way to learn that but to use it. So a failure on a **pooled** connection is retried once on a fresh one; a failure on a **fresh** connection is returned. The retry is sound because it only happens where the peer had closed the socket, and because these are the RPCs Raft already re-sends — an AppendEntries or a Vote at the same term from the same sender lands the same way twice.

## A defect this introduced, found by distrusting its own test

`a_pooled_connection_the_peer_closed_is_retried_on_a_fresh_one` **passed with the retry deleted**. So it proved nothing, and I only knew because I checked rather than taking green as evidence.

The cause was real. A connection thread parked in `read_line` when shutdown was signalled woke on the next request and served it, because the shutdown flag was checked only *before* the read. **A kept-alive connection could be served by a server that had already been shut down** — a regression this PR would have introduced, invisible behind a passing test.

The flag is checked after the read as well now. With that fixed the test fails without the retry (`connection closed before a response`), which is what makes it a guard.

`concurrent_callers_are_all_served` covers the concurrency the reuse depends on: six threads, ten RPCs each, all served.

## Checks

526 tests pass (524 + 2 added here). `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure.

