### PR TITLE
Let a sealed WAL segment release its records

### DIFF
--- a/examples/wal_record_footprint.rs
+++ b/examples/wal_record_footprint.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Where the memory of a retained WAL record actually goes.
+//!
+//! Segment rolls no longer retain the whole log, so what a record costs is now
+//! its own fixed overhead rather than a copy of everything before it. This
+//! attributes that overhead field by field, by walking the retained records and
+//! summing capacities, so the answer is a count rather than an inference from
+//! resident memory.
+//!
+//! Resident is reported alongside, because the gap between the two is the
+//! allocator's, and it is worth knowing which of the two a change would move.
+
+use matrixraft::{
+    ApplySnapshotFence, HardState, LogEntry, LogId, Membership, PersistentRaftWal,
+    PersistentRaftWalOptions, RaftError, WalRecord,
+};
+
+const PAYLOAD_BYTES: usize = 256;
+
+fn rss_bytes() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            if let Ok(kb) = rest.trim().trim_end_matches(" kB").trim().parse::<u64>() {
+                return kb * 1024;
+            }
+        }
+    }
+    0
+}
+
+#[derive(Default)]
+struct Footprint {
+    records: usize,
+    record_structs: usize,
+    membership_heap: usize,
+    checksum_heap: usize,
+    entry_vec_heap: usize,
+    payload_heap: usize,
+}
+
+impl Footprint {
+    fn add(&mut self, record: &WalRecord) {
+        self.records += 1;
+        self.record_structs += std::mem::size_of::<WalRecord>();
+        self.membership_heap += (record.membership.voters.capacity()
+            + record.membership.learners.capacity()
+            + record.membership.witnesses.capacity())
+            * std::mem::size_of::<u64>();
+        self.checksum_heap += record.checksum.capacity();
+        self.entry_vec_heap += record.entries.capacity() * std::mem::size_of::<LogEntry>();
+        self.payload_heap += record
+            .entries
+            .iter()
+            .map(|entry| entry.payload.capacity())
+            .sum::<usize>();
+    }
+
+    fn total(&self) -> usize {
+        self.record_structs
+            + self.membership_heap
+            + self.checksum_heap
+            + self.entry_vec_heap
+            + self.payload_heap
+    }
+
+    fn report(&self, rss_growth: u64) {
+        let per = |bytes: usize| bytes as f64 / self.records.max(1) as f64;
+        println!(
+            "records_in_memory={} payload_bytes={PAYLOAD_BYTES}",
+            self.records
+        );
+        println!(
+            "  {:<22} {:>12} {:>10}",
+            "field", "total bytes", "per record"
+        );
+        for (name, bytes) in [
+            ("WalRecord struct", self.record_structs),
+            ("membership vecs", self.membership_heap),
+            ("checksum string", self.checksum_heap),
+            ("entries vec", self.entry_vec_heap),
+            ("payloads", self.payload_heap),
+        ] {
+            println!("  {name:<22} {bytes:>12} {:>10.1}", per(bytes));
+        }
+        println!(
+            "  {:<22} {:>12} {:>10.1}",
+            "counted total",
+            self.total(),
+            per(self.total())
+        );
+        println!(
+            "  {:<22} {:>12} {:>10.1}",
+            "resident growth",
+            rss_growth,
+            rss_growth as f64 / self.records.max(1) as f64
+        );
+        let useful = self.payload_heap as f64 / self.total().max(1) as f64 * 100.0;
+        println!("  payload is {useful:.1}% of what is counted");
+    }
+}
+
+fn record(index: u64) -> WalRecord {
+    WalRecord {
+        group_id: 9,
+        node_id: 1,
+        hard_state: HardState {
+            current_term: 3,
+            voted_for: Some(1),
+            committed: Some(LogId { term: 3, index }),
+        },
+        membership: Membership {
+            group_id: 9,
+            voters: vec![1, 2, 3],
+            learners: Vec::new(),
+            witnesses: Vec::new(),
+            epoch: 3,
+        },
+        entries: vec![LogEntry {
+            log_id: LogId { term: 3, index },
+            payload: vec![7u8; PAYLOAD_BYTES],
+            is_command: true,
+        }],
+        entries_are_delta: false,
+        installed_snapshot: None,
+        apply_snapshot_fence: ApplySnapshotFence {
+            applied_index: index,
+            commit_index: index,
+            installed_snapshot_index: 0,
+            first_retained_log_index: 1,
+        },
+        checksum: String::new(),
+    }
+}
+
+fn main() -> Result<(), RaftError> {
+    let appends: u64 = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(20_000);
+    let per_segment: usize = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(10_000);
+    let dir = std::env::temp_dir().join(format!("mr-footprint-{appends}-{per_segment}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create dir");
+
+    let mut options = PersistentRaftWalOptions::new(&dir);
+    options.fsync_on_append = false;
+    options.min_keep_segments = usize::MAX;
+    options.max_records_per_segment = per_segment;
+    let mut wal = PersistentRaftWal::open(options)?;
+
+    let rss_before = rss_bytes();
+    for index in 1..=appends {
+        wal.append(record(index))?;
+    }
+    let rss_growth = rss_bytes().saturating_sub(rss_before);
+
+    println!(
+        "appends={appends} per_segment={per_segment} segments={}",
+        wal.segments().len()
+    );
+    let mut footprint = Footprint::default();
+    for segment in wal.segments() {
+        for record in &segment.records {
+            footprint.add(record);
+        }
+    }
+    footprint.report(rss_growth);
+
+    drop(wal);
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}

--- a/examples/wal_type_sizes.rs
+++ b/examples/wal_type_sizes.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! What each field of a `WalRecord` costs before any payload is stored.
+
+use matrixraft::{
+    ApplySnapshotFence, HardState, LogEntry, LogId, Membership, SnapshotMetadata, WalRecord,
+    WalSegment,
+};
+
+fn main() {
+    let rows: [(&str, usize); 9] = [
+        ("WalRecord (whole)", std::mem::size_of::<WalRecord>()),
+        ("  HardState", std::mem::size_of::<HardState>()),
+        ("  Membership", std::mem::size_of::<Membership>()),
+        (
+            "  Option<SnapshotMetadata>",
+            std::mem::size_of::<Option<SnapshotMetadata>>(),
+        ),
+        (
+            "  SnapshotMetadata",
+            std::mem::size_of::<SnapshotMetadata>(),
+        ),
+        (
+            "  ApplySnapshotFence",
+            std::mem::size_of::<ApplySnapshotFence>(),
+        ),
+        ("  Vec<LogEntry>", std::mem::size_of::<Vec<LogEntry>>()),
+        ("LogEntry", std::mem::size_of::<LogEntry>()),
+        ("WalSegment", std::mem::size_of::<WalSegment>()),
+    ];
+    for (name, size) in rows {
+        println!("{name:<28} {size:>5} bytes");
+    }
+    println!();
+    println!(
+        "Option<Box<SnapshotMetadata>> would be {} bytes instead of {}",
+        std::mem::size_of::<Option<Box<SnapshotMetadata>>>(),
+        std::mem::size_of::<Option<SnapshotMetadata>>()
+    );
+    println!("LogId {} bytes", std::mem::size_of::<LogId>());
+}

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -60,6 +60,7 @@ impl LocalRaftWal {
                 first_index: 0,
                 last_index: 0,
                 records: Vec::new(),
+                record_count: 0,
                 sealed: false,
             }],
             next_segment_id: 1,
@@ -82,6 +83,7 @@ impl LocalRaftWal {
                 first_index: 0,
                 last_index: 0,
                 records: Vec::new(),
+                record_count: 0,
                 sealed: false,
             });
             self.next_segment_id += 1;
@@ -104,6 +106,7 @@ impl LocalRaftWal {
         }
         segment.last_index = record_index;
         segment.records.push(record);
+        segment.record_count = segment.records.len() as u64;
         Ok(checksum)
     }
 
@@ -129,7 +132,7 @@ impl LocalRaftWal {
                 segment_id: segment.segment_id,
                 first_log_index: segment.first_index,
                 last_log_index: segment.last_index,
-                record_count: segment.records.len() as u64,
+                record_count: segment.record_count,
                 sealed: segment.sealed,
                 bytes: 0,
             })
@@ -257,6 +260,7 @@ impl PersistentRaftWal {
                 first_index: 0,
                 last_index: 0,
                 records: Vec::new(),
+                record_count: 0,
                 sealed: false,
             });
             write_wal_segment_file(&options.dir, &segments[0])?;
@@ -287,6 +291,9 @@ impl PersistentRaftWal {
             active_covered: None,
         };
         wal.active_covered = wal.covered_from_segments();
+        // Coverage has been folded, so the sealed segments have served their
+        // purpose in memory.
+        wal.release_sealed_segment_records();
         Ok(wal)
     }
 
@@ -337,12 +344,47 @@ impl PersistentRaftWal {
     /// This folds every segment rather than only the active one: a segment's
     /// first record is now a delta against the segment before it, so the active
     /// segment on its own no longer describes the whole log.
+    /// Reads back a segment's records.
+    ///
+    /// A sealed segment releases its records once they are on disk, so anything
+    /// that needs them -- compaction, or a caller asking for the whole log --
+    /// reads them from the file that already holds them.
+    fn segment_records(&self, segment: &WalSegment) -> Result<Vec<WalRecord>, RaftError> {
+        if segment.record_count == 0 || !segment.records.is_empty() {
+            return Ok(segment.records.clone());
+        }
+        let (records, _) =
+            read_wal_segment_file(&wal_segment_path(&self.options.dir, segment.segment_id))?;
+        Ok(records)
+    }
+
+    /// Drops the in-memory records of every sealed segment.
+    ///
+    /// A segment is written before it is sealed, so this loses nothing. Holding
+    /// them was what made resident memory grow with the whole log rather than
+    /// with the segment currently being written.
+    fn release_sealed_segment_records(&mut self) {
+        for segment in self.segments.iter_mut() {
+            if segment.sealed && !segment.records.is_empty() {
+                segment.records = Vec::new();
+            }
+        }
+    }
+
+    /// How many records are retained, without materialising any of them.
+    fn retained_record_count(&self) -> u64 {
+        self.segments
+            .iter()
+            .map(|segment| segment.record_count)
+            .sum()
+    }
+
     fn covered_from_segments(&self) -> Option<(LogIndex, LogIndex, Term)> {
-        let entries = matrixraft_fold_wal_entries(
-            self.segments
-                .iter()
-                .flat_map(|segment| segment.records.iter()),
-        );
+        let mut entries: Vec<LogEntry> = Vec::new();
+        for segment in &self.segments {
+            let records = self.segment_records(segment).ok()?;
+            entries = matrixraft_fold_wal_entries_from(entries, records.iter());
+        }
         let first = entries.first()?;
         let last = entries.last()?;
         Some((first.log_id.index, last.log_id.index, last.log_id.term))
@@ -543,6 +585,7 @@ impl PersistentRaftWal {
         }
         segment.last_index = record_index;
         segment.records.push(record);
+        segment.record_count = segment.records.len() as u64;
         let segment_id = segment.segment_id;
         self.advance_active_covered();
         Ok(WalWriteReport {
@@ -577,6 +620,7 @@ impl PersistentRaftWal {
                 first_index: 0,
                 last_index: 0,
                 records: Vec::new(),
+                record_count: 0,
                 sealed: false,
             }]
         } else {
@@ -593,6 +637,7 @@ impl PersistentRaftWal {
         self.active_segment = open_segment_for_append(&self.options.dir, active_id)?;
         self.next_segment_id = active_id + 1;
         self.active_covered = self.covered_from_segments();
+        self.release_sealed_segment_records();
         let observed_corrupt_tail = self.truncated_corrupt_tail || truncated_corrupt_tail;
         self.truncated_corrupt_tail = observed_corrupt_tail;
         Ok(WalRecoveryReport {
@@ -669,25 +714,37 @@ impl PersistentRaftWal {
         else {
             return Ok(());
         };
-        let entries = {
-            let Some(first) = self.segments[position].records.first() else {
-                return Ok(());
-            };
-            if !first.entries_are_delta {
-                return Ok(());
-            }
-            matrixraft_fold_wal_entries(
-                self.segments[..position]
-                    .iter()
-                    .flat_map(|segment| segment.records.iter())
-                    .chain(std::iter::once(first)),
-            )
-        };
-        let record = &mut self.segments[position].records[0];
-        record.entries = entries;
-        record.entries_are_delta = false;
-        record.checksum = matrixraft_wal_checksum(record);
-        write_wal_segment_file(&self.options.dir, &self.segments[position])
+        // The survivor is usually sealed, so its records are on disk rather
+        // than in memory.
+        let mut survivor = self.segment_records(&self.segments[position])?;
+        match survivor.first() {
+            Some(first) if first.entries_are_delta => {}
+            _ => return Ok(()),
+        }
+        // Fold the segments that are about to be deleted one at a time, so
+        // compaction never holds all of them at once.
+        let mut entries: Vec<LogEntry> = Vec::new();
+        for segment in &self.segments[..position] {
+            let records = self.segment_records(segment)?;
+            entries = matrixraft_fold_wal_entries_from(entries, records.iter());
+        }
+        let head = survivor[0].clone();
+        entries = matrixraft_fold_wal_entries_from(entries, std::iter::once(&head));
+
+        survivor[0].entries = entries;
+        survivor[0].entries_are_delta = false;
+        survivor[0].checksum = matrixraft_wal_checksum(&survivor[0]);
+
+        let sealed = self.segments[position].sealed;
+        let mut segment = self.segments[position].clone();
+        segment.records = survivor;
+        write_wal_segment_file(&self.options.dir, &segment)?;
+        if !sealed {
+            // The active segment keeps its records; a sealed one goes back to
+            // holding none.
+            self.segments[position].records = segment.records;
+        }
+        Ok(())
     }
 
     pub fn compact_through_with_fence(
@@ -811,21 +868,24 @@ impl PersistentRaftWal {
         matrixraft_wal_checksum_format()
     }
 
-    /// Number of retained records, without materialising them.
-    fn retained_record_count(&self) -> u64 {
-        self.segments
-            .iter()
-            .map(|segment| segment.records.len() as u64)
-            .sum()
+    /// The retained records, folded whole.
+    ///
+    /// Sealed segments are read back from disk, so this is no longer free.
+    /// Callers that only want a count should use [`Self::status`], which no
+    /// longer materialises anything. A segment that cannot be read yields an
+    /// empty result rather than a partial one; [`Self::try_records`] returns
+    /// the error instead.
+    pub fn records(&self) -> Vec<WalRecord> {
+        self.try_records().unwrap_or_default()
     }
 
-    pub fn records(&self) -> Vec<WalRecord> {
-        let stored: Vec<_> = self
-            .segments
-            .iter()
-            .flat_map(|segment| segment.records.iter().cloned())
-            .collect();
-        matrixraft_fold_wal_records(&stored)
+    /// [`Self::records`], with the read failure surfaced.
+    pub fn try_records(&self) -> Result<Vec<WalRecord>, RaftError> {
+        let mut stored: Vec<WalRecord> = Vec::with_capacity(self.retained_record_count() as usize);
+        for segment in &self.segments {
+            stored.extend(self.segment_records(segment)?);
+        }
+        Ok(matrixraft_fold_wal_records(&stored))
     }
 
     pub fn corrupt_tail_for_test(&mut self) -> Result<(), RaftError> {
@@ -841,6 +901,10 @@ impl PersistentRaftWal {
         if let Some(segment) = self.segments.last_mut() {
             segment.sealed = true;
             write_wal_segment_file(&self.options.dir, segment)?;
+            // The segment is on disk now, so nothing needs its records in
+            // memory. This is what bounds resident memory by the segment being
+            // written rather than by the whole log.
+            segment.records = Vec::new();
         }
         let segment_id = self.next_segment_id;
         self.next_segment_id += 1;
@@ -849,6 +913,7 @@ impl PersistentRaftWal {
             first_index: 0,
             last_index: 0,
             records: Vec::new(),
+            record_count: 0,
             sealed: false,
         };
         write_wal_segment_file(&self.options.dir, &segment)?;
@@ -907,10 +972,7 @@ fn wal_retained_range(segments: &[WalSegment]) -> LogRetainedRange {
             .last()
             .map(|segment| segment.segment_id)
             .unwrap_or(0),
-        record_count: segments
-            .iter()
-            .map(|segment| segment.records.len() as u64)
-            .sum(),
+        record_count: segments.iter().map(|segment| segment.record_count).sum(),
     }
 }
 
@@ -921,7 +983,7 @@ fn wal_segment_index(dir: &Path, segments: &[WalSegment]) -> Vec<WalSegmentIndex
             segment_id: segment.segment_id,
             first_log_index: segment.first_index,
             last_log_index: segment.last_index,
-            record_count: segment.records.len() as u64,
+            record_count: segment.record_count,
             sealed: segment.sealed,
             bytes: fs::metadata(wal_segment_path(dir, segment.segment_id))
                 .map(|metadata| metadata.len())
@@ -981,6 +1043,7 @@ fn read_wal_segments_from_dir(dir: &Path) -> Result<(Vec<WalSegment>, bool), Raf
             segment_id,
             first_index,
             last_index,
+            record_count: records.len() as u64,
             records,
             sealed: file_position != last_file_index,
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,8 @@ pub use unique_id::{
     MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK,
 };
 pub use wal::{
-    matrixraft_fold_wal_entries, matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
+    matrixraft_fold_wal_entries, matrixraft_fold_wal_entries_from,
+    matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
     matrixraft_recover_from_wal_records, matrixraft_recover_latest_wal_record,
     matrixraft_validate_apply_snapshot_fence, matrixraft_validate_hard_state_persistence,
     matrixraft_validate_wal_lifecycle_evidence_artifact, matrixraft_wal_checksum,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -108,7 +108,18 @@ pub struct WalSegment {
     pub segment_id: u64,
     pub first_index: LogIndex,
     pub last_index: LogIndex,
+    /// The records held in memory for this segment.
+    ///
+    /// A sealed segment releases these once it is on disk, so this is empty for
+    /// every segment but the active one. Read them back with
+    /// `PersistentRaftWal::records`, which loads what it needs from the segment
+    /// files. Use `record_count` rather than `records.len()` for how many a
+    /// segment holds -- they differ exactly when the records have been released.
+    #[serde(default)]
     pub records: Vec<WalRecord>,
+    /// How many records the segment has, whether or not they are in memory.
+    #[serde(default)]
+    pub record_count: u64,
     pub sealed: bool,
 }
 
@@ -393,7 +404,22 @@ pub fn matrixraft_fold_wal_entries<'a, I>(records: I) -> Vec<LogEntry>
 where
     I: IntoIterator<Item = &'a WalRecord>,
 {
-    let mut folded: Vec<LogEntry> = Vec::new();
+    matrixraft_fold_wal_entries_from(Vec::new(), records)
+}
+
+/// Continues a fold that has already consumed earlier records.
+///
+/// A sealed segment does not keep its records in memory, so folding a whole WAL
+/// means loading one segment at a time. Continuing from what is folded so far
+/// lets that happen without every segment's records being live at once, which
+/// is the difference between holding the log and holding the whole WAL.
+pub fn matrixraft_fold_wal_entries_from<'a, I>(
+    mut folded: Vec<LogEntry>,
+    records: I,
+) -> Vec<LogEntry>
+where
+    I: IntoIterator<Item = &'a WalRecord>,
+{
     for record in records {
         if !matrixraft_wal_checksum_valid(record) {
             break;

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -8,6 +8,7 @@ use matrixraft::{
     PersistentRaftWal, PersistentRaftWalOptions, StorageApplyFence, WalRecord,
 };
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -752,20 +753,24 @@ fn roll_options(dir: PathBuf) -> PersistentRaftWalOptions {
     }
 }
 
-fn retained_entries(wal: &PersistentRaftWal) -> usize {
+/// Records held in memory, which is now only the active segment's.
+fn in_memory_record_count(wal: &PersistentRaftWal) -> usize {
     wal.segments()
         .iter()
-        .flat_map(|segment| segment.records.iter())
-        .map(|record| record.entries.len())
+        .map(|segment| segment.records.len())
         .sum()
 }
 
-fn whole_record_count(wal: &PersistentRaftWal) -> usize {
-    wal.segments()
-        .iter()
-        .flat_map(|segment| segment.records.iter())
-        .filter(|record| !record.entries_are_delta)
-        .count()
+/// A segment's first record, read from the file rather than from memory.
+///
+/// Sealed segments release their records once they are on disk, so a test that
+/// wants to see what was *stored* has to read the file, which is the point.
+fn first_stored_record(dir: &Path, segment_id: u64) -> WalRecord {
+    let path = dir.join(format!("{segment_id:020}.wal"));
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    let line = text.lines().next().expect("the segment has a record");
+    serde_json::from_str(line).expect("a stored record parses")
 }
 
 /// A segment roll used to rewrite the whole retained log, so N appends cost
@@ -785,15 +790,26 @@ fn a_segment_roll_no_longer_rewrites_the_whole_log() {
         wal.segments().len() >= 5,
         "the log has to cross several segments for this to mean anything"
     );
+    // Counted from the files, because sealed segments no longer keep their
+    // records in memory. 50 records with one whole one means 49 deltas; a
+    // whole record per segment roll would leave 45.
     assert_eq!(
-        whole_record_count(&wal),
-        1,
-        "only the very first record of the WAL is stored whole"
+        stored_delta_count(&dir),
+        49,
+        "only the very first record of the WAL should be stored whole; a roll          that rewrote the log would leave 5 whole records here"
     );
     assert_eq!(
-        retained_entries(&wal),
-        50,
-        "each append should retain one entry; rewriting the log at every roll          retained 150 here, and grows quadratically from there"
+        in_memory_record_count(&wal),
+        wal.segments()
+            .last()
+            .expect("an active segment")
+            .records
+            .len(),
+        "only the active segment's records belong in memory"
+    );
+    assert!(
+        in_memory_record_count(&wal) <= 10,
+        "memory should be bounded by the segment being written, not the log"
     );
     fs::remove_dir_all(&dir).ok();
 }
@@ -856,11 +872,8 @@ fn compaction_materialises_the_record_its_survivors_depend_on() {
         for index in 1..=50 {
             wal.append(growing_wal_record(index, 3)).expect("append");
         }
-        let first_survivor_was_a_delta = wal.segments()[1]
-            .records
-            .first()
-            .expect("the second segment has records")
-            .entries_are_delta;
+        let first_survivor_was_a_delta =
+            first_stored_record(&dir, wal.segments()[1].segment_id).entries_are_delta;
         assert!(
             first_survivor_was_a_delta,
             "the segment that survives has to start as a delta, or this proves nothing"
@@ -870,11 +883,7 @@ fn compaction_materialises_the_record_its_survivors_depend_on() {
 
     let mut reopened = PersistentRaftWal::open(options).expect("reopen");
     assert!(
-        !reopened.segments()[0]
-            .records
-            .first()
-            .expect("the surviving segment has records")
-            .entries_are_delta,
+        !first_stored_record(&dir, reopened.segments()[0].segment_id).entries_are_delta,
         "the first surviving record must have been materialised on disk"
     );
     let recovered = reopened


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#38`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #35**, which is stacked on #34. Merge #34, then #35, then this.

The WAL held **every record of every retained segment in memory**. #35 stopped each segment roll from rewriting the whole log, which left the records themselves as the remaining cost — **732 bytes resident per record** for a 256-byte payload, growing with the log rather than with what is being written.

A segment is written to its file before it is sealed, so nothing needs its records afterwards. Sealed segments release them now, and the two paths that do need them — compaction, and a caller asking for the whole log — read them back from the files that already hold them.

## Measured

`examples/wal_record_footprint` is added here. It attributes memory field by field by walking retained records and summing capacities, so the figure is a count rather than an inference from resident. 2,000 records per segment:

| | records in memory | resident |
| --- | ---: | ---: |
| 20,000 appends, before | 20,000 | 14.66 MiB |
| 40,000 appends, before | 40,000 | 29.27 MiB |
| 20,000 appends, **after** | **2,000** | **1.57 MiB** |
| 40,000 appends, **after** | **2,000** | **1.62 MiB** |

Resident was linear in the log and is now **flat at one segment** — 18× less at 40,000 appends, and the gap widens with every append after that. At the default 10,000 records per segment, a million-record log holds about **7 MiB rather than 732 MiB**.

## What it needed

- **`WalSegment::record_count`**, so counting a segment does not require its records. `WalSegment::records` is empty for a sealed segment now — the one behaviour change a caller can see.
- **`matrixraft_fold_wal_entries_from`**, which continues a fold rather than starting one. Coverage on reopen and materialisation at compaction both fold the whole WAL; this lets them do it a segment at a time instead of holding every segment's records at once.
- **`PersistentRaftWal::try_records`**, because `records` now does I/O and can fail. `records` keeps its signature and returns empty on a read error; `try_records` returns the error.

## A defect found on the way

`wal_segment_index` counted `records.len()`, so it would have reported a record count of **zero for every sealed segment** — a silently wrong observability number. The existing `persistent_wal_writer_reports_checksum_segment_index_and_retained_range` caught it, which is the test doing its job.

The tests that inspected stored records through `segments()` read the segment files instead. That is not a workaround: what those tests check is what was *stored*, and the file is where that now lives.

## One flaky failure, recorded rather than hidden

`node_runtime_times_out_lagging_leader_transfer` failed once during a full run at load 8. It asserts on a 25 ms sleep. It passes **10/10 in isolation on this branch and 10/10 on the base branch**, with a clean tree asserted before each run, and the full suite passes at lower load. It is this suite's existing wall-clock sensitivity, not this change.

(My first attempt at that comparison was invalid — the checkout to the base branch was refused because of uncommitted formatting changes, so both rows ran on this branch. The numbers above are from the re-run.)

## Still true after this

A `WalRecord` is **328 bytes before any payload**, of which **88 are an `Option<SnapshotMetadata>` that is `None` on virtually every record**. Boxing it would make that 8. That is the next thing, and it is a much smaller one than this.

## Checks

527 tests pass, 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure.

