### PR TITLE
Coalesce queued proposals into one fsync, without callers opting in

### DIFF
--- a/src/facade/node_runtime.rs
+++ b/src/facade/node_runtime.rs
@@ -1287,8 +1287,14 @@ fn raft_node_runtime_loop(
     let mut blockers = Vec::<String>::new();
     let mut fatal_blockers = Vec::<String>::new();
     let mut membership_executor = MembershipExecutor::new();
+    // A command drained by proposal coalescing that turned out not to be a
+    // proposal; processed first on the next iteration, untouched.
+    let mut carried_command: Option<NodeRuntimeOp> = None;
     loop {
-        let command = match command_rx.recv_timeout(heartbeat_interval) {
+        let command = if let Some(command) = carried_command.take() {
+            command
+        } else {
+            match command_rx.recv_timeout(heartbeat_interval) {
             Ok(command) => command,
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 if state == NodeRuntimeState::Running {
@@ -1410,6 +1416,89 @@ fn raft_node_runtime_loop(
                 continue;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        };
+        // Auto group commit. A durable proposal is its fsync and very little
+        // else, so a node answering concurrent proposers one at a time is
+        // capped at a few hundred per second whatever else it does. While one
+        // proposal's fsync runs, the next proposers queue; draining the queued
+        // proposals here applies them together, persists them with one fsync,
+        // and answers each sender individually. A lone proposal takes the
+        // ordinary path below unchanged, and a drained command that turned out
+        // not to be a proposal is carried into the next iteration.
+        let command = match command {
+            NodeRuntimeOp::Step(message @ Message::Propose { .. }, reply)
+                if state == NodeRuntimeState::Running =>
+            {
+                let mut pending = vec![(message, reply)];
+                // Bounded so a saturated queue cannot starve ticks and other
+                // commands indefinitely.
+                while pending.len() < 128 {
+                    match command_rx.try_recv() {
+                        Ok(NodeRuntimeOp::Step(next @ Message::Propose { .. }, next_reply)) => {
+                            pending.push((next, next_reply));
+                        }
+                        Ok(other) => {
+                            carried_command = Some(other);
+                            break;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                if pending.len() == 1 {
+                    let (message, reply) = pending.pop().expect("one pending proposal");
+                    NodeRuntimeOp::Step(message, reply)
+                } else {
+                    let mut results = Vec::with_capacity(pending.len());
+                    let mut replies = Vec::with_capacity(pending.len());
+                    let mut any_applied = false;
+                    for (message, reply) in pending {
+                        let result = runtime_step_message(
+                            &mut cluster,
+                            &mut wal,
+                            &mut membership_executor,
+                            node_id,
+                            message,
+                            false,
+                        );
+                        any_applied |= result.is_ok();
+                        results.push(result);
+                        replies.push(reply);
+                    }
+                    // One record covers every proposal applied above, exactly
+                    // as step_batch persists. Nothing applied means nothing to
+                    // persist.
+                    let persisted: Result<(), RaftError> = if any_applied {
+                        match wal.as_mut() {
+                            Some(wal) => wal
+                                .append_built(|coverage| {
+                                    cluster.wal_record_for_coverage(node_id, coverage)
+                                })
+                                .map(|_| ()),
+                            None => Ok(()),
+                        }
+                    } else {
+                        Ok(())
+                    };
+                    for (result, reply) in results.into_iter().zip(replies) {
+                        // A proposal that applied but did not persist is not
+                        // durable, and must not be acknowledged as if it were.
+                        let result = match (&persisted, result) {
+                            (Err(error), Ok(_)) => Err(error.clone()),
+                            (_, result) => result,
+                        };
+                        let _ = reply.send(record_runtime_result(
+                            "propose",
+                            result,
+                            &mut blockers,
+                            &mut fatal_blockers,
+                            true,
+                        ));
+                    }
+                    continue;
+                }
+            }
+            other => other,
         };
         match command {
             NodeRuntimeOp::Start(reply) => {

--- a/tests/node_runtime.rs
+++ b/tests/node_runtime.rs
@@ -2235,3 +2235,60 @@ fn propose_batch_persists_once_and_returns_a_log_id_per_payload() {
     );
     runtime.stop().expect("stop");
 }
+
+/// Concurrent proposers must share fsyncs without opting into anything: while
+/// one proposal's fsync runs the others queue, and the runtime applies the
+/// queued ones together and persists once. Asserted on the fsync count, which
+/// is exact where elapsed time on this box is not.
+#[test]
+fn concurrent_proposers_share_fsyncs_without_opting_in() {
+    use std::sync::Arc;
+
+    let mut runtime = NodeRuntime::create(node_options_in(temp_runtime_dir("auto-batch")))
+        .expect("create runtime");
+    runtime.start().expect("start");
+    runtime.campaign(true).expect("campaign");
+    let before = runtime.wal_lifecycle_status().expect("status").fsync_count;
+
+    let runtime = Arc::new(runtime);
+    let threads = 8;
+    let per_thread = 25;
+    let workers: Vec<_> = (0..threads)
+        .map(|worker| {
+            let runtime = Arc::clone(&runtime);
+            std::thread::spawn(move || {
+                let mut log_ids = Vec::with_capacity(per_thread);
+                for index in 0..per_thread {
+                    let payload = format!("w{worker}-{index}").into_bytes();
+                    log_ids.push(runtime.propose(payload).expect("propose"));
+                }
+                log_ids
+            })
+        })
+        .collect();
+    let mut all: Vec<_> = workers
+        .into_iter()
+        .flat_map(|worker| worker.join().expect("no worker panics"))
+        .collect();
+
+    let proposals = (threads * per_thread) as u64;
+    all.sort_by_key(|log_id| log_id.index);
+    all.dedup_by_key(|log_id| log_id.index);
+    assert_eq!(
+        all.len() as u64,
+        proposals,
+        "every proposal gets its own log index"
+    );
+
+    let after = runtime.wal_lifecycle_status().expect("status").fsync_count;
+    let fsyncs = after - before;
+    assert!(
+        fsyncs >= 1 && fsyncs < proposals / 2,
+        "two hundred concurrent proposals should coalesce well below one fsync \
+         each; got {fsyncs} for {proposals} -- exactly {proposals} means \
+         coalescing is not happening at all"
+    );
+
+    let mut runtime = Arc::into_inner(runtime).expect("all workers joined");
+    runtime.stop().expect("stop");
+}


### PR DESCRIPTION
*Mirror of a source-repo PR (`bjmeetsfo/MatrixRaft#48`); PR numbers referenced below are the source repo's numbering. The branch is a single squashed commit over the published snapshot; the diff is identical to the source PR.*

**Stacked on #43** (on #42).

`propose_batch` amortises the fsync for a caller who has a batch in hand. Most callers don't — they are N threads each proposing one entry — and each of those paid its own fsync, so a node under concurrent proposers was capped at a few hundred proposals/sec whatever else it did.

**While one proposal's fsync runs, the other proposers queue.** The runtime loop now drains consecutive queued `Step(Propose)` commands (bounded at 128), applies them together, persists them with **one WAL record and one fsync**, and answers each sender individually with its own log id. A lone proposal takes the ordinary path unchanged; a drained command that isn't a proposal is carried into the next iteration untouched.

**The ack rule is unchanged**: nothing is acknowledged before the fsync that made it durable returns, and a proposal that applied but failed to persist gets the persist error, not an ack.

## The guard

`concurrent_proposers_share_fsyncs_without_opting_in` — 200 proposals from 8 threads through the plain `propose` API:

- every proposal gets its own log index (200 distinct), and
- the fsync count is **strictly under half of one per proposal**.

Disabling the drain fails it with **exactly 200 fsyncs for 200 proposals**, so it is load-bearing — and it counts fsyncs rather than timing anything, because the count is exact where this box's clock is not.

## Recorded while in here

Under sustained load the loop only ticks on a receive timeout, so heartbeat/lease ticks already depend on queue gaps. Coalescing reduces iterations per proposal and makes gaps more likely, but that shape predates this change and is not addressed by it.

## Checks

529 tests across 42 suites. clippy `-D warnings`, fmt, doc (zero warnings) all clean. Repository CI is still disabled by the Actions billing failure.
