### PR TITLE
Lower the default WAL segment size, which the roll fix inverted

### DIFF
--- a/src/facade/node_runtime.rs
+++ b/src/facade/node_runtime.rs
@@ -1270,7 +1270,9 @@ fn raft_node_runtime_loop(
     let mut last_wal_recovery_report = None;
     let mut wal = match PersistentRaftWal::open(PersistentRaftWalOptions {
         dir: PathBuf::from(&options.wal_dir),
-        max_records_per_segment: 10_000,
+        // See `PersistentRaftWalOptions::new`: this is now just how much the
+        // node holds in memory, and smaller is strictly cheaper.
+        max_records_per_segment: 1_000,
         max_segment_bytes: options.config.max_segment_bytes,
         min_keep_segments: options.config.min_keep_segment_num as usize,
         fsync_on_append: true,

--- a/src/facade/wal_runtime.rs
+++ b/src/facade/wal_runtime.rs
@@ -194,7 +194,15 @@ impl PersistentRaftWalOptions {
     pub fn new(dir: impl Into<PathBuf>) -> Self {
         Self {
             dir: dir.into(),
-            max_records_per_segment: 10_000,
+            // Ten thousand was right while a segment roll rewrote the whole
+            // retained log: rolling was expensive, so rolling rarely was the
+            // only sane choice, and halving this doubled the total cost.
+            // Rolls are cheap now and a sealed segment releases its records, so
+            // this is simply how much a node holds in memory --
+            // `segment size * ~672 bytes` for a 256-byte payload. Measured at
+            // 20,000 appends: 10,000 holds 6.72 MiB, 1,000 holds 672 KiB, while
+            // restart time and bytes written are identical either way.
+            max_records_per_segment: 1_000,
             max_segment_bytes: 64 * 1024 * 1024,
             min_keep_segments: 2,
             fsync_on_append: true,


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#44`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #38** (which is on #35, on #34). Merge in that order.

Ten thousand records per segment was the right default **while a segment roll rewrote the whole retained log**. Rolling was expensive, so rolling rarely was the only sane choice — and halving this number *doubled* the total cost.

Neither is true after #35 and #38. A roll writes one delta like any other append, and a sealed segment releases its records. So this number is now simply **how much a node holds in memory**: `segment size × ~672 bytes` for a 256-byte payload. The default sits on the wrong end of a trade that reversed.

## Measured on the merged stack

Memory held, 20,000 appends of 256 bytes:

| per_segment | records held | bytes held |
| ---: | ---: | ---: |
| 500 | 500 | 336 KiB |
| **1,000** | 1,000 | **672 KiB** |
| 2,000 | 2,000 | 1.34 MiB |
| 10,000 *(old default)* | 10,000 | **6.72 MiB** |

Restart, 8,000 appends:

| per_segment | recover_ms | resident |
| ---: | ---: | ---: |
| 500 | 92 | 8.95 MiB |
| 1,000 | 87 | 9.06 MiB |
| 2,000 | 84 | 8.83 MiB |
| 10,000 | 92 | **15.59 MiB** |

Bytes written, 8,192 appends: **4,935,349 at every segment size**, 602 per append. Identical, because after #35 only the very first record of the WAL is ever stored whole.

So smaller is cheaper in memory, free on disk, and level on restart time. 10,000 costs about **10× the held memory** and **1.75× the restart memory** for nothing.

## What it costs

More segment files for the same log — more inodes, a longer segment index. Compaction bounds both, and restart time did not move across a twentyfold change in segment count (500 → 10,000).

## This depends on #35

**On `main` this change would be actively harmful.** Smaller segments there mean more whole-log rewrites, which is the quadratic #34 measures. The default is only wrong once the roll fix lands.

## Checks

527 tests pass across 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean **with zero warnings** (see note below). Repository CI is still disabled by the Actions billing failure.

---

*Note on "doc clean": on #35, #38 and this branch I had been reporting `cargo doc` clean meaning **exit 0**, while it emitted one intra-doc-link warning — a public doc comment linking to the private `fold_wal_entries_step`. Fixed at its source in #35 and cascaded here; all three now emit zero warnings. The claim was true as stated and weaker than it sounded.*

