### PR TITLE
Persist a batch of proposals once, and give callers a way to ask for it

### DIFF
--- a/examples/baseline_raft_operational_evidence.rs
+++ b/examples/baseline_raft_operational_evidence.rs
@@ -83,6 +83,7 @@ fn wal_lifecycle_status() -> WalLifecycleStatus {
         last_log_index: 228,
         released_segment_count: 4,
         slow_fsync_backpressure_observed: true,
+        fsync_count: 0,
         slow_fsync_threshold_ms: 10,
         slow_fsync_count: 2,
         consecutive_slow_fsync_count: 1,

--- a/src/facade/node_runtime.rs
+++ b/src/facade/node_runtime.rs
@@ -165,6 +165,46 @@ impl NodeRuntime {
         }
     }
 
+    /// Proposes several payloads and persists them together.
+    ///
+    /// A durable append is its fsync and very little else, so proposing one at
+    /// a time caps a node at a few hundred entries per second however fast the
+    /// rest of it is. This applies the whole batch and writes one WAL record
+    /// for it, which is one fsync rather than one each.
+    ///
+    /// Every proposal is durable when this returns and none before, exactly as
+    /// with [`Self::propose`]. Do not acknowledge any of them until it returns.
+    pub fn propose_batch(&self, payloads: Vec<Payload>) -> Result<Vec<LogId>, RaftError> {
+        self.propose_batch_with_options(payloads, ProposeOptions::default())
+    }
+
+    /// [`Self::propose_batch`], with the same options applied to every payload.
+    pub fn propose_batch_with_options(
+        &self,
+        payloads: Vec<Payload>,
+        options: ProposeOptions,
+    ) -> Result<Vec<LogId>, RaftError> {
+        if payloads.is_empty() {
+            return Ok(Vec::new());
+        }
+        let messages: Vec<Message> = payloads
+            .into_iter()
+            .map(|payload| Message::Propose {
+                payload,
+                options: options.clone(),
+            })
+            .collect();
+        self.step_batch(messages)?
+            .into_iter()
+            .map(|result| match result {
+                StepResult::Proposed(log_id) => Ok(log_id),
+                other => Err(RaftError::InvalidRequest(format!(
+                    "unexpected propose result: {other:?}"
+                ))),
+            })
+            .collect()
+    }
+
     pub fn step(&self, message: Message) -> Result<StepResult, RaftError> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.sender()?
@@ -1119,12 +1159,19 @@ fn runtime_step_operation_name(message: &Message) -> &'static str {
     }
 }
 
+/// Applies one message.
+///
+/// `persist_proposal` is false when the caller will persist for a whole batch
+/// of messages instead. A WAL record describes the log as it stands, so one
+/// record covers every proposal applied before it -- and one fsync makes them
+/// all durable, rather than one fsync each.
 fn runtime_step_message(
     cluster: &mut RaftCluster,
     wal: &mut Option<PersistentRaftWal>,
     membership_executor: &mut MembershipExecutor,
     node_id: NodeId,
     message: Message,
+    persist_proposal: bool,
 ) -> Result<StepResult, RaftError> {
     match message {
         Message::Propose { payload, options } => {
@@ -1134,7 +1181,7 @@ fn runtime_step_message(
                 ));
             }
             let log_id = cluster.propose_with_options(payload, options)?;
-            if let Some(wal) = wal.as_mut() {
+            if let Some(wal) = wal.as_mut().filter(|_| persist_proposal) {
                 // Built against what the WAL already holds, so a proposal does
                 // not copy and hash the whole log to write one entry.
                 wal.append_built(|coverage| cluster.wal_record_for_coverage(node_id, coverage))?;
@@ -1483,6 +1530,7 @@ fn raft_node_runtime_loop(
                     &mut membership_executor,
                     node_id,
                     message,
+                    true,
                 );
                 if result
                     .as_ref()
@@ -1528,7 +1576,14 @@ fn raft_node_runtime_loop(
                     })
                     .count() as u64;
                 campaign_executions = campaign_executions.saturating_add(campaign_message_count);
-                let result: Result<Vec<StepResult>, RaftError> = messages
+                // A WAL record describes the log as it stands, so one record
+                // covers every proposal in the batch. Persisting per proposal
+                // made a batch of N cost N fsyncs, and an fsync is essentially
+                // the whole cost of a durable append.
+                let batch_has_proposal = messages
+                    .iter()
+                    .any(|message| matches!(message, Message::Propose { .. }));
+                let stepped: Result<Vec<StepResult>, RaftError> = messages
                     .into_iter()
                     .map(|message| {
                         runtime_step_message(
@@ -1537,9 +1592,29 @@ fn raft_node_runtime_loop(
                             &mut membership_executor,
                             node_id,
                             message,
+                            false,
                         )
                     })
                     .collect();
+                // Persisted even when a message failed, so what is on disk
+                // still describes what the node applied.
+                let persisted = if batch_has_proposal {
+                    match wal.as_mut() {
+                        Some(wal) => wal
+                            .append_built(|coverage| {
+                                cluster.wal_record_for_coverage(node_id, coverage)
+                            })
+                            .map(|_| ()),
+                        None => Ok(()),
+                    }
+                } else {
+                    Ok(())
+                };
+                let result: Result<Vec<StepResult>, RaftError> = match (stepped, persisted) {
+                    (Ok(results), Ok(())) => Ok(results),
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                };
                 let _ = reply.send(record_runtime_result(
                     "step_batch",
                     result,

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -766,6 +766,7 @@ impl PersistentRaftWal {
                 .unwrap_or(0),
             released_segment_count: self.released_segment_count,
             slow_fsync_backpressure_observed: self.slow_fsync_count > 0,
+            fsync_count: self.fsync_count,
             slow_fsync_threshold_ms: self.slow_fsync_threshold_ms,
             slow_fsync_count: self.slow_fsync_count,
             consecutive_slow_fsync_count: self.consecutive_slow_fsync_count,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -141,6 +141,10 @@ pub struct WalLifecycleStatus {
     pub last_log_index: u64,
     pub released_segment_count: u64,
     pub slow_fsync_backpressure_observed: bool,
+    /// Every fsync this WAL has done, not only the slow ones. This is what says
+    /// whether batching amortised anything.
+    #[serde(default)]
+    pub fsync_count: u64,
     #[serde(default)]
     pub slow_fsync_threshold_ms: u64,
     #[serde(default)]

--- a/tests/baseline_raft_runtime_capability.rs
+++ b/tests/baseline_raft_runtime_capability.rs
@@ -418,6 +418,7 @@ fn complete_wal_lifecycle_status() -> WalLifecycleStatus {
         last_log_index: 228,
         released_segment_count: 4,
         slow_fsync_backpressure_observed: true,
+        fsync_count: 0,
         slow_fsync_threshold_ms: 10,
         slow_fsync_count: 2,
         consecutive_slow_fsync_count: 1,

--- a/tests/node_runtime.rs
+++ b/tests/node_runtime.rs
@@ -2148,3 +2148,90 @@ fn node_runtime_recovers_committed_index_from_persistent_wal() {
 
     let _ = fs::remove_dir_all(base_dir);
 }
+
+/// A durable append is its fsync, so a batch of proposals has to cost one
+/// fsync rather than one each. Asserted by counting, because the count is exact
+/// where elapsed time is not.
+#[test]
+fn a_batch_of_proposals_costs_one_fsync() {
+    let mut runtime = NodeRuntime::create(node_options_in(temp_runtime_dir("batch-fsync")))
+        .expect("create runtime");
+    runtime.start().expect("start");
+    runtime.campaign(true).expect("campaign");
+
+    let before = runtime.wal_lifecycle_status().expect("status").fsync_count;
+
+    let batch: Vec<_> = (0..16)
+        .map(|index| Message::Propose {
+            payload: format!("entry-{index}").into_bytes(),
+            options: Default::default(),
+        })
+        .collect();
+    let results = runtime.step_batch(batch).expect("step batch");
+    assert_eq!(results.len(), 16, "a result per proposal");
+
+    let after = runtime.wal_lifecycle_status().expect("status").fsync_count;
+    assert_eq!(
+        after - before,
+        1,
+        "sixteen proposals in one batch should cost one fsync, not sixteen"
+    );
+
+    // A proposal on its own still persists on its own, so the batch is doing
+    // something the ordinary path does not.
+    let single_before = after;
+    runtime
+        .step(Message::Propose {
+            payload: b"single".to_vec(),
+            options: Default::default(),
+        })
+        .expect("single propose");
+    let single_after = runtime.wal_lifecycle_status().expect("status").fsync_count;
+    assert_eq!(
+        single_after - single_before,
+        1,
+        "one proposal outside a batch still costs its own fsync"
+    );
+    runtime.stop().expect("stop");
+}
+
+/// `propose_batch` is the obvious way to get what `step_batch` makes possible,
+/// without a caller assembling `Message::Propose` values by hand.
+#[test]
+fn propose_batch_persists_once_and_returns_a_log_id_per_payload() {
+    let mut runtime = NodeRuntime::create(node_options_in(temp_runtime_dir("propose-batch")))
+        .expect("create runtime");
+    runtime.start().expect("start");
+    runtime.campaign(true).expect("campaign");
+
+    assert!(
+        runtime
+            .propose_batch(Vec::new())
+            .expect("empty batch")
+            .is_empty(),
+        "an empty batch proposes nothing"
+    );
+
+    let before = runtime.wal_lifecycle_status().expect("status").fsync_count;
+    let payloads: Vec<_> = (0..12)
+        .map(|index| format!("payload-{index}").into_bytes())
+        .collect();
+    let log_ids = runtime.propose_batch(payloads).expect("propose batch");
+    let after = runtime.wal_lifecycle_status().expect("status").fsync_count;
+
+    assert_eq!(log_ids.len(), 12, "a log id per payload");
+    let indexes: Vec<_> = log_ids.iter().map(|log_id| log_id.index).collect();
+    let mut sorted = indexes.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        indexes, sorted,
+        "log ids come back in proposal order, one per payload"
+    );
+    assert_eq!(
+        after - before,
+        1,
+        "twelve proposals in one batch should cost one fsync"
+    );
+    runtime.stop().expect("stop");
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#43`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #42.**

`step_batch` exists so a caller can hand a node several messages at once — but it stepped them one at a time, and **each proposal wrote its own WAL record and fsynced**. A batch of sixteen cost sixteen fsyncs, so the batching API bought nothing where it matters most.

A WAL record describes the log as it stands, so **one record covers every proposal applied before it**. `step_batch` now applies the whole batch and persists once. A single `step` still persists on its own — which is what makes the batch worth having rather than a rename of the same cost.

## `propose_batch`, because `step_batch` was not a usable answer

Reaching the batched path meant assembling `Message::Propose` values by hand, while every caller proposing normally goes through `propose`, which had no batched form. `propose_batch(payloads)` returns a log id per payload and costs **one fsync**.

The underlying number, from #42: **224 durable appends/sec against 85,014 without the fsync**. The fsync is 99.75% of a durable append, so persisting per proposal caps a node at a few hundred proposals/sec whatever else it does.

## Guards count fsyncs, and here is why that matters

`fsync_count` is added to `WalLifecycleStatus`, because the count is what says whether a batch amortised anything and `slow_fsync_count` only ever counted the slow ones.

The same probe measured **273 appends/sec in one run and 58 in another**, hours apart on this box, with the **fsync counts identical to the digit**. A guard written against elapsed time would fail for reasons that have nothing to do with the code.

- `a_batch_of_proposals_costs_one_fsync` — sixteen proposals cost **one** fsync, and a proposal outside a batch still costs its own. Stepping the batch per message again makes it fail with **seventeen**, so it is not passing by construction.
- `propose_batch_persists_once_and_returns_a_log_id_per_payload` — twelve payloads, twelve log ids in proposal order, one fsync, and an empty batch proposes nothing.

On a failure inside the batch the record is still written, so what is on disk describes what the node applied rather than lagging behind it.

## An API cost worth naming

Adding a public field to `WalLifecycleStatus` broke three struct literals in tests and examples that build one by hand. They are updated — there is no way to add a field to a public struct with public fields without that.

## Checks

528 tests pass across 42 suites. clippy `-D warnings`, fmt, and doc all clean. Repository CI is still disabled by the Actions billing failure.

---

*Amended after first push to add `propose_batch` and its test: `step_batch` alone left the win reachable only by hand-assembling messages, which is not an answer for the callers that would benefit.*

