### PR TITLE
Restart without materialising a whole-log record per stored record

### DIFF
--- a/examples/wal_recovery_cost.rs
+++ b/examples/wal_recovery_cost.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Restart probe: what does recovering a delta-encoded WAL cost?
+//!
+//! Recovery folds the stored records back into the log. Folding used to build a
+//! whole-log record for *every* stored record, and each of those carries the log
+//! as it stood at that point, so an N-record WAL materialised about N^2/2
+//! entries at once.
+//!
+//! The records here are built the way `wal_record_for_coverage` builds them --
+//! the whole log when the segment cannot extend, a delta when it can, and
+//! checksummed by the builder, which is what `append_built` expects. A probe
+//! that skips the checksum stores records the fold rejects, and then recovery
+//! returns nothing and looks free.
+//!
+//! One log size per process, so a later run cannot reuse pages an earlier one
+//! freed. Run it as: wal_recovery_cost <appends> <records_per_segment>
+
+use std::time::Instant;
+
+use matrixraft::{
+    matrixraft_wal_checksum, ApplySnapshotFence, HardState, LogEntry, LogId, Membership,
+    PersistentRaftWal, PersistentRaftWalOptions, RaftError, WalRecord,
+};
+
+const PAYLOAD_BYTES: usize = 64;
+
+fn entry(index: u64) -> LogEntry {
+    LogEntry {
+        log_id: LogId { term: 3, index },
+        payload: vec![7u8; PAYLOAD_BYTES],
+        is_command: true,
+    }
+}
+
+/// The record `wal_record_for_coverage` would build for this coverage.
+fn build(log: &[LogEntry], coverage: Option<(u64, u64, u64)>) -> Result<WalRecord, RaftError> {
+    let last_index = log.last().map(|entry| entry.log_id.index).unwrap_or(0);
+    let extends = coverage.and_then(|(first_index, last, last_term)| {
+        let log_first = log.first()?.log_id.index;
+        if log_first > first_index {
+            return None;
+        }
+        let position = log.iter().position(|entry| entry.log_id.index == last)?;
+        if log[position].log_id.term != last_term {
+            return None;
+        }
+        Some(position + 1)
+    });
+    let (entries, entries_are_delta) = match extends {
+        Some(from) => (log[from..].to_vec(), true),
+        None => (log.to_vec(), false),
+    };
+    let mut record = WalRecord {
+        group_id: 9,
+        node_id: 1,
+        hard_state: HardState {
+            current_term: 3,
+            voted_for: Some(1),
+            committed: Some(LogId {
+                term: 3,
+                index: last_index,
+            }),
+        },
+        membership: Membership {
+            group_id: 9,
+            voters: vec![1, 2, 3],
+            learners: Vec::new(),
+            witnesses: Vec::new(),
+            epoch: 3,
+        },
+        entries,
+        entries_are_delta,
+        installed_snapshot: None,
+        apply_snapshot_fence: ApplySnapshotFence {
+            applied_index: last_index,
+            commit_index: last_index,
+            installed_snapshot_index: 0,
+            first_retained_log_index: 1,
+        },
+        checksum: String::new(),
+    };
+    record.checksum = matrixraft_wal_checksum(&record);
+    Ok(record)
+}
+
+fn rss_bytes() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            if let Ok(kb) = rest.trim().trim_end_matches(" kB").trim().parse::<u64>() {
+                return kb * 1024;
+            }
+        }
+    }
+    0
+}
+
+fn options(dir: &std::path::Path, per_segment: usize) -> PersistentRaftWalOptions {
+    let mut options = PersistentRaftWalOptions::new(dir);
+    options.max_records_per_segment = per_segment;
+    options.fsync_on_append = false;
+    options.min_keep_segments = usize::MAX;
+    options
+}
+
+fn main() -> Result<(), RaftError> {
+    let mut args = std::env::args().skip(1);
+    let appends: u64 = args.next().and_then(|a| a.parse().ok()).unwrap_or(2000);
+    let per_segment: usize = args.next().and_then(|a| a.parse().ok()).unwrap_or(256);
+
+    let dir = std::env::temp_dir().join(format!("mr-recover-{appends}-{per_segment}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create dir");
+
+    {
+        let mut wal = PersistentRaftWal::open(options(&dir, per_segment))?;
+        let mut log: Vec<LogEntry> = Vec::new();
+        for index in 1..=appends {
+            log.push(entry(index));
+            wal.append_built(|coverage| build(&log, coverage))?;
+        }
+    }
+
+    // Everything above is setup. The restart is what is being measured.
+    let before = rss_bytes();
+    let started = Instant::now();
+    let mut wal = PersistentRaftWal::open(options(&dir, per_segment))?;
+    let report = wal.recover()?;
+    let elapsed_ms = started.elapsed().as_millis();
+    let growth = rss_bytes().saturating_sub(before);
+
+    println!(
+        "appends={appends} per_segment={per_segment} surviving={} recovered_entries={} \
+         recover_ms={elapsed_ms} rss_bytes={growth} rss_per_append={}",
+        report.surviving_records,
+        report
+            .recovered
+            .as_ref()
+            .map(|record| record.entries.len())
+            .unwrap_or(0),
+        growth / appends,
+    );
+
+    drop(wal);
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -328,12 +328,14 @@ impl PersistentRaftWal {
 
     /// Rebuilds the active segment's coverage by folding what is already on
     /// disk, so an appended-to WAL keeps writing deltas after a reopen.
-    fn covered_from_active_segment(
-        &self,
-    ) -> Option<(LogIndex, LogIndex, Term)> {
+    ///
+    /// Only the log as the segment leaves it is wanted here. Folding to a record
+    /// per step built one whole-log record for every record in the segment --
+    /// at the default ten thousand records per segment that is ten thousand
+    /// copies of the log, on every open.
+    fn covered_from_active_segment(&self) -> Option<(LogIndex, LogIndex, Term)> {
         let segment = self.segments.last()?;
-        let folded = matrixraft_fold_wal_records(&segment.records);
-        let entries = &folded.last()?.entries;
+        let entries = matrixraft_fold_wal_entries(segment.records.iter());
         let first = entries.first()?;
         let last = entries.last()?;
         Some((first.log_id.index, last.log_id.index, last.log_id.term))
@@ -508,9 +510,12 @@ impl PersistentRaftWal {
         let (segments, truncated_corrupt_tail) = read_wal_segments_from_dir(&self.options.dir)?;
         // Counting used to clone every retained record, payloads included.
         let original_len = self.retained_record_count() as usize;
-        let records = matrixraft_fold_wal_record_iter(
-            segments.iter().flat_map(|segment| segment.records.iter()),
-        );
+        let stored: Vec<_> = segments
+            .iter()
+            .flat_map(|segment| segment.records.iter().cloned())
+            .collect();
+        // One streaming pass rather than a whole-log record per stored record.
+        let (surviving_records, recovered) = matrixraft_recover_from_wal_records(&stored);
         self.segments = if segments.is_empty() {
             vec![WalSegment {
                 segment_id: 0,
@@ -536,10 +541,10 @@ impl PersistentRaftWal {
         let observed_corrupt_tail = self.truncated_corrupt_tail || truncated_corrupt_tail;
         self.truncated_corrupt_tail = observed_corrupt_tail;
         Ok(WalRecoveryReport {
-            recovered: matrixraft_recover_latest_wal_record(&records).ok(),
+            recovered,
             truncated_corrupt_tail: observed_corrupt_tail,
-            surviving_records: records.len(),
-            removed_records: original_len.saturating_sub(records.len()),
+            surviving_records,
+            removed_records: original_len.saturating_sub(surviving_records),
             segments_scanned: self.segments.len() as u64,
             checksum_format: Some(matrixraft_wal_checksum_format()),
             retained_range: Some(wal_retained_range(&self.segments)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,8 @@ pub use unique_id::{
     MATRIXRAFT_UNIQUE_ID_TIMESTAMP_MASK,
 };
 pub use wal::{
-    matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
+    matrixraft_fold_wal_entries, matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
+    matrixraft_recover_from_wal_records,
     matrixraft_recover_latest_wal_record, matrixraft_validate_apply_snapshot_fence,
     matrixraft_validate_hard_state_persistence,
     matrixraft_validate_wal_lifecycle_evidence_artifact, matrixraft_wal_checksum,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -340,23 +340,116 @@ where
         if !matrixraft_wal_checksum_valid(record) {
             break;
         }
-        if record.entries_are_delta {
-            if let Some(first) = record.entries.first() {
-                let cut =
-                    folded_entries.partition_point(|entry| entry.log_id.index < first.log_id.index);
-                folded_entries.truncate(cut);
-            }
-            folded_entries.extend(record.entries.iter().cloned());
-        } else {
-            folded_entries.clone_from(&record.entries);
-        }
-        let mut whole = record.clone();
-        whole.entries.clone_from(&folded_entries);
-        whole.entries_are_delta = false;
-        whole.checksum = matrixraft_wal_checksum(&whole);
-        out.push(whole);
+        fold_wal_entries_step(&mut folded_entries, record);
+        out.push(whole_from_folded(record, &folded_entries));
     }
     out
+}
+
+/// Applies one stored record to the entries folded so far.
+///
+/// A whole record replaces them. A delta truncates back to where it starts and
+/// then extends, so a record that rewrites a diverged tail wins over what it
+/// replaces rather than being appended after it.
+fn fold_wal_entries_step(folded: &mut Vec<LogEntry>, record: &WalRecord) {
+    if record.entries_are_delta {
+        if let Some(first) = record.entries.first() {
+            let cut = folded.partition_point(|entry| entry.log_id.index < first.log_id.index);
+            folded.truncate(cut);
+        }
+        folded.extend(record.entries.iter().cloned());
+    } else {
+        folded.clone_from(&record.entries);
+    }
+}
+
+/// The whole-log record a stored record folds to, given the entries folded up
+/// to and including it.
+fn whole_from_folded(record: &WalRecord, folded: &[LogEntry]) -> WalRecord {
+    let mut whole = record.clone();
+    whole.entries.clear();
+    whole.entries.extend_from_slice(folded);
+    whole.entries_are_delta = false;
+    whole.checksum = matrixraft_wal_checksum(&whole);
+    whole
+}
+
+/// Folds `records` into the log they describe, without building a record per
+/// step.
+///
+/// [`matrixraft_fold_wal_records`] answers "what did the log look like at each
+/// record", and pays a whole-log record per step to do it. Callers that only
+/// want the log as it ends up -- reopening to see what a segment already
+/// covers, for one -- want this instead.
+///
+/// Like the record fold, this stops at the first record whose checksum does not
+/// validate, which is where a reader scanning for a valid prefix would stop.
+pub fn matrixraft_fold_wal_entries<'a, I>(records: I) -> Vec<LogEntry>
+where
+    I: IntoIterator<Item = &'a WalRecord>,
+{
+    let mut folded: Vec<LogEntry> = Vec::new();
+    for record in records {
+        if !matrixraft_wal_checksum_valid(record) {
+            break;
+        }
+        fold_wal_entries_step(&mut folded, record);
+    }
+    folded
+}
+
+/// What recovery needs from a WAL: how many records survived, and the one
+/// record it would restore from.
+///
+/// [`matrixraft_fold_wal_records`] builds a whole-log record for *every* stored
+/// record, and each of those carries the log as it stood at that point. For an
+/// N-record WAL that is about N^2/2 entries held at once -- a gigabyte at four
+/// thousand records, and quadratic from there, which is enough to stop a node
+/// restarting at all.
+///
+/// Recovery never needed all of them. It needs the surviving count and the
+/// single latest valid record, so this folds in one streaming pass, keeping only
+/// the log itself, and then replays to rebuild just the record it picked.
+///
+/// The record chosen is the same one [`matrixraft_recover_latest_wal_record`]
+/// would choose: among records that pass hard-state and fence validation, the
+/// one with the highest committed index, and the last of those on a tie.
+pub fn matrixraft_recover_from_wal_records(stored: &[WalRecord]) -> (usize, Option<WalRecord>) {
+    // One pass for the surviving prefix and each record's committed index. The
+    // validity checks look at the folded entries, so they cannot be decided
+    // here -- candidates are ranked now and verified by replay below.
+    let mut surviving = 0usize;
+    let mut candidates: Vec<(u64, usize)> = Vec::new();
+    for (position, record) in stored.iter().enumerate() {
+        if !matrixraft_wal_checksum_valid(record) {
+            break;
+        }
+        surviving += 1;
+        let committed = record
+            .hard_state
+            .committed
+            .as_ref()
+            .map(|log_id| log_id.index)
+            .unwrap_or_default();
+        candidates.push((committed, position));
+    }
+    // Highest committed index first, and the later position on a tie, which is
+    // what `max_by_key` settles on.
+    candidates.sort_by(|left, right| right.cmp(left));
+
+    for (_, position) in candidates {
+        let mut folded: Vec<LogEntry> = Vec::new();
+        for record in stored.iter().take(position + 1) {
+            fold_wal_entries_step(&mut folded, record);
+        }
+        let whole = whole_from_folded(&stored[position], &folded);
+        if matrixraft_validate_hard_state_persistence(&whole).is_ok()
+            && matrixraft_validate_apply_snapshot_fence(&whole).is_ok()
+        {
+            return (surviving, Some(whole));
+        }
+    }
+    (surviving, None)
 }
 
 /// Whether `entries` extends `covered` rather than diverging from it.

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -2,9 +2,10 @@
 // Copyright 2026 MatrixArkAI
 
 use matrixraft::{
-    matrixraft_wal_checksum_format, matrixraft_wal_lifecycle_evidence, ApplySnapshotFence,
-    HardState, LogEntry, LogId, Membership, PersistentRaftWal, PersistentRaftWalOptions,
-    StorageApplyFence, WalRecord,
+    matrixraft_fold_wal_records, matrixraft_recover_from_wal_records,
+    matrixraft_recover_latest_wal_record, matrixraft_wal_checksum, matrixraft_wal_checksum_format,
+    matrixraft_wal_lifecycle_evidence, ApplySnapshotFence, HardState, LogEntry, LogId, Membership,
+    PersistentRaftWal, PersistentRaftWalOptions, StorageApplyFence, WalRecord,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -626,4 +627,72 @@ fn wal_payload_encoding_shrinks_a_realistic_record() {
         "expected the shared entry encoding to be unchanged, got {}",
         bare_entries.len()
     );
+}
+
+/// Builds a stored record: whole when `from` is zero, otherwise a delta that
+/// carries entries from `from` onward. Checksummed as the writer would.
+fn stored_record(last: u64, term: u64, from: u64) -> WalRecord {
+    let mut record = growing_wal_record(last, term);
+    if from > 0 {
+        record.entries.retain(|entry| entry.log_id.index >= from);
+        record.entries_are_delta = true;
+    }
+    record.checksum = matrixraft_wal_checksum(&record);
+    record
+}
+
+/// The streaming recovery has to pick exactly what the fold-everything path
+/// picked. It exists to avoid materialising a whole-log record per stored
+/// record, not to change which record recovery restores from.
+fn assert_recovery_agrees(case: &str, stored: &[WalRecord]) {
+    let folded = matrixraft_fold_wal_records(stored);
+    let expected_record = matrixraft_recover_latest_wal_record(&folded).ok();
+    let (surviving, recovered) = matrixraft_recover_from_wal_records(stored);
+
+    assert_eq!(
+        surviving,
+        folded.len(),
+        "{case}: surviving record count must match the fold"
+    );
+    assert_eq!(
+        recovered.as_ref().map(|record| record.entries.len()),
+        expected_record.as_ref().map(|record| record.entries.len()),
+        "{case}: recovered entry count must match"
+    );
+    assert_eq!(
+        recovered, expected_record,
+        "{case}: recovered record must match"
+    );
+}
+
+#[test]
+fn streaming_recovery_picks_what_folding_everything_picked() {
+    // A plain growing log stored as one whole record then deltas.
+    let mut deltas = vec![stored_record(1, 3, 0)];
+    for index in 2..=12 {
+        deltas.push(stored_record(index, 3, index));
+    }
+    assert_recovery_agrees("growing log", &deltas);
+
+    // A tail rewritten at the same index in a newer term, which the fold has to
+    // resolve in favour of the rewrite rather than appending after it.
+    let mut rewritten = deltas.clone();
+    rewritten.push(stored_record(12, 4, 10));
+    assert_recovery_agrees("rewritten tail", &rewritten);
+
+    // A corrupt record: everything after it is discarded, by both paths.
+    let mut corrupt = deltas.clone();
+    let mut bad = stored_record(13, 3, 13);
+    bad.checksum = "not-a-checksum".to_string();
+    corrupt.push(bad);
+    corrupt.push(stored_record(14, 3, 14));
+    assert_recovery_agrees("corrupt tail", &corrupt);
+
+    // Nothing valid at all.
+    let mut only_bad = stored_record(1, 3, 0);
+    only_bad.checksum = "not-a-checksum".to_string();
+    assert_recovery_agrees("no valid records", &[only_bad]);
+
+    // Empty.
+    assert_recovery_agrees("empty", &[]);
 }


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#39`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`. **This is a pre-existing bug on `main`, not one my other WAL branches introduced** — the before column below is main.

**A node with a few thousand WAL records cannot restart.** Two folds on the restart path built a whole-log record for every record they walked, and each carries the log as it stood at that point:

- **`recover`** folded every stored record — about **N²/2 entries** for an N-record WAL.
- **`covered_from_active_segment`** folded the active segment the same way, to learn one thing: what the segment already covers. At the **default 10,000 records per segment that is 10,000 copies of the log, on every open.**

The second is the worse of the two at the shipped segment size, and neither shows up until the WAL holds a few thousand records.

## Measured

`examples/wal_recovery_cost` is added here. 64-byte payloads, one log size per process.

**At the shipped segment size (10,000/segment):**

| appends | main | after |
| ---: | --- | --- |
| 2,000 | 3,062 ms / **516.1 MiB** | **61 ms / 3.87 MiB** |
| 4,000 | *not run* | 104 ms / 7.86 MiB |

**50× faster, 133× less memory.**

**At 256/segment**, where the roll quadratic also bites:

| appends | main | after |
| ---: | --- | --- |
| 1,000 | 348 ms / 91.9 MiB | 53 ms / 1.78 MiB |
| 2,000 | 1,214 ms / 310.0 MiB | 141 ms / 4.38 MiB |
| 4,000 | 5,842 ms / **1,113.7 MiB** | 472 ms / 13.34 MiB |
| 8,000 | *not run* | 2,023 ms / 46.41 MiB |

On main both columns roughly **quadruple per doubling**. The rows marked *not run* were skipped deliberately: this box has 7 GiB with other sessions on it, and 8,000 appends on main needs about 4 GiB.

## The fix

Recovery needs the **surviving count** and the **one record it restores from**, not a folded copy of every record. `matrixraft_recover_from_wal_records` folds in a single streaming pass keeping only the log, then replays to rebuild just the record it picked. `matrixraft_fold_wal_entries` does the same for coverage.

`matrixraft_fold_wal_records` is unchanged and still used where every folded record is genuinely wanted.

## Picking the same record matters more than the speed

`streaming_recovery_picks_what_folding_everything_picked` asserts the two paths agree — on a growing log, a tail rewritten at the same index in a newer term, a corrupt record mid-file, nothing valid, and empty. Reversing the candidate ordering makes it fail, so it is not passing by construction.

## Why no earlier probe caught this

They stored records with an **empty checksum**. `append_built` stores what the builder hands it, and the builder is what checksums — exactly as `wal_record_for_coverage` does. Without it the fold stops at the first record, recovery returns nothing, and the cost measures as **zero**.

The probe here checksums, and asserting `surviving == appends` is what makes any recovery number believable. (It also means the disk-byte figures in #34 and #35 were ~2.7% low, equally on both sides, so those ratios stand.)

## What is left, and it is not this

At 256/segment the after column still grows faster than linearly, because **a segment roll stores the whole log on main** — the separate quadratic #34 measures and #35 fixes. At one segment the after column is linear, which is what the 10,000 rows show. The two fixes compose.

## Conflicts

#33, #35 and #38 also touch `recover`. Whichever lands after this needs a small resolution there. #35 adds an identical `matrixraft_fold_wal_entries`, so that hunk resolves to itself.

## Checks

525 tests pass across 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure.

---

*Amended after first push: the original commit omitted `examples/wal_recovery_cost.rs` — a stray `rm` while on `main` left a staged deletion that a later `git add -A` folded into the squash. The PR referenced a probe it did not add. It is in the commit now, and the coverage fold fix and its measurements were added in the same amend.*

