### PR TITLE
Give callers a cheap way to read the log a WAL ends up with

### DIFF
--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -876,13 +876,19 @@ impl PersistentRaftWal {
         matrixraft_wal_checksum_format()
     }
 
-    /// The retained records, folded whole.
+    /// Every retained record, each folded to the whole log it describes.
     ///
-    /// Sealed segments are read back from disk, so this is no longer free.
-    /// Callers that only want a count should use [`Self::status`], which no
-    /// longer materialises anything. A segment that cannot be read yields an
-    /// empty result rather than a partial one; [`Self::try_records`] returns
-    /// the error instead.
+    /// **This costs about N^2/2 entries for an N-record WAL**, because that is
+    /// what it is being asked for: a record per step, each carrying the log as
+    /// it stood then. A few thousand records is enough for that to be a
+    /// gigabyte.
+    ///
+    /// Almost nothing wants that. For the log as it ends up, use
+    /// [`Self::latest_record`]; for how many records are retained, use
+    /// [`Self::status`], which materialises nothing. Sealed segments are read
+    /// back from disk, so this is not even free at small sizes; a segment that
+    /// cannot be read yields an empty result rather than a partial one, and
+    /// [`Self::try_records`] returns the error instead.
     pub fn records(&self) -> Vec<WalRecord> {
         self.try_records().unwrap_or_default()
     }
@@ -894,6 +900,22 @@ impl PersistentRaftWal {
             stored.extend(self.segment_records(segment)?);
         }
         Ok(matrixraft_fold_wal_records(&stored))
+    }
+
+    /// The log as the retained records leave it.
+    ///
+    /// The cheap form of [`Self::records`]`.last()`: it folds once and builds
+    /// one record, rather than building one per stored record and discarding
+    /// all but the last. Sealed segments release their in-memory records, so
+    /// like [`Self::records`] this reads them back from disk; a segment that
+    /// cannot be read yields `None` rather than a fold of a partial prefix.
+    pub fn latest_record(&self) -> Option<WalRecord> {
+        let mut stored: Vec<WalRecord> =
+            Vec::with_capacity(self.retained_record_count() as usize);
+        for segment in &self.segments {
+            stored.extend(self.segment_records(segment).ok()?);
+        }
+        matrixraft_fold_wal_latest_record(&stored)
     }
 
     pub fn corrupt_tail_for_test(&mut self) -> Result<(), RaftError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,8 @@ pub use unique_id::{
 };
 pub use wal::{
     matrixraft_fold_wal_entries, matrixraft_fold_wal_entries_from,
-    matrixraft_fold_wal_record_iter, matrixraft_fold_wal_records,
+    matrixraft_fold_wal_latest_record, matrixraft_fold_wal_record_iter,
+    matrixraft_fold_wal_records,
     matrixraft_recover_from_wal_records, matrixraft_recover_latest_wal_record,
     matrixraft_validate_apply_snapshot_fence, matrixraft_validate_hard_state_persistence,
     matrixraft_validate_wal_lifecycle_evidence_artifact, matrixraft_wal_checksum,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -429,6 +429,28 @@ where
     folded
 }
 
+/// The log as the retained records leave it, as a single whole record.
+///
+/// [`matrixraft_fold_wal_records`] answers the same question by building a
+/// whole-log record for every stored record, which costs about N^2/2 entries
+/// for an N-record WAL. Callers that want the final state -- which is most of
+/// them -- want this instead.
+///
+/// This is a plain fold, unlike [`matrixraft_recover_from_wal_records`], which
+/// also filters by hard-state and fence validity and picks by committed index.
+pub fn matrixraft_fold_wal_latest_record(stored: &[WalRecord]) -> Option<WalRecord> {
+    let mut folded: Vec<LogEntry> = Vec::new();
+    let mut last: Option<&WalRecord> = None;
+    for record in stored {
+        if !matrixraft_wal_checksum_valid(record) {
+            break;
+        }
+        fold_wal_entries_step(&mut folded, record);
+        last = Some(record);
+    }
+    last.map(|record| whole_from_folded(record, &folded))
+}
+
 /// What recovery needs from a WAL: how many records survived, and the one
 /// record it would restore from.
 ///

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -445,8 +445,7 @@ fn a_log_truncated_by_a_conflict_is_stored_whole() {
     let reopened = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("reopen");
     // Read the folded records rather than going through recovery, which picks
     // by highest committed index and would hand back the pre-conflict record.
-    let folded = reopened.records();
-    let last = folded.last().expect("a record was stored");
+    let last = reopened.latest_record().expect("a record was stored");
     assert_eq!(
         last.entries.len(),
         3,
@@ -516,8 +515,7 @@ fn a_tail_rewritten_at_the_same_index_is_stored_whole() {
     }
 
     let reopened = PersistentRaftWal::open(wide_segment_options(dir.clone())).expect("reopen");
-    let folded = reopened.records();
-    let last = folded.last().expect("a record was stored");
+    let last = reopened.latest_record().expect("a record was stored");
     assert_eq!(last.entries.len(), 5);
     assert_eq!(
         last.entries[4].log_id.term, 7,
@@ -739,6 +737,44 @@ fn a_batch_pays_for_one_fsync_not_one_per_record() {
         wal.fsync_count(),
         6,
         "five single appends add five fsyncs to the batch's one"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+/// `latest_record` is the cheap form of `records().last()`, and has to be the
+/// same record. It folds once instead of building a whole-log record per stored
+/// record, which is what makes `records` quadratic.
+#[test]
+fn latest_record_is_what_records_last_would_have_been() {
+    let dir = temp_wal_dir("latest-record");
+    let options = PersistentRaftWalOptions {
+        dir: dir.clone(),
+        max_records_per_segment: 10,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        fsync_on_append: false,
+    };
+    let mut wal = PersistentRaftWal::open(options).expect("open");
+    for index in 1..=40 {
+        wal.append(growing_wal_record(index, 3)).expect("append");
+    }
+
+    let expected = wal.records().last().cloned();
+    let actual = wal.latest_record();
+    assert!(expected.is_some(), "the WAL has records");
+    assert_eq!(
+        actual, expected,
+        "latest_record must match records().last()"
+    );
+
+    // And on a conflict-rewritten tail, where the fold has to resolve rather
+    // than append.
+    wal.append(growing_wal_record(40, 4))
+        .expect("append rewrite");
+    assert_eq!(
+        wal.latest_record(),
+        wal.records().last().cloned(),
+        "the two have to agree after a rewritten tail too"
     );
     fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#41`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #39.** Merge that first.

`records` folds every stored record into the whole log it describes, so it costs about **N²/2 entries** for an N-record WAL. That is genuinely what it is being asked for — a record per step, each carrying the log as it stood then — but almost no caller wants it. In this repository every use is `.len()`, `.last()`, or a single index.

`recover` and `covered_from_active_segment` had the same shape and are fixed in #39 because they sit on the restart path. **This one is a public accessor**, so leaving it as the last remaining instance makes it exactly the trap the other two were: a consumer polling it on a large WAL allocates a gigabyte and does not find out why.

## Added, not changed

`records` keeps its contract — the fix is to make the cheap paths exist and be obvious.

- `matrixraft_fold_wal_latest_record` folds once and builds one record.
- `PersistentRaftWal::latest_record` is the cheap form of `records().last()`.
- `records` now documents what it costs and points at `latest_record`, and at `status` for a count, which materialises nothing.

## The guard

`latest_record_is_what_records_last_would_have_been` asserts the two agree — on a plain growing log, and on a **tail rewritten at the same index in a newer term**. That second case is the one where the fold has to resolve rather than append, so it is where a shortcut would diverge if it were wrong.

The two tests that read `records().last()` use `latest_record` now. They were never asking for the intermediate records.

## Checks

526 tests pass across 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure.

