### PR TITLE
Let a WAL fsync once for a batch instead of once per record

### DIFF
--- a/examples/wal_group_commit.rs
+++ b/examples/wal_group_commit.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Durability probe: what does a WAL append cost, and what does batching save?
+//!
+//! A durable append is its fsync and very little else. This appends the same
+//! number of records at several batch sizes and reports both the throughput and
+//! the fsync count, because the count is exact while the seconds move with the
+//! disk and the load on it.
+//!
+//!     wal_group_commit <appends> <payload_bytes>
+
+use std::time::Instant;
+
+use matrixraft::{
+    matrixraft_wal_checksum, ApplySnapshotFence, HardState, LogEntry, LogId, Membership,
+    PersistentRaftWal, PersistentRaftWalOptions, RaftError, WalRecord,
+};
+
+fn record(index: u64, payload_bytes: usize) -> WalRecord {
+    let mut record = WalRecord {
+        group_id: 9,
+        node_id: 1,
+        hard_state: HardState {
+            current_term: 3,
+            voted_for: Some(1),
+            committed: Some(LogId { term: 3, index }),
+        },
+        membership: Membership {
+            group_id: 9,
+            voters: vec![1, 2, 3],
+            learners: Vec::new(),
+            witnesses: Vec::new(),
+            epoch: 3,
+        },
+        entries: vec![LogEntry {
+            log_id: LogId { term: 3, index },
+            payload: vec![7u8; payload_bytes],
+            is_command: true,
+        }],
+        entries_are_delta: false,
+        installed_snapshot: None,
+        apply_snapshot_fence: ApplySnapshotFence {
+            applied_index: index,
+            commit_index: index,
+            installed_snapshot_index: 0,
+            first_retained_log_index: 1,
+        },
+        checksum: String::new(),
+    };
+    record.checksum = matrixraft_wal_checksum(&record);
+    record
+}
+
+fn run(appends: u64, batch: u64, payload_bytes: usize) -> Result<(f64, u64), RaftError> {
+    let dir = std::env::temp_dir().join(format!("mr-group-{appends}-{batch}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let mut options = PersistentRaftWalOptions::new(&dir);
+    options.min_keep_segments = usize::MAX;
+    let mut wal = PersistentRaftWal::open(options)?;
+
+    let started = Instant::now();
+    let mut index = 1;
+    while index <= appends {
+        let take = batch.min(appends - index + 1);
+        if take == 1 {
+            wal.append(record(index, payload_bytes))?;
+        } else {
+            let records = (index..index + take)
+                .map(|i| record(i, payload_bytes))
+                .collect();
+            wal.append_batch(records)?;
+        }
+        index += take;
+    }
+    let seconds = started.elapsed().as_secs_f64();
+    let fsyncs = wal.fsync_count();
+    drop(wal);
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok((seconds, fsyncs))
+}
+
+fn main() -> Result<(), RaftError> {
+    let mut args = std::env::args().skip(1);
+    let appends: u64 = args.next().and_then(|a| a.parse().ok()).unwrap_or(2000);
+    let payload_bytes: usize = args.next().and_then(|a| a.parse().ok()).unwrap_or(256);
+
+    println!("appends={appends} payload_bytes={payload_bytes}");
+    println!(
+        "{:>6}  {:>9}  {:>9}  {:>14}  {:>8}",
+        "batch", "seconds", "fsyncs", "appends/sec", "vs one"
+    );
+    let mut baseline: Option<f64> = None;
+    for batch in [1_u64, 2, 8, 32, 128] {
+        let (seconds, fsyncs) = run(appends, batch, payload_bytes)?;
+        let rate = appends as f64 / seconds;
+        let speedup = baseline.map(|b| b / seconds).unwrap_or(1.0);
+        println!("{batch:>6}  {seconds:>9.3}  {fsyncs:>9}  {rate:>14.0}  {speedup:>7.1}x");
+        if baseline.is_none() {
+            baseline = Some(seconds);
+        }
+    }
+    Ok(())
+}

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -232,6 +232,9 @@ pub struct PersistentRaftWal {
     max_fsync_elapsed_ms: u64,
     compacted_after_slow_fsync_count: u64,
     inject_next_fsync_delay_ms: Option<u64>,
+    /// Every fsync, not only the slow ones. An append is dominated by its
+    /// fsync, so this is what says whether a batch actually amortised one.
+    fsync_count: u64,
     /// What the active segment's records already describe, as
     /// (first index, last index, term at the last index). `None` means the
     /// segment is empty, so the next record has to be stored whole.
@@ -280,6 +283,7 @@ impl PersistentRaftWal {
             max_fsync_elapsed_ms: 0,
             compacted_after_slow_fsync_count: 0,
             inject_next_fsync_delay_ms: None,
+            fsync_count: 0,
             active_covered: None,
         };
         wal.active_covered = wal.covered_from_active_segment();
@@ -341,6 +345,89 @@ impl PersistentRaftWal {
         Some((first.log_id.index, last.log_id.index, last.log_id.term))
     }
 
+    /// Fsyncs the active segment and records what it cost.
+    fn fsync_active_segment(&mut self) -> Result<(u64, bool), RaftError> {
+        let started = Instant::now();
+        if let Some(delay_ms) = self.inject_next_fsync_delay_ms.take() {
+            thread::sleep(Duration::from_millis(delay_ms));
+        }
+        self.active_segment
+            .sync_data()
+            .map_err(|err| RaftError::Storage(format!("failed to fsync WAL record: {err}")))?;
+        self.fsync_count += 1;
+        let elapsed_ms: u64 = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        self.max_fsync_elapsed_ms = self.max_fsync_elapsed_ms.max(elapsed_ms);
+        let slow = self.slow_fsync_threshold_ms > 0 && elapsed_ms >= self.slow_fsync_threshold_ms;
+        if slow {
+            self.slow_fsync_count += 1;
+            self.consecutive_slow_fsync_count += 1;
+        } else {
+            self.consecutive_slow_fsync_count = 0;
+        }
+        Ok((elapsed_ms, slow))
+    }
+
+    /// How many times this WAL has fsynced.
+    pub fn fsync_count(&self) -> u64 {
+        self.fsync_count
+    }
+
+    /// Appends several records and fsyncs once for all of them.
+    ///
+    /// A durable append is its fsync and very little else: 224 appends per
+    /// second with `fsync_on_append`, against 85,014 with it off. Appending one
+    /// record at a time therefore caps a group at a few hundred entries per
+    /// second however fast the rest of it is.
+    ///
+    /// Every record is durable when this returns and none before, which is the
+    /// trade group commit makes. A caller must not acknowledge any record in
+    /// the batch until this returns, exactly as it must not acknowledge a
+    /// single append before `append` returns.
+    ///
+    /// A torn tail is no more dangerous than it already was: records are
+    /// line-delimited and recovery stops at the first record whose checksum
+    /// does not validate, so a batch interrupted by a crash truncates at
+    /// whatever was written whole.
+    pub fn append_batch(
+        &mut self,
+        records: Vec<WalRecord>,
+    ) -> Result<Vec<WalWriteReport>, RaftError> {
+        if records.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut reports = Vec::with_capacity(records.len());
+        for record in records {
+            let active_records = self
+                .segments
+                .last()
+                .map(|segment| segment.records.len())
+                .unwrap_or_default();
+            let rolling_by_count = active_records >= self.options.max_records_per_segment;
+            let stored = if rolling_by_count {
+                whole_record(&record)
+            } else {
+                self.delta_record(&record)
+            };
+            // Deferred deliberately: one fsync covers the whole batch, below.
+            reports.push(self.write_record(
+                stored,
+                active_records,
+                rolling_by_count,
+                false,
+                || Ok(whole_record(&record)),
+            )?);
+        }
+        if self.options.fsync_on_append {
+            let (elapsed_ms, slow) = self.fsync_active_segment()?;
+            if let Some(last) = reports.last_mut() {
+                last.fsync_on_append = true;
+                last.fsync_elapsed_ms = elapsed_ms;
+                last.slow_fsync_observed = slow;
+            }
+        }
+        Ok(reports)
+    }
+
     pub fn set_slow_fsync_threshold_ms(&mut self, threshold_ms: u64) {
         self.slow_fsync_threshold_ms = threshold_ms;
     }
@@ -380,7 +467,13 @@ impl PersistentRaftWal {
             self.active_covered
         };
         let record = build(coverage)?;
-        self.write_record(record, active_records, rolling_by_count, || build(None))
+        self.write_record(
+            record,
+            active_records,
+            rolling_by_count,
+            self.options.fsync_on_append,
+            || build(None),
+        )
     }
 
     pub fn append(&mut self, record: WalRecord) -> Result<String, RaftError> {
@@ -402,9 +495,13 @@ impl PersistentRaftWal {
         } else {
             self.delta_record(&record)
         };
-        self.write_record(stored, active_records, rolling_by_count, || {
-            Ok(whole_record(&record))
-        })
+        self.write_record(
+            stored,
+            active_records,
+            rolling_by_count,
+            self.options.fsync_on_append,
+            || Ok(whole_record(&record)),
+        )
     }
 
     /// Writes a record that has already been reduced to what will be stored.
@@ -417,6 +514,7 @@ impl PersistentRaftWal {
         mut record: WalRecord,
         active_records: usize,
         rolling_by_count: bool,
+        fsync: bool,
         whole: W,
     ) -> Result<WalWriteReport, RaftError>
     where
@@ -454,28 +552,10 @@ impl PersistentRaftWal {
             .map_err(|err| RaftError::Storage(format!("failed to append WAL record: {err}")))?;
         let mut fsync_elapsed_ms = 0;
         let mut slow_fsync_observed = false;
-        if self.options.fsync_on_append {
-            let fsync_started = Instant::now();
-            if let Some(delay_ms) = self.inject_next_fsync_delay_ms.take() {
-                thread::sleep(Duration::from_millis(delay_ms));
-            }
-            self.active_segment
-                .sync_data()
-                .map_err(|err| RaftError::Storage(format!("failed to fsync WAL record: {err}")))?;
-            fsync_elapsed_ms = fsync_started
-                .elapsed()
-                .as_millis()
-                .try_into()
-                .unwrap_or(u64::MAX);
-            self.max_fsync_elapsed_ms = self.max_fsync_elapsed_ms.max(fsync_elapsed_ms);
-            slow_fsync_observed =
-                self.slow_fsync_threshold_ms > 0 && fsync_elapsed_ms >= self.slow_fsync_threshold_ms;
-            if slow_fsync_observed {
-                self.slow_fsync_count += 1;
-                self.consecutive_slow_fsync_count += 1;
-            } else {
-                self.consecutive_slow_fsync_count = 0;
-            }
+        if fsync {
+            let observed = self.fsync_active_segment()?;
+            fsync_elapsed_ms = observed.0;
+            slow_fsync_observed = observed.1;
         }
         let checksum = record.checksum.clone();
         let record_index = wal_record_index(&record);
@@ -496,7 +576,7 @@ impl PersistentRaftWal {
             checksum,
             checksum_format: matrixraft_wal_checksum_format(),
             bytes_written: record_bytes,
-            fsync_on_append: self.options.fsync_on_append,
+            fsync_on_append: fsync,
             fsync_elapsed_ms,
             slow_fsync_threshold_ms: self.slow_fsync_threshold_ms,
             slow_fsync_observed,

--- a/tests/persistent_wal.rs
+++ b/tests/persistent_wal.rs
@@ -696,3 +696,93 @@ fn streaming_recovery_picks_what_folding_everything_picked() {
     // Empty.
     assert_recovery_agrees("empty", &[]);
 }
+
+fn group_commit_options(dir: PathBuf) -> PersistentRaftWalOptions {
+    PersistentRaftWalOptions {
+        dir,
+        max_records_per_segment: 1_000,
+        max_segment_bytes: u64::MAX,
+        min_keep_segments: 1,
+        fsync_on_append: true,
+    }
+}
+
+/// A durable append is its fsync, so what a batch has to prove is that it paid
+/// for one and not for each record. Asserted by counting: the count is exact,
+/// where the seconds move with the disk and whatever else is running.
+#[test]
+fn a_batch_pays_for_one_fsync_not_one_per_record() {
+    let dir = temp_wal_dir("group-commit-count");
+    let mut wal = PersistentRaftWal::open(group_commit_options(dir.clone())).expect("open");
+
+    assert_eq!(wal.fsync_count(), 0, "opening does not fsync a record");
+    wal.append_batch(Vec::new()).expect("an empty batch");
+    assert_eq!(wal.fsync_count(), 0, "an empty batch has nothing to sync");
+
+    let batch: Vec<_> = (1..=25).map(|index| growing_wal_record(index, 3)).collect();
+    let reports = wal.append_batch(batch).expect("batch");
+    assert_eq!(reports.len(), 25, "a report per record");
+    assert_eq!(
+        wal.fsync_count(),
+        1,
+        "twenty-five records should cost one fsync"
+    );
+
+    // One at a time still pays per record, which is what makes the batch worth
+    // having rather than a rewrite of the same cost.
+    for index in 26..=30 {
+        wal.append(growing_wal_record(index, 3)).expect("append");
+    }
+    assert_eq!(
+        wal.fsync_count(),
+        6,
+        "five single appends add five fsyncs to the batch's one"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+/// Batching changes when the fsync happens, and nothing else. What is stored
+/// and what recovers has to be identical to appending one at a time.
+#[test]
+fn a_batched_wal_recovers_exactly_as_a_one_at_a_time_wal_does() {
+    let batched_dir = temp_wal_dir("group-commit-batched");
+    let single_dir = temp_wal_dir("group-commit-single");
+    {
+        let mut wal =
+            PersistentRaftWal::open(group_commit_options(batched_dir.clone())).expect("open");
+        let batch: Vec<_> = (1..=40).map(|index| growing_wal_record(index, 3)).collect();
+        wal.append_batch(batch).expect("batch");
+    }
+    {
+        let mut wal =
+            PersistentRaftWal::open(group_commit_options(single_dir.clone())).expect("open");
+        for index in 1..=40 {
+            wal.append(growing_wal_record(index, 3)).expect("append");
+        }
+    }
+
+    let mut batched =
+        PersistentRaftWal::open(group_commit_options(batched_dir.clone())).expect("reopen");
+    let mut single =
+        PersistentRaftWal::open(group_commit_options(single_dir.clone())).expect("reopen");
+    let batched_report = batched.recover().expect("recover batched");
+    let single_report = single.recover().expect("recover single");
+
+    assert_eq!(
+        batched_report.surviving_records, single_report.surviving_records,
+        "the same records survive either way"
+    );
+    assert_eq!(
+        batched_report.recovered, single_report.recovered,
+        "the recovered record must not depend on when the fsync happened"
+    );
+    assert_eq!(
+        batched_report
+            .recovered
+            .as_ref()
+            .map(|record| record.entries.len()),
+        Some(40)
+    );
+    fs::remove_dir_all(&batched_dir).ok();
+    fs::remove_dir_all(&single_dir).ok();
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#42`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

Off `main`, independent of the WAL stack.

**A durable append is its fsync and very little else.** Measured on this box at 256-byte payloads:

| | appends/sec | µs/append |
| --- | ---: | ---: |
| `fsync_on_append = true` (the default) | **224** | 4,471.7 |
| `fsync_on_append = false` | 85,014 | 11.8 |

**379×.** Everything else in the append path together accounts for a quarter of one percent of what a durable append costs — and there was no way to amortise it. `append` writes one record and syncs; nothing else existed.

## `append_batch`

Writes every record in the batch and fsyncs once for all of them. `examples/wal_group_commit` is added here — 2,000 appends of 256 bytes:

| batch | fsyncs | appends/sec | vs one |
| ---: | ---: | ---: | ---: |
| 1 | 2,000 | 273 | 1.0× |
| 2 | 1,000 | 397 | 1.5× |
| 8 | 250 | 1,730 | 6.3× |
| 32 | 63 | 4,819 | 17.6× |
| 128 | **16** | **14,267** | **52.2×** |

The **fsync column is exactly `appends / batch`**. That is the part that is exact; the seconds move with the disk and with whatever else is on the box.

## The trade, stated plainly

Every record is durable when `append_batch` returns, and **none before**. A caller must not acknowledge any record in the batch until it returns — exactly as it must not acknowledge a single append before `append` returns. That is in the doc comment, because getting it wrong is an acknowledged write that was never on disk.

A torn tail is no more dangerous than it already was: records are line-delimited and recovery stops at the first record whose checksum does not validate, so a batch interrupted by a crash truncates at whatever was written whole — the same place a single interrupted append truncates.

## Guards count fsyncs, not seconds

`fsync_count` is added and exposed, because the fsync count is what says whether a batch amortised anything and there was no way to see it. `slow_fsync_count` only ever counted the slow ones.

- `a_batch_pays_for_one_fsync_not_one_per_record` — twenty-five records cost **one** fsync, an empty batch costs **none**, and five single appends after it still cost **five**. The last part matters: it proves the batch is doing something the normal path does not.
- `a_batched_wal_recovers_exactly_as_a_one_at_a_time_wal_does` — the same forty records written both ways recover to the same record, because batching changes *when* the fsync happens and nothing else.

## Conflicts

Touches `write_record`, which #35 also changes. Whichever lands second needs a small resolution — this adds an `fsync` parameter, #35 removes the `whole` closure.

## Checks

526 tests pass across 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean. Repository CI is still disabled by the Actions billing failure.

