### PR TITLE
Send snapshot chunk bytes as base64, the largest wire cost in the protocol

### DIFF
--- a/examples/rpc_wire_bytes.rs
+++ b/examples/rpc_wire_bytes.rs
@@ -7,7 +7,10 @@
 //! request is exactly its encoded length -- a count, not a timing, and so
 //! independent of machine load.
 
-use matrixraft::{AppendEntriesRequest, LogEntry, LogId, TcpRaftTransportRequest};
+use matrixraft::{
+    AppendEntriesRequest, InstallSnapshotRequest, LogEntry, LogId, SnapshotChunk, SnapshotMetadata,
+    TcpRaftTransportRequest,
+};
 
 fn request(payload_bytes: usize, entries: usize) -> TcpRaftTransportRequest {
     TcpRaftTransportRequest::AppendEntries {
@@ -33,6 +36,31 @@ fn request(payload_bytes: usize, entries: usize) -> TcpRaftTransportRequest {
     }
 }
 
+fn snapshot_request(chunk_bytes: usize) -> TcpRaftTransportRequest {
+    TcpRaftTransportRequest::InstallSnapshot {
+        target: 2,
+        request: InstallSnapshotRequest {
+            group_id: 3,
+            term: 1,
+            leader_id: 1,
+            chunk: SnapshotChunk {
+                meta: SnapshotMetadata {
+                    snapshot_id: "snap-1".to_string(),
+                    last_log_id: LogId {
+                        term: 1,
+                        index: 100,
+                    },
+                    membership: vec![1, 2, 3],
+                    members: Vec::new(),
+                },
+                offset: 0,
+                data: (0..chunk_bytes).map(|byte| byte as u8).collect(),
+                done: false,
+            },
+        },
+    }
+}
+
 fn main() {
     println!(
         "{:>12}  {:>8}  {:>12}  {:>16}",
@@ -49,6 +77,19 @@ fn main() {
         println!(
             "{payload:>12}  {entries:>8}  {:>12}  {per:>16.2}",
             encoded.len()
+        );
+    }
+    println!();
+    println!(
+        "{:>12}  {:>12}  {:>16}",
+        "chunk bytes", "wire bytes", "bytes/data B"
+    );
+    for chunk in [4096usize, 65536] {
+        let encoded = serde_json::to_vec(&snapshot_request(chunk)).expect("encode");
+        println!(
+            "{chunk:>12}  {:>12}  {:>16.2}",
+            encoded.len(),
+            encoded.len() as f64 / chunk as f64
         );
     }
 }

--- a/src/facade/snapshot_runtime.rs
+++ b/src/facade/snapshot_runtime.rs
@@ -17,6 +17,15 @@ pub struct SnapshotMetadata {
 pub struct SnapshotChunk {
     pub meta: SnapshotMetadata,
     pub offset: u64,
+    /// Chunk bytes travel as base64, not as a JSON number array.
+    ///
+    /// A number array costs about 3.9 bytes per data byte and a chunk is
+    /// 64 KiB by default, so this was the largest single wire cost in the
+    /// protocol. Decode still accepts the number-array form, so chunks and
+    /// snapshot files written before this codec still read; an old receiver
+    /// rejects the new form, so a mixed-version cluster upgrades receivers
+    /// first.
+    #[serde(with = "crate::wal::bytes_as_base64")]
     pub data: SnapshotPayload,
     pub done: bool,
 }
@@ -31,9 +40,23 @@ pub struct GenericSnapshot<G = GroupId, P = SnapshotPayload> {
 pub type RaftSnapshot = GenericSnapshot<GroupId, SnapshotPayload>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(bound(
+    serialize = "P: serde::Serialize + AsRef<[u8]>",
+    deserialize = "P: serde::Deserialize<'de> + From<Vec<u8>>"
+))]
 pub struct GenericSnapshotChunk<P = SnapshotPayload> {
     pub meta: SnapshotMetadata,
     pub offset: u64,
+    /// Chunk bytes travel as base64, not as a JSON number array.
+    ///
+    /// A number array costs about 3.9 bytes per data byte and a chunk is
+    /// 64 KiB by default, so this is the largest single wire cost in the
+    /// protocol. Decode still accepts the number-array form, so chunks and
+    /// snapshot files written before this codec still read; an old receiver
+    /// rejects the new form, so a mixed-version cluster upgrades receivers
+    /// first. The serde bounds above are what the codec itself needs -- a
+    /// payload type that is not byte-like was never base64-serializable.
+    #[serde(with = "crate::wal::bytes_as_base64")]
     pub data: P,
     pub done: bool,
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -675,6 +675,47 @@ pub(crate) mod wal_entry_payloads {
     }
 }
 
+/// Base64 for a bare byte-buffer field, with the same legacy tolerance as
+/// [`wal_entry_payloads`]: decode accepts the old number-array form, so data
+/// written before this codec still reads.
+///
+/// Generic over the payload type so it can sit on a generic struct field. The
+/// bounds are the codec's real requirements -- the bytes must be readable to
+/// encode and constructible to decode -- and a payload type that is not
+/// byte-like was never serializable as base64 anyway.
+pub(crate) mod bytes_as_base64 {
+    use serde::de::{Deserializer, Error as DeError};
+    use serde::{Deserialize, Serializer};
+
+    pub(crate) fn serialize<S, P>(data: &P, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        P: AsRef<[u8]>,
+    {
+        serializer.serialize_str(&super::wal_entry_payloads::encode(data.as_ref()))
+    }
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BytesIn {
+        Text(String),
+        Numbers(Vec<u8>),
+    }
+
+    pub(crate) fn deserialize<'de, D, P>(deserializer: D) -> Result<P, D::Error>
+    where
+        D: Deserializer<'de>,
+        P: From<Vec<u8>>,
+    {
+        match BytesIn::deserialize(deserializer)? {
+            BytesIn::Text(text) => super::wal_entry_payloads::decode(&text)
+                .map(P::from)
+                .map_err(DeError::custom),
+            BytesIn::Numbers(bytes) => Ok(P::from(bytes)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod wal_entry_payload_codec_tests {
     use super::wal_entry_payloads::{decode, encode};

--- a/tests/transport_contract.rs
+++ b/tests/transport_contract.rs
@@ -864,3 +864,36 @@ fn a_new_request_carries_base64_payloads_on_the_wire() {
         other => panic!("decoded to the wrong variant: {other:?}"),
     }
 }
+
+/// Snapshot chunks changed encoding too. An old sender's number-array chunk
+/// still decodes -- the direction a rolling upgrade needs -- and the new form
+/// is base64 text.
+#[test]
+fn a_number_array_snapshot_chunk_from_an_old_sender_still_decodes() {
+    let legacy = r#"{
+        "meta": {
+            "snapshot_id": "snap-1",
+            "last_log_id": {"term": 1, "index": 100},
+            "membership": [1, 2, 3]
+        },
+        "offset": 0,
+        "data": [104, 101, 108, 108, 111],
+        "done": true
+    }"#;
+    let decoded: SnapshotChunk =
+        serde_json::from_str(legacy).expect("legacy number-array chunk decodes");
+    assert_eq!(decoded.data, b"hello");
+
+    let reencoded = serde_json::to_string(&decoded).expect("encode");
+    assert!(
+        reencoded.contains("\"aGVsbG8=\""),
+        "chunk data should be base64 text: {reencoded}"
+    );
+    assert!(
+        !reencoded.contains("[104"),
+        "chunk data must not be a number array: {reencoded}"
+    );
+    let round: SnapshotChunk = serde_json::from_str(&reencoded).expect("round trip");
+    assert_eq!(round.data, b"hello");
+    assert_eq!(round, decoded);
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#46`); PR numbers referenced below are the source repo's numbering. Branches here are single squashed commits over the published snapshot; the diffs are identical to the source PRs.*

**Stacked on #45** (which is on #29). Merge #29 → #45 → this.

Entry payloads stopped crossing the wire as JSON number arrays in #45 — but a **snapshot chunk still did**, and at 64 KiB per chunk it is the largest single message the protocol sends. A lagging follower catching up by snapshot paid ~3.6 bytes of wire for every byte of data.

## Measured

`examples/rpc_wire_bytes`, extended with chunk rows; data bytes rotate through all 256 values.

| chunk | before | after | |
| ---: | ---: | ---: | ---: |
| 4 KiB | 14,867 | 5,708 | 2.60× |
| 64 KiB | 234,227 | **87,628** | **2.67×** |

A default-sized chunk now costs 88 KB on the wire rather than 234 KB.

## The codec

`bytes_as_base64` is a sibling of the entries codec and reuses its base64. It is generic with the bounds the codec actually needs — `AsRef<[u8]>` to encode, `From<Vec<u8>>` to decode — so it also sits on `GenericSnapshotChunk<P>`, whose serde bounds now state that a chunk payload must be byte-like to serialize. Every instantiation in the crate and tests is `Vec<u8>`.

## Two chunk types, and I instrumented the wrong one first

`GenericSnapshotChunk` (snapshot_runtime.rs:34) got the codec; the wire's `InstallSnapshotRequest` uses the concrete `SnapshotChunk` at line 17. **The probe caught it**: the "after" measurement reproduced the "before" numbers — which by this session's standing rule means one artifact measured twice, not two measurements. Both types carry the codec now, and the probe run in the table above is from the fixed build.

(This also corrects #45's claim that a typed codec could not attach to the generic — it can, with honest bounds. That PR's body said the chunk change "needs its own change"; this is it.)

## Compatibility

Same one-way contract as #45: decode accepts the legacy number-array form, so **old senders and old snapshot files still read**; an old receiver rejects the new form, so receivers upgrade first. `a_number_array_snapshot_chunk_from_an_old_sender_still_decodes` pins the legacy direction, the new form byte-for-byte, and the round trip.

## Checks

533 tests pass across 42 suites. `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc --no-deps` clean with zero warnings. Repository CI is still disabled by the Actions billing failure.

