### PR TITLE
Send entry payloads as base64 on the wire, not as JSON number arrays

### DIFF
--- a/examples/rpc_wire_bytes.rs
+++ b/examples/rpc_wire_bytes.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Wire-size probe: what does an AppendEntries RPC cost in bytes?
+//!
+//! The TCP transport frames one JSON document per RPC, so the wire cost of a
+//! request is exactly its encoded length -- a count, not a timing, and so
+//! independent of machine load.
+
+use matrixraft::{AppendEntriesRequest, LogEntry, LogId, TcpRaftTransportRequest};
+
+fn request(payload_bytes: usize, entries: usize) -> TcpRaftTransportRequest {
+    TcpRaftTransportRequest::AppendEntries {
+        target: 2,
+        request: AppendEntriesRequest {
+            group_id: 3,
+            term: 1,
+            leader_id: 1,
+            prev_log_id: None,
+            entries: (1..=entries as u64)
+                .map(|index| LogEntry {
+                    log_id: LogId { term: 1, index },
+                    // Every byte value in rotation, so the number-array cost
+                    // reflects real data rather than a single-digit best case:
+                    // "7," is two characters, "142," is four.
+                    payload: (0..payload_bytes).map(|byte| byte as u8).collect(),
+                    is_command: true,
+                })
+                .collect(),
+            leader_commit: 1,
+            lease_epoch: 0,
+        },
+    }
+}
+
+fn main() {
+    println!(
+        "{:>12}  {:>8}  {:>12}  {:>16}",
+        "payload", "entries", "wire bytes", "bytes/payload B"
+    );
+    for (payload, entries) in [(0usize, 1usize), (64, 1), (256, 1), (1024, 1), (256, 16)] {
+        let encoded = serde_json::to_vec(&request(payload, entries)).expect("encode");
+        let total_payload = payload * entries;
+        let per = if total_payload == 0 {
+            f64::NAN
+        } else {
+            encoded.len() as f64 / total_payload as f64
+        };
+        println!(
+            "{payload:>12}  {entries:>8}  {:>12}  {per:>16.2}",
+            encoded.len()
+        );
+    }
+}

--- a/src/facade/api_messages.rs
+++ b/src/facade/api_messages.rs
@@ -108,6 +108,15 @@ pub struct AppendEntriesRequest {
     pub term: Term,
     pub leader_id: NodeId,
     pub prev_log_id: Option<LogId>,
+    /// Payloads travel as base64, not as JSON number arrays.
+    ///
+    /// A number array costs about 3.9 bytes per payload byte on the wire;
+    /// base64 costs a flat 1.37. The WAL stores entries the same way and for
+    /// the same reason, and this reuses its codec, which still accepts the
+    /// legacy number-array form on decode -- an old sender can talk to a new
+    /// receiver. The reverse is not true, so a mixed-version cluster upgrades
+    /// receivers first.
+    #[serde(default, with = "crate::wal::wal_entry_payloads")]
     pub entries: Vec<LogEntry>,
     pub leader_commit: LogIndex,
     #[serde(default)]

--- a/tests/transport_contract.rs
+++ b/tests/transport_contract.rs
@@ -793,3 +793,74 @@ fn tcp_transport_batches_mixed_rpc_requests() {
 
     server.shutdown().expect("shutdown server");
 }
+
+/// The wire format changed from number arrays to base64 for entry payloads.
+/// An old sender still emits number arrays, and a new receiver has to accept
+/// them -- that is the direction a rolling upgrade needs.
+#[test]
+fn a_number_array_request_from_an_old_sender_still_decodes() {
+    let legacy = r#"{
+        "rpc": "append_entries",
+        "payload": {
+            "target": 2,
+            "request": {
+                "group_id": 3,
+                "term": 1,
+                "leader_id": 1,
+                "prev_log_id": null,
+                "entries": [{
+                    "log_id": {"term": 1, "index": 1},
+                    "payload": [104, 101, 108, 108, 111],
+                    "is_command": true
+                }],
+                "leader_commit": 1
+            }
+        }
+    }"#;
+    let decoded: TcpRaftTransportRequest =
+        serde_json::from_str(legacy).expect("legacy number-array request decodes");
+    match decoded {
+        TcpRaftTransportRequest::AppendEntries { request, .. } => {
+            assert_eq!(request.entries.len(), 1);
+            assert_eq!(request.entries[0].payload, b"hello");
+        }
+        other => panic!("decoded to the wrong variant: {other:?}"),
+    }
+}
+
+/// And the new encoding is what a new sender emits: base64 text, not an array.
+#[test]
+fn a_new_request_carries_base64_payloads_on_the_wire() {
+    let request = TcpRaftTransportRequest::AppendEntries {
+        target: 2,
+        request: AppendEntriesRequest {
+            group_id: 3,
+            term: 1,
+            leader_id: 1,
+            prev_log_id: None,
+            entries: vec![LogEntry {
+                log_id: LogId { term: 1, index: 1 },
+                payload: b"hello".to_vec(),
+                is_command: true,
+            }],
+            leader_commit: 1,
+            lease_epoch: 0,
+        },
+    };
+    let encoded = serde_json::to_string(&request).expect("encode");
+    assert!(
+        encoded.contains("\"aGVsbG8=\""),
+        "payload should be base64 text: {encoded}"
+    );
+    assert!(
+        !encoded.contains("[104"),
+        "payload must not be a number array: {encoded}"
+    );
+    let round: TcpRaftTransportRequest = serde_json::from_str(&encoded).expect("round trip");
+    match round {
+        TcpRaftTransportRequest::AppendEntries { request, .. } => {
+            assert_eq!(request.entries[0].payload, b"hello");
+        }
+        other => panic!("decoded to the wrong variant: {other:?}"),
+    }
+}


### PR DESCRIPTION
Continues #29, which closed automatically when its base branch was deleted mid-stack; same change, rebased onto main.