### PR TITLE
Show that beginning a snapshot send holds a second copy of it

### DIFF
--- a/examples/snapshot_checkpoint_cost.rs
+++ b/examples/snapshot_checkpoint_cost.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Snapshot-send probe: what does chunking a snapshot cost before a byte moves?
+//!
+//! `SnapshotLifecycle::checkpoint` builds every chunk up front, so beginning a
+//! send holds a second copy of the payload as well as the snapshot itself. Each
+//! chunk also clones the metadata, and that metadata carries a `Vec<Peer>` whose
+//! peers each hold two `String`s -- so the clone count grows with the payload
+//! even though the metadata never changes.
+//!
+//! Sending a snapshot is exactly when a lagging follower makes the leader spend
+//! memory, so the multiple matters. One payload size per process.
+//!
+//!     snapshot_checkpoint_cost <payload_mib> <chunk_kib>
+
+use matrixraft::{LogId, Peer, RaftSnapshot, ReplicaRole, SnapshotLifecycle, SnapshotMetadata};
+
+fn rss_bytes() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            if let Ok(kb) = rest.trim().trim_end_matches(" kB").trim().parse::<u64>() {
+                return kb * 1024;
+            }
+        }
+    }
+    0
+}
+
+fn peer(node_id: u64) -> Peer {
+    Peer {
+        node_id,
+        raft_addr: format!("10.0.0.{node_id}:9000"),
+        snapshot_addr: format!("10.0.0.{node_id}:10000"),
+        role: ReplicaRole::Voter,
+        auto_promote: false,
+    }
+}
+
+fn main() {
+    let payload_mib: usize = std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(64);
+    let chunk_kib: u64 = std::env::args()
+        .nth(2)
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(64);
+
+    let payload_bytes = payload_mib * 1024 * 1024;
+    let snapshot = RaftSnapshot {
+        group_id: 9,
+        meta: SnapshotMetadata {
+            snapshot_id: "snapshot-7".to_string(),
+            last_log_id: LogId {
+                term: 3,
+                index: 1_000,
+            },
+            membership: vec![1, 2, 3],
+            members: vec![peer(1), peer(2), peer(3)],
+        },
+        payload: vec![7u8; payload_bytes],
+    };
+
+    let before = rss_bytes();
+    let chunks = SnapshotLifecycle::checkpoint(&snapshot, chunk_kib * 1024).expect("checkpoint");
+    let after = rss_bytes();
+    let growth = after.saturating_sub(before);
+
+    println!(
+        "payload={payload_mib} MiB chunk={chunk_kib} KiB chunks={} rss_growth={:.1} MiB \
+         multiple_of_payload={:.2}",
+        chunks.len(),
+        growth as f64 / (1024.0 * 1024.0),
+        growth as f64 / payload_bytes as f64,
+    );
+    // Keep the chunks alive so the measurement is of what a send holds.
+    assert!(!chunks.is_empty());
+}

--- a/src/facade/snapshot_runtime.rs
+++ b/src/facade/snapshot_runtime.rs
@@ -187,6 +187,18 @@ impl SnapshotLifecycle {
         })
     }
 
+    /// Splits a snapshot into the chunks a send will transmit.
+    ///
+    /// Every chunk is built up front, so the result is a second copy of the
+    /// payload. Measured with `examples/snapshot_checkpoint_cost`, that is
+    /// 1.01x the payload -- 258 MiB held for a 256 MiB snapshot, of which about
+    /// 1% is the per-chunk metadata clone and the rest is the payload itself.
+    ///
+    /// Chunks cannot simply be dropped as they are sent: a rejected response
+    /// rewinds `next_chunk`, so an earlier chunk can be asked for again.
+    /// Removing the second copy means the sender holding the snapshot and
+    /// slicing a chunk when it is asked for, which needs `begin_send` to share
+    /// the snapshot rather than take it by reference.
     pub fn checkpoint(
         snapshot: &RaftSnapshot,
         chunk_size: u64,
@@ -219,6 +231,12 @@ impl SnapshotLifecycle {
         Ok(chunks)
     }
 
+    /// Starts sending a snapshot.
+    ///
+    /// This holds every chunk for the whole transfer, so a send costs roughly
+    /// twice the snapshot in memory until it completes -- and it begins exactly
+    /// when a follower has fallen behind, which is not when a leader has memory
+    /// to spare. See [`Self::checkpoint`] for what it would take to avoid.
     pub fn begin_send(
         &mut self,
         snapshot: &RaftSnapshot,


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#40`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of everything else. **No behaviour change** — a measurement and a doc note.

`begin_send` builds every chunk up front and keeps them all for the whole transfer, so **sending a snapshot costs roughly twice the snapshot in memory**. That begins exactly when a follower has fallen behind, which is not when a leader has memory to spare.

## Measured

`examples/snapshot_checkpoint_cost` measures what checkpointing adds on top of the snapshot itself.

| payload | chunks | held | multiple |
| ---: | ---: | ---: | ---: |
| 16 MiB | 256 | 16.2 MiB | 1.01 |
| 64 MiB | 1,024 | 64.6 MiB | 1.01 |
| 256 MiB | 4,096 | **258.4 MiB** | 1.01 |
| 256 MiB | 256 | 257.1 MiB | 1.00 |

## What I expected to find, and didn't

I went looking for the per-chunk metadata clone. `SnapshotMetadata` carries a `Vec<Peer>` and each `Peer` holds two `String`s, so 4,096 chunks clone that 4,096 times — roughly 98,000 string allocations for one send.

**It is about 640 bytes per chunk, near 1% of the total.** Raising the chunk size sixteenfold moves the figure from 1.01 to 1.00, and that is the whole of the difference. The multiple is the payload copy, not the bookkeeping. Recording that because the plausible-sounding cause was the wrong one.

## Why this is documented rather than fixed

Chunks cannot simply be dropped as they are sent: **a rejected response rewinds `next_chunk`**, so an earlier chunk can be asked for again. Retaining them is load-bearing.

Removing the copy means the sender holding the snapshot and slicing a chunk when it is asked for — which needs `begin_send` to share the snapshot rather than take it by reference. That is a public signature change for a **2× constant factor**, not a quadratic, so it is worth your decision rather than my assumption.

The doc comments on `checkpoint` and `begin_send` now state the cost and what removing it would take, so the next person to look does not have to measure it again.

## Checks

524 tests pass across 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure.

